### PR TITLE
Fixed occasional incorrect preview windows when restoring a layout

### DIFF
--- a/src/provider/snapanddock/SnapGroup.ts
+++ b/src/provider/snapanddock/SnapGroup.ts
@@ -204,6 +204,8 @@ export class SnapGroup {
     }
 
     private onWindowModified(window: SnapWindow): void {
+        this._origin.markStale();
+        this._halfSize.markStale();
         this.onModified.emit(this, window);
     }
 


### PR DESCRIPTION
SnapGroup wouldn't know to refresh it's internal state when a layout is restored. Will now mark it's cache as stale when a window within the group is modified.

This may end up being slightly excessive. Should find a way to better detect restore events as part of future refactoring.