### PR TITLE
[SERVICE-234] Update service app UUID to something more descriptive

### DIFF
--- a/res/demo/app2.json
+++ b/res/demo/app2.json
@@ -15,5 +15,5 @@
         "arguments": "--v=1 --enable-crash-reporting",
         "version": "9.61.33.32"
     },
-    "services": [{"name": "layoutsManager", "manifestUrl": "http://localhost:1337/provider/app.json"}]
+    "services": [{"name": "layouts", "manifestUrl": "http://localhost:1337/provider/app.json"}]
 }

--- a/res/demo/app3.json
+++ b/res/demo/app3.json
@@ -15,5 +15,5 @@
         "arguments": "--v=1 --enable-crash-reporting",
         "version": "9.61.33.32"
     },
-    "services": [{"name": "layoutsManager", "manifestUrl": "http://localhost:1337/provider/app.json"}]
+    "services": [{"name": "layouts", "manifestUrl": "http://localhost:1337/provider/app.json"}]
 }

--- a/res/provider/app.json
+++ b/res/provider/app.json
@@ -1,10 +1,10 @@
 {
     "devtools_port": 9091,
     "startup_app": {
-        "name": "Layout-Manager",
+        "name": "layouts-service",
         "description": "OpenFin Layouts Managing Service",
         "url": "https://cdn.openfin.co/services/openfin/layouts/stable/index.html",
-        "uuid": "Layout-Manager",
+        "uuid": "layouts-service",
         "autoShow": true,
         "showTaskbarIcon": true,
         "defaultHeight": 300,

--- a/res/test/provider.json
+++ b/res/test/provider.json
@@ -1,10 +1,10 @@
 {
     "devtools_port": 9091,
     "startup_app": {
-        "name": "Layout-Manager",
+        "name": "layouts-service",
         "description": "OpenFin Layouts Managing Service",
         "url": "http://localhost:1337/test/provider.html",
-        "uuid": "Layout-Manager",
+        "uuid": "layouts-service",
         "autoShow": true,
         "showTaskbarIcon": true,
         "defaultHeight": 300,

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -9,8 +9,8 @@ export {AppApi} from './AppApi';
 export {TabbingApi} from './TabbingApi';
 
 const IDENTITY = {
-    uuid: 'Layout-Manager',
-    name: 'Layout-Manager'
+    uuid: 'layouts-service',
+    name: 'layouts-service'
 };
 const VERSION = '0.0.1';
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -77,8 +77,8 @@ export interface TabIdentifier {
 }
 
 export enum TabServiceID {
-    NAME = 'Layout-Manager',
-    UUID = 'Layout-Manager'
+    NAME = 'layouts-service',
+    UUID = 'layouts-service'
 }
 
 export interface TabOptions {

--- a/test/client/TabbingApi.unittest.ts
+++ b/test/client/TabbingApi.unittest.ts
@@ -58,7 +58,7 @@ describe.skip('Tests for tab api', () => {
                 tabbingApi.addTab(expectedClientUuid, expectedClientName);
 
                 // Assert
-                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('Layout-Manager', 'tab-api', expectedPayload);
+                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('layouts-service', 'tab-api', expectedPayload);
             });
         });
     });
@@ -107,7 +107,7 @@ describe.skip('Tests for tab api', () => {
                 tabbingApi.ejectTab(uuid, name);
 
                 // Assert
-                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('Layout-Manager', 'tab-api', expectedPayload);
+                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('layouts-service', 'tab-api', expectedPayload);
             });
         });
     });
@@ -160,7 +160,7 @@ describe.skip('Tests for tab api', () => {
                 tabbingApi.activateTab(uuid, name);
 
                 // Assert
-                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('Layout-Manager', 'tab-api', expectedPayload);
+                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('layouts-service', 'tab-api', expectedPayload);
             });
         });
     });
@@ -213,7 +213,7 @@ describe.skip('Tests for tab api', () => {
                 tabbingApi.closeTab(uuid, name);
 
                 // Assert
-                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('Layout-Manager', 'tab-api', expectedPayload);
+                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('layouts-service', 'tab-api', expectedPayload);
             });
         });
     });
@@ -286,7 +286,7 @@ describe.skip('Tests for tab api', () => {
                 tabbingApi.updateTabProperties(uuid, name, tabProperties);
 
                 // Assert
-                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('Layout-Manager', 'tab-api', expectedPayload);
+                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('layouts-service', 'tab-api', expectedPayload);
             });
         });
     });
@@ -303,7 +303,7 @@ describe.skip('Tests for tab api', () => {
                 tabbingApi.startDrag();
 
                 // Assert
-                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('Layout-Manager', 'tab-api', expectedPayload);
+                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('layouts-service', 'tab-api', expectedPayload);
             });
         });
     });
@@ -402,7 +402,7 @@ describe.skip('Tests for tab api', () => {
                 tabbingApi.endDrag(mockDragEvent as DragEvent, uuid, name);
 
                 // Assert
-                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('Layout-Manager', 'tab-api', expectedPayload);
+                expect(fin.desktop.InterApplicationBus.send).toBeCalledWith('layouts-service', 'tab-api', expectedPayload);
             });
         });
     });

--- a/test/client/TabbingApiWindowActions.unittest.ts
+++ b/test/client/TabbingApiWindowActions.unittest.ts
@@ -33,7 +33,7 @@ describe("Tests for tabbing api window actions", () => {
 				tabbingApiWindowActions.maximize();
 
 				// Assert
-				expect(fin.desktop.InterApplicationBus.send).toBeCalledWith("Layout-Manager", "tab-api", expectedPayload);
+				expect(fin.desktop.InterApplicationBus.send).toBeCalledWith("layouts-service", "tab-api", expectedPayload);
 			});
 		});
 	});
@@ -51,7 +51,7 @@ describe("Tests for tabbing api window actions", () => {
 			tabbingApiWindowActions.minimize();
 
 			// Assert
-			expect(fin.desktop.InterApplicationBus.send).toBeCalledWith("Layout-Manager", "tab-api", expectedPayload);
+			expect(fin.desktop.InterApplicationBus.send).toBeCalledWith("layouts-service", "tab-api", expectedPayload);
 		});
 	});
 
@@ -68,7 +68,7 @@ describe("Tests for tabbing api window actions", () => {
 			tabbingApiWindowActions.restore();
 
 			// Assert
-			expect(fin.desktop.InterApplicationBus.send).toBeCalledWith("Layout-Manager", "tab-api", expectedPayload);
+			expect(fin.desktop.InterApplicationBus.send).toBeCalledWith("layouts-service", "tab-api", expectedPayload);
 		});
 	});
 
@@ -85,7 +85,7 @@ describe("Tests for tabbing api window actions", () => {
 			tabbingApiWindowActions.close();
 
 			// Assert
-			expect(fin.desktop.InterApplicationBus.send).toBeCalledWith("Layout-Manager", "tab-api", expectedPayload);
+			expect(fin.desktop.InterApplicationBus.send).toBeCalledWith("layouts-service", "tab-api", expectedPayload);
 		});
 	});
 
@@ -102,7 +102,7 @@ describe("Tests for tabbing api window actions", () => {
 			tabbingApiWindowActions.toggleMaximize();
 
 			// Assert
-			expect(fin.desktop.InterApplicationBus.send).toBeCalledWith("Layout-Manager", "tab-api", expectedPayload);
+			expect(fin.desktop.InterApplicationBus.send).toBeCalledWith("layouts-service", "tab-api", expectedPayload);
 		});
 	});
 });

--- a/test/demo/tabbing/createTabFromMultipleWindows.test.ts
+++ b/test/demo/tabbing/createTabFromMultipleWindows.test.ts
@@ -53,7 +53,7 @@ test.failing("Create tab group from 2 windows", async (assert) => {
     }];
 
     // Get the service window in order to be able to find the tabgroup window
-    const serviceApplication: Application = await fin.Application.wrap({ uuid: "Layout-Manager", name: "Layout-Manager" });    
+    const serviceApplication: Application = await fin.Application.wrap({ uuid: "layouts-service", name: "layouts-service" });    
 
 
     // Act
@@ -66,7 +66,7 @@ test.failing("Create tab group from 2 windows", async (assert) => {
     let uuidTestPattern = new RegExp('^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$', 'i');
 
     const newTabGroupWindow: Window | undefined = serviceChildWindows.find((window: Window) => {
-        return window.identity.uuid == "Layout-Manager" && uuidTestPattern.test(window.identity.name!);
+        return window.identity.uuid == "layouts-service" && uuidTestPattern.test(window.identity.name!);
     });
     
 

--- a/test/demo/utils/executeJavascriptOnService.ts
+++ b/test/demo/utils/executeJavascriptOnService.ts
@@ -8,7 +8,7 @@ import { Fin } from "hadouken-js-adapter";
 export async function executeJavascriptOnService(script: string): Promise<any> {
     const fin: Fin = await getConnection();
     return new Promise((resolve, reject) => {
-        fin.InterApplicationBus.subscribe({ uuid: "Layout-Manager", name: "Layout-Manager" }, "replytest", (message: string) => { console.log(message); resolve(message); })
-        fin.InterApplicationBus.send({ uuid: "Layout-Manager", name: "Layout-Manager" }, 'test', script);
+        fin.InterApplicationBus.subscribe({ uuid: "layouts-service", name: "layouts-service" }, "replytest", (message: string) => { console.log(message); resolve(message); })
+        fin.InterApplicationBus.send({ uuid: "layouts-service", name: "layouts-service" }, 'test', script);
     });
 }

--- a/test/provider/deregisterWindow.test.ts
+++ b/test/provider/deregisterWindow.test.ts
@@ -124,7 +124,7 @@ test('deregister snapped window', async t => {
 
 test('no preview when deregistered - dragging registered', async t => {
     // Wrap the pre-spawned preview window
-    const previewWin = await getWindow({ name: 'previewWindow-', uuid: 'Layout-Manager' });
+    const previewWin = await getWindow({ name: 'previewWindow-', uuid: 'layouts-service' });
 
     // Spawn two child windows (one of them deregistered)
     win1 = await createChildWindow({ autoShow: true, saveWindowState: false, defaultTop: 100, defaultLeft: 100, defaultHeight: 200, defaultWidth: 200, url: 'http://localhost:1337/demo/frameless-window.html', frame: false });
@@ -144,7 +144,7 @@ test('no preview when deregistered - dragging registered', async t => {
 
 test('no preview when deregistered - dragging deregistered', async t => {
     // Wrap the pre-spawned preview window
-    const previewWin = await getWindow({ name: 'previewWindow-', uuid: 'Layout-Manager' });
+    const previewWin = await getWindow({ name: 'previewWindow-', uuid: 'layouts-service' });
 
     // Spawn two child windows (one of them deregistered)
     win1 = await createChildWindow({ autoShow: true, saveWindowState: false, defaultTop: 100, defaultLeft: 100, defaultHeight: 200, defaultWidth: 200, url: 'http://localhost:1337/demo/frameless-window-deregistered.html', frame: false });

--- a/test/provider/previewWindow.test.ts
+++ b/test/provider/previewWindow.test.ts
@@ -9,7 +9,7 @@ let previewWin: _Window;
 
 test.beforeEach(async () => {
     const fin = await getConnection();
-    previewWin = await fin.Window.wrap({ name: 'previewWindow-', uuid: 'Layout-Manager' });
+    previewWin = await fin.Window.wrap({ name: 'previewWindow-', uuid: 'layouts-service' });
 });
 
 test('preview on right side', async t => {

--- a/test/provider/utils/explodeGroup.ts
+++ b/test/provider/utils/explodeGroup.ts
@@ -9,7 +9,7 @@ export interface WindowIdentity {
 
 const getClientConnection = async () => {
     const fin:Fin = await getConnection();
-    return fin.Service.connect({uuid: 'Layout-Manager'});
+    return fin.Service.connect({uuid: 'layouts-service'});
 };
 
 export async function explodeGroup(identity: WindowIdentity) {

--- a/test/provider/utils/undockWindow.ts
+++ b/test/provider/utils/undockWindow.ts
@@ -9,7 +9,7 @@ export interface WindowIdentity {
 
 const getClientConnection = async () => {
     const fin:Fin = await getConnection();
-    return fin.Service.connect({uuid: 'Layout-Manager'});
+    return fin.Service.connect({uuid: 'layouts-service'});
 };
 
 export async function undockWindow(identity: WindowIdentity) {


### PR DESCRIPTION
NOTE: This change will require client and provider to be updated in tandem. Any client versions from prior to this change will not work with provider versions from after it, and vice versa.

Change service UUID from 'Layouts-Manager' to 'layouts-service'