### PR TITLE
[SERVICE-252] z-ordering - when dragging tabs out of tabset

### DIFF
--- a/src/provider/tabbing/TabUtilities.ts
+++ b/src/provider/tabbing/TabUtilities.ts
@@ -173,7 +173,8 @@ export function getWindowAt(x: number, y: number, exclude?: Identity) {
             state.halfSize = {x: state.halfSize.x, y: state.halfSize.y + 15};
         }
 
-        return window.getId() !== id && !window.getState().hidden && window.getState().state !== 'minimized' && RectUtils.isPointInRect(state.center, state.halfSize, point);
+        return window.getId() !== id && !window.getState().hidden && window.getState().state !== 'minimized' &&
+            RectUtils.isPointInRect(state.center, state.halfSize, point);
     });
 
 

--- a/src/provider/tabbing/TabWindow.ts
+++ b/src/provider/tabbing/TabWindow.ts
@@ -61,6 +61,7 @@ export class TabWindow extends AsyncWindow {
         const snapWindow: SnapWindow|undefined = windows.find(window => window.getId() === id);
         const hasFrame: boolean = !snapWindow || snapWindow.getState().frame;  // If can't find the window (shouldn't be possible), assume window had a frame
 
+        this._window.bringToFront();
         // @ts-ignore resizeRegion.sides is valid.  Its not in the type file.
         return this.updateWindowOptions({showTaskbarIcon: true, frame: hasFrame, resizeRegion: {sides: {top: true}}});
     }


### PR DESCRIPTION
Tab strip + apps are no longer split when you eject a tab