### PR TITLE
[SERVICE-230] Disabled snapping for tab sets, and tabbing of snapped windows

### DIFF
--- a/src/provider/snapanddock/Resolver.ts
+++ b/src/provider/snapanddock/Resolver.ts
@@ -1,10 +1,11 @@
+import {TabService} from '../tabbing/TabService';
+
 import {SNAP_DISTANCE} from './Config';
 import {Projector} from './Projector';
 import {SnapGroup} from './SnapGroup';
-import {SnapWindow, WindowState, WindowIdentity} from './SnapWindow';
+import {SnapWindow, WindowIdentity, WindowState} from './SnapWindow';
 import {Point, PointUtils} from './utils/PointUtils';
 import {RectUtils} from './utils/RectUtils';
-import { TabService } from '../tabbing/TabService';
 
 export enum eSnapValidity {
     /**
@@ -124,7 +125,8 @@ export class Resolver {
                         const activeState: WindowState = activeWindow.getState();
 
                         // Only do the next loop if there's a chance that this window can intersect with the other group
-                        if (this.isSnappable(activeWindow.getIdentity(), activeState) && RectUtils.distance(candidateGroup, activeState).within(SNAP_DISTANCE)) {
+                        if (this.isSnappable(activeWindow.getIdentity(), activeState) &&
+                            RectUtils.distance(candidateGroup, activeState).within(SNAP_DISTANCE)) {
                             candidateGroup.windows.forEach(candidateWindow => {
                                 const candidateState: WindowState = candidateWindow.getState();
 

--- a/src/provider/snapanddock/Resolver.ts
+++ b/src/provider/snapanddock/Resolver.ts
@@ -1,9 +1,10 @@
 import {SNAP_DISTANCE} from './Config';
 import {Projector} from './Projector';
 import {SnapGroup} from './SnapGroup';
-import {SnapWindow, WindowState} from './SnapWindow';
+import {SnapWindow, WindowState, WindowIdentity} from './SnapWindow';
 import {Point, PointUtils} from './utils/PointUtils';
 import {RectUtils} from './utils/RectUtils';
+import { TabService } from '../tabbing/TabService';
 
 export enum eSnapValidity {
     /**
@@ -123,11 +124,11 @@ export class Resolver {
                         const activeState: WindowState = activeWindow.getState();
 
                         // Only do the next loop if there's a chance that this window can intersect with the other group
-                        if (this.isSnappable(activeState) && RectUtils.distance(candidateGroup, activeState).within(SNAP_DISTANCE)) {
+                        if (this.isSnappable(activeWindow.getIdentity(), activeState) && RectUtils.distance(candidateGroup, activeState).within(SNAP_DISTANCE)) {
                             candidateGroup.windows.forEach(candidateWindow => {
                                 const candidateState: WindowState = candidateWindow.getState();
 
-                                if (this.isSnappable(candidateState)) {
+                                if (this.isSnappable(candidateWindow.getIdentity(), candidateState)) {
                                     projector.project(activeState, candidateState);
                                 }
                             });
@@ -182,9 +183,10 @@ export class Resolver {
      *
      * If this check fails, we shouldn't be doing any bounds-checking or creating and snap targets for this window.
      *
+     * @param identity Handle to the window we are considering for snapping
      * @param windowState State of the window object we are considering for snapping
      */
-    private isSnappable(windowState: WindowState): boolean {
-        return !windowState.hidden && windowState.opacity > 0 && windowState.state === 'normal';
+    private isSnappable(identity: WindowIdentity, windowState: WindowState): boolean {
+        return !windowState.hidden && windowState.opacity > 0 && windowState.state === 'normal' && TabService.INSTANCE.getTab(identity) === undefined;
     }
 }

--- a/src/provider/tabbing/TabUtilities.ts
+++ b/src/provider/tabbing/TabUtilities.ts
@@ -147,6 +147,11 @@ export function getWindowAt(x: number, y: number, exclude?: Identity) {
     const windowsAtPoint: SnapWindow[] = windows.filter((window: SnapWindow) => {
         const state: WindowState = Object.assign({}, window.getState());
 
+        // Ignore any windows that are snapped (temporary solution - see SERVICE-230/SERVICE-200)
+        if (window.getGroup().length > 1) {
+            return false;
+        }
+
         // Hack to deal with tabstrips being unknown to the snapservice
         const tabGroup = TabService.INSTANCE.getTabGroupByApp(window.getIdentity());
         if (tabGroup) {

--- a/src/provider/tabbing/TabWindow.ts
+++ b/src/provider/tabbing/TabWindow.ts
@@ -1,4 +1,7 @@
 import {TabIdentifier, TabWindowOptions} from '../../client/types';
+import {SnapService} from '../snapanddock/SnapService';
+import {SnapWindow} from '../snapanddock/SnapWindow';
+
 import {AsyncWindow} from './asyncWindow';
 import {Tab} from './Tab';
 import {TabGroup} from './TabGroup';
@@ -51,8 +54,15 @@ export class TabWindow extends AsyncWindow {
         const bounds = await this.getWindowBounds();
         await this._window.resizeTo(bounds.width, bounds.height + this._tab.tabGroup.window.initialWindowOptions.height!, 'bottom-left');
 
+        // Check if the window should have a frame
+        const identity: TabIdentifier = this._tab.ID;
+        const id = `${identity.uuid}/${identity.name}`;
+        const windows: SnapWindow[] = (window as Window & {snapService: SnapService}).snapService['windows'];
+        const snapWindow: SnapWindow|undefined = windows.find(window => window.getId() === id);
+        const hasFrame: boolean = !snapWindow || snapWindow.getState().frame;  // If can't find the window (shouldn't be possible), assume window had a frame
+
         // @ts-ignore resizeRegion.sides is valid.  Its not in the type file.
-        return this.updateWindowOptions({showTaskbarIcon: true, frame: true, resizeRegion: {sides: {top: true}}});
+        return this.updateWindowOptions({showTaskbarIcon: true, frame: hasFrame, resizeRegion: {sides: {top: true}}});
     }
 
     /**

--- a/src/provider/tabbing/components/ApplicationConfigManager.ts
+++ b/src/provider/tabbing/components/ApplicationConfigManager.ts
@@ -1,4 +1,4 @@
-import { ApplicationUIConfig, TabWindowOptions } from "../../../client/types";
+import {ApplicationUIConfig, TabWindowOptions} from '../../../client/types';
 
 /**
  * Class that handles which application configuration to use for the app and all its child windows
@@ -22,9 +22,9 @@ export class ApplicationConfigManager {
      * Retrieves the ui config given the Uuid
      * @param {string} uuid The uuid of the application to bind the window options to
      */
-    public getApplicationUIConfig(uuid: string): TabWindowOptions | undefined {
+    public getApplicationUIConfig(uuid: string): TabWindowOptions|undefined {
         if (!this.exists(uuid)) {
-            console.error("No application config found");
+            console.error('No application config found');
             return;
         }
 
@@ -56,8 +56,8 @@ export class ApplicationConfigManager {
      * @param {string} otherUuid THe other uuid to compare
      */
     public compareConfigBetweenApplications(uuid: string, otherUuid: string): boolean {
-        const config: TabWindowOptions | undefined = this.getApplicationUIConfig(uuid);
-        const otherConfig: TabWindowOptions | undefined = this.getApplicationUIConfig(otherUuid);
+        const config: TabWindowOptions|undefined = this.getApplicationUIConfig(uuid);
+        const otherConfig: TabWindowOptions|undefined = this.getApplicationUIConfig(otherUuid);
 
         return ((config && otherConfig && config.url === otherConfig.url) || (!config && !otherConfig));
     }


### PR DESCRIPTION
These features are not yet integrated, which is causing usability issues. This PR filters snapping and tabbing actions until we can complete SERVICE-200.

PR also contains a change to what happens when removing a window from a tab set. `TabWindow` will now only restore the frame of a window if the window had a frame before it was tabbed.