### PR TITLE
On restore, if a child window is open and in a tab group, and part of…

### DIFF
--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -123,6 +123,8 @@ export const restoreLayout = async(payload: Layout, identity: Identity): Promise
                     } else {
                         await createNormalPlaceholder(win);
                     }
+                } else {
+                    await removeTab(win);
                 }
             }
         } else {


### PR DESCRIPTION
… a layout about to be restored, remove it from its tab group