### PR TITLE
Fix demo windows not persisting frames on restore

### DIFF
--- a/src/demo/LayoutsUI.ts
+++ b/src/demo/LayoutsUI.ts
@@ -70,7 +70,7 @@ export function openChild(name: string, i: number, url?: string) {
         defaultLeft: 320*(i%3),
         defaultTop: i > 2 ? 400 : 50,
         saveWindowState: false,
-
+        frame: !(url && url.includes('frameless')),
         name
     });
     return win;


### PR DESCRIPTION
Issue reported where saving and restoring the frameless snappable windows from the demo does not maintain the framelessness of the windows.