### PR TITLE
[SERVICE-253] Deregister for Save & Restore

### DIFF
--- a/res/demo/app2.html
+++ b/res/demo/app2.html
@@ -4,14 +4,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Demo App - App 2</title>
-    <script src="./LayoutsUI-bundle.js"></script>
+    <script src="./normalApp-bundle.js"></script>
 </head>
 <body>
     <h1>
         App2 - Main Window
     </h1>
 
-    <p>Unregistered from snapdock/tabbing</p>
-    <button onclick="LayoutsUI.createChild('App2')">Create Child</button>
+    <p>Not unregistered from Snap & Dock, Tabbing, and Save & Restore</p>
+    <button onclick="normalApp.createChild('App2')">Create Child</button>
 </body>
 </html>

--- a/res/demo/app3.html
+++ b/res/demo/app3.html
@@ -4,14 +4,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Demo App - App 3</title>
-    <script src="./LayoutsUI-bundle.js"></script>
+    <script src="./deregisteredApp-bundle.js"></script>
 </head>
 <body>
     <h1>
         App3 - Main Window
     </h1>
 
-    <p>Unregistered from snapdock/tabbing</p>
-    <button onclick="LayoutsUI.createChild('App3')">Create Child</button>
+    <p>Unregistered from Snap & Dock, Tabbing, and Save & Restore</p>
+    <button onclick="deregisteredApp.createChild('App3')">Create Child</button>
 </body>
 </html>

--- a/res/demo/app4.html
+++ b/res/demo/app4.html
@@ -4,14 +4,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Demo App - App 4</title>
-    <script src="./LayoutsUI-bundle.js"></script>
+    <script src="./normalApp-bundle.js"></script>
 </head>
 <body>
     <h1>
         App4 - Main Window
     </h1>
 
-    <p>Unregistered from snapdock/tabbing</p>
-    <button onclick="LayoutsUI.createChild('App4')">Create Child</button>
+    <p>Not unregistered from Snap & Dock, Tabbing, and Save & Restore</p>
+    <button onclick="normalApp.createChild('App4')">Create Child</button>
 </body>
 </html>

--- a/res/demo/app5.html
+++ b/res/demo/app5.html
@@ -4,14 +4,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Demo App - App 5</title>
-    <script src="./LayoutsUI-bundle.js"></script>
+    <script src="./deregisteredApp-bundle.js"></script>
 </head>
 <body>
     <h1>
         App5 - Main Window
     </h1>
 
-    <p>Unregistered from snapdock/tabbing</p>
-    <button onclick="LayoutsUI.createChild('App5')">Create Child</button>
+    <p>Unregistered from Snap & Dock, Tabbing, and Save & Restore</p>
+    <button onclick="deregisteredApp.createChild('App5')">Create Child</button>
 </body>
 </html>

--- a/res/demo/demo-window.html
+++ b/res/demo/demo-window.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <script src="./LayoutsUI-bundle.js"></script>
+        <script src="./normalApp-bundle.js"></script>
     </head>
 <body style="-webkit-app-region:drag">
     <h1 id='winName'></h1>

--- a/src/demo/deregisteredApp.ts
+++ b/src/demo/deregisteredApp.ts
@@ -1,66 +1,6 @@
-import {Identity} from 'hadouken-js-adapter';
-import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
-
-import {Layout, LayoutApp} from '../client/types';
-import {positionWindow} from '../provider/workspaces/utils';
-
-export interface Workspace {
-    id: string;
-    layout: Layout;
-}
-
 import * as Layouts from '../client/main';
 
-declare var window: _Window&{forgetMe: (identity: Identity) => void};
-
-let numChildren = 0;
-const launchDir = location.href.slice(0, location.href.lastIndexOf('/'));
-
-export async function createChild(parentWindowName: string): Promise<void> {
-    const win = await openChild(parentWindowName + ' -  win' + numChildren, numChildren);
-    win.show();
-}
-
-export function openChild(name: string, i: number, frame = true, url?: string) {
-    numChildren++;
-    const win = fin.Window.create({
-        url: url || `${launchDir}/demo-window.html`,
-        autoShow: false,
-        defaultHeight: 250 + 50 * i,
-        defaultWidth: 250 + 50 * i,
-        defaultLeft: 320 * (i % 3),
-        defaultTop: i > 2 ? 400 : 50,
-        saveWindowState: false,
-        frame,
-        name
-    });
-    return win;
-}
-
-async function onAppRes(layoutApp: LayoutApp): Promise<LayoutApp> {
-    console.log('Apprestore called:', layoutApp);
-    // We use the v1 version of Application.getCurrent() due to an event-loop bug
-    // when calling the v2 version inside a channel callback. Due for fix in v35
-    const ofApp = fin.desktop.Application.getCurrent();
-    const openWindows = await new Promise<fin.OpenFinWindow[]>(res => ofApp.getChildWindows(res));
-    const openAndPosition = layoutApp.childWindows.map(async (win, index) => {
-        if (!openWindows.some((w: fin.OpenFinWindow) => w.name === win.name)) {
-            const ofWin = await openChild(win.name, index, win.frame, win.info.url);
-            await positionWindow(win);
-        } else {
-            await positionWindow(win);
-        }
-    });
-    await Promise.all(openAndPosition);
-    return layoutApp;
-}
+export {createChild, onAppRes} from './normalApp';
 
 // Do not snap to other windows
 Layouts.deregister();
-
-// Allow layouts service to save and restore this application
-Layouts.onApplicationSave(() => {
-    return {test: true};
-});
-Layouts.onAppRestore(onAppRes);
-Layouts.ready();

--- a/src/demo/deregisteredApp.ts
+++ b/src/demo/deregisteredApp.ts
@@ -1,0 +1,65 @@
+import {Identity} from 'hadouken-js-adapter';
+import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
+
+import {Layout, LayoutApp} from '../client/types';
+import {positionWindow} from '../provider/workspaces/utils';
+
+export interface Workspace {
+    id: string;
+    layout: Layout;
+}
+
+import * as Layouts from '../client/main';
+
+declare var window: _Window&{forgetMe: (identity: Identity) => void};
+
+let numChildren = 0;
+const launchDir = location.href.slice(0, location.href.lastIndexOf('/'));
+
+export async function createChild(parentWindowName: string): Promise<void> {
+    openChild(parentWindowName + ' -  win' + numChildren, numChildren);
+    numChildren++;
+}
+
+export function openChild(name: string, i: number, frame = true, url?: string) {
+    const win = fin.Window.create({
+        url: url || `${launchDir}/demo-window.html`,
+        autoShow: true,
+        defaultHeight: 250 + 50 * i,
+        defaultWidth: 250 + 50 * i,
+        defaultLeft: 320 * (i % 3),
+        defaultTop: i > 2 ? 400 : 50,
+        saveWindowState: false,
+        frame,
+        name
+    });
+    return win;
+}
+
+async function onAppRes(layoutApp: LayoutApp): Promise<LayoutApp> {
+    console.log('Apprestore called:', layoutApp);
+    // We use the v1 version of Application.getCurrent() due to an event-loop bug
+    // when calling the v2 version inside a channel callback. Due for fix in v35
+    const ofApp = fin.desktop.Application.getCurrent();
+    const openWindows = await new Promise<fin.OpenFinWindow[]>(res => ofApp.getChildWindows(res));
+    const openAndPosition = layoutApp.childWindows.map(async (win, index) => {
+        if (!openWindows.some((w: fin.OpenFinWindow) => w.name === win.name)) {
+            const ofWin = await openChild(win.name, index, win.frame, win.info.url);
+            await positionWindow(win);
+        } else {
+            await positionWindow(win);
+        }
+    });
+    await Promise.all(openAndPosition);
+    return layoutApp;
+}
+
+// Do not snap to other windows
+Layouts.deregister();
+
+// Allow layouts service to save and restore this application
+Layouts.onApplicationSave(() => {
+    return {test: true};
+});
+Layouts.onAppRestore(onAppRes);
+Layouts.ready();

--- a/src/demo/deregisteredApp.ts
+++ b/src/demo/deregisteredApp.ts
@@ -17,14 +17,15 @@ let numChildren = 0;
 const launchDir = location.href.slice(0, location.href.lastIndexOf('/'));
 
 export async function createChild(parentWindowName: string): Promise<void> {
-    openChild(parentWindowName + ' -  win' + numChildren, numChildren);
-    numChildren++;
+    const win = await openChild(parentWindowName + ' -  win' + numChildren, numChildren);
+    win.show();
 }
 
 export function openChild(name: string, i: number, frame = true, url?: string) {
+    numChildren++;
     const win = fin.Window.create({
         url: url || `${launchDir}/demo-window.html`,
-        autoShow: true,
+        autoShow: false,
         defaultHeight: 250 + 50 * i,
         defaultWidth: 250 + 50 * i,
         defaultLeft: 320 * (i % 3),

--- a/src/demo/normalApp.ts
+++ b/src/demo/normalApp.ts
@@ -37,7 +37,7 @@ export function openChild(name: string, i: number, frame = true, url?: string) {
     return win;
 }
 
-async function onAppRes(layoutApp: LayoutApp): Promise<LayoutApp> {
+export async function onAppRes(layoutApp: LayoutApp): Promise<LayoutApp> {
     console.log('Apprestore called:', layoutApp);
     // We use the v1 version of Application.getCurrent() due to an event-loop bug
     // when calling the v2 version inside a channel callback. Due for fix in v35

--- a/src/demo/normalApp.ts
+++ b/src/demo/normalApp.ts
@@ -1,0 +1,62 @@
+import {Identity} from 'hadouken-js-adapter';
+import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
+
+import {Layout, LayoutApp} from '../client/types';
+import {positionWindow} from '../provider/workspaces/utils';
+
+export interface Workspace {
+    id: string;
+    layout: Layout;
+}
+
+import * as Layouts from '../client/main';
+
+declare var window: _Window&{forgetMe: (identity: Identity) => void};
+
+let numChildren = 0;
+const launchDir = location.href.slice(0, location.href.lastIndexOf('/'));
+
+export async function createChild(parentWindowName: string): Promise<void> {
+    openChild(parentWindowName + ' -  win' + numChildren, numChildren);
+    numChildren++;
+}
+
+export function openChild(name: string, i: number, frame = true, url?: string) {
+    const win = fin.Window.create({
+        url: url || `${launchDir}/demo-window.html`,
+        autoShow: true,
+        defaultHeight: 250 + 50 * i,
+        defaultWidth: 250 + 50 * i,
+        defaultLeft: 320 * (i % 3),
+        defaultTop: i > 2 ? 400 : 50,
+        saveWindowState: false,
+        frame,
+        name
+    });
+    return win;
+}
+
+async function onAppRes(layoutApp: LayoutApp): Promise<LayoutApp> {
+    console.log('Apprestore called:', layoutApp);
+    // We use the v1 version of Application.getCurrent() due to an event-loop bug
+    // when calling the v2 version inside a channel callback. Due for fix in v35
+    const ofApp = fin.desktop.Application.getCurrent();
+    const openWindows = await new Promise<fin.OpenFinWindow[]>(res => ofApp.getChildWindows(res));
+    const openAndPosition = layoutApp.childWindows.map(async (win, index) => {
+        if (!openWindows.some((w: fin.OpenFinWindow) => w.name === win.name)) {
+            const ofWin = await openChild(win.name, index, win.frame, win.info.url);
+            await positionWindow(win);
+        } else {
+            await positionWindow(win);
+        }
+    });
+    await Promise.all(openAndPosition);
+    return layoutApp;
+}
+
+// Allow layouts service to save and restore this application
+Layouts.onApplicationSave(() => {
+    return {test: true};
+});
+Layouts.onAppRestore(onAppRes);
+Layouts.ready();

--- a/src/demo/normalApp.ts
+++ b/src/demo/normalApp.ts
@@ -17,14 +17,15 @@ let numChildren = 0;
 const launchDir = location.href.slice(0, location.href.lastIndexOf('/'));
 
 export async function createChild(parentWindowName: string): Promise<void> {
-    openChild(parentWindowName + ' -  win' + numChildren, numChildren);
-    numChildren++;
+    const win = await openChild(parentWindowName + ' -  win' + numChildren, numChildren);
+    win.show();
 }
 
 export function openChild(name: string, i: number, frame = true, url?: string) {
+    numChildren++;
     const win = fin.Window.create({
         url: url || `${launchDir}/demo-window.html`,
-        autoShow: true,
+        autoShow: false,
         defaultHeight: 250 + 50 * i,
         defaultWidth: 250 + 50 * i,
         defaultLeft: 320 * (i % 3),

--- a/src/provider/main.ts
+++ b/src/provider/main.ts
@@ -9,7 +9,7 @@ import {SnapService} from './snapanddock/SnapService';
 import {SnapWindow, WindowIdentity} from './snapanddock/SnapWindow';
 import {win10Check} from './snapanddock/utils/platform';
 import {TabService} from './tabbing/TabService';
-import {generateLayout} from './workspaces/create';
+import {deregisterWindow, generateLayout} from './workspaces/create';
 import {getAppToRestore, restoreApplication, restoreLayout} from './workspaces/restore';
 
 export let snapService: SnapService;
@@ -38,6 +38,7 @@ async function registerService() {
     providerChannel.register('deregister', (identity: WindowIdentity) => {
         snapService.deregister(identity);
         tabService.apiHandler.deregister(identity);
+        deregisterWindow(identity);
     });
     providerChannel.register('undockGroup', (identity: WindowIdentity) => {
         snapService.explodeGroup(identity);

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -3,13 +3,13 @@ import {ApplicationInfo} from 'hadouken-js-adapter/out/types/src/api/application
 import {WindowDetail, WindowInfo} from 'hadouken-js-adapter/out/types/src/api/system/window';
 import {Identity} from 'hadouken-js-adapter/out/types/src/identity';
 
-import {CustomData, Layout, LayoutApp, LayoutWindowData, WindowState, TabIdentifier, TabBlob} from '../../client/types';
+import {CustomData, Layout, LayoutApp, LayoutWindowData, TabBlob, TabIdentifier, WindowState} from '../../client/types';
 import {WindowIdentity} from '../snapanddock/SnapWindow';
 import {promiseMap} from '../snapanddock/utils/async';
 import {getTabSaveInfo} from '../tabbing/SaveAndRestoreAPI';
 
 import {getGroup} from './group';
-import {isClientConnection, sendToClient, wasCreatedFromManifest, wasCreatedProgrammatically, WindowObject, inWindowObject, addToWindowObject} from './utils';
+import {addToWindowObject, inWindowObject, isClientConnection, sendToClient, wasCreatedFromManifest, wasCreatedProgrammatically, WindowObject} from './utils';
 
 const deregisteredWindows: WindowObject = {};
 
@@ -54,7 +54,7 @@ export const getCurrentLayout = async(): Promise<Layout> => {
             tabGroup.groupInfo.active = newActiveWindow;
             addToWindowObject(newActiveWindow, newShowingWindows);
             if (filteredTabs.length === 1) {
-                addToWindowObject(newActiveWindow, newUntabbedWindows);                
+                addToWindowObject(newActiveWindow, newUntabbedWindows);
             }
         }
 
@@ -163,14 +163,15 @@ export const generateLayout = async(payload: null, identity: Identity): Promise<
     return confirmedLayout;
 };
 
-const getLayoutWindowData = async (ofWin: Window, tabbedWindows: WindowObject, newShowingWindows: WindowObject, newUntabbedWindows: WindowObject): Promise<LayoutWindowData> => {
+const getLayoutWindowData =
+    async(ofWin: Window, tabbedWindows: WindowObject, newShowingWindows: WindowObject, newUntabbedWindows: WindowObject): Promise<LayoutWindowData> => {
     const {uuid} = ofWin.identity;
     const info = await ofWin.getInfo();
-    
+
     const windowGroup = await getGroup(ofWin.identity);
     const filteredWindowGroup: Identity[] = [];
     windowGroup.forEach((windowIdentity) => {
-        const parentIsDeregistered = inWindowObject({ uuid: windowIdentity.uuid, name: windowIdentity.uuid }, deregisteredWindows);
+        const parentIsDeregistered = inWindowObject({uuid: windowIdentity.uuid, name: windowIdentity.uuid}, deregisteredWindows);
         const windowIsDeregistered = inWindowObject(windowIdentity, deregisteredWindows);
         if (!parentIsDeregistered && !windowIsDeregistered && windowIdentity.uuid !== 'layouts-service') {
             filteredWindowGroup.push(windowIdentity);
@@ -178,10 +179,10 @@ const getLayoutWindowData = async (ofWin: Window, tabbedWindows: WindowObject, n
     });
 
     const options = await ofWin.getOptions();
-    
+
     const frame = inWindowObject(ofWin.identity, newUntabbedWindows) ? true : options.frame;
     const isTabbed = inWindowObject(ofWin.identity, tabbedWindows) ? true : false;
     const isShowing = inWindowObject(ofWin.identity, newShowingWindows) ? true : await ofWin.isShowing();
 
-    return { info, uuid, windowGroup: filteredWindowGroup, frame, state: options.state, isTabbed, isShowing};
+    return {info, uuid, windowGroup: filteredWindowGroup, frame, state: options.state, isTabbed, isShowing};
 };

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -9,12 +9,12 @@ import {promiseMap} from '../snapanddock/utils/async';
 import {getTabSaveInfo} from '../tabbing/SaveAndRestoreAPI';
 
 import {getGroup} from './group';
-import {isClientConnection, sendToClient, wasCreatedFromManifest, wasCreatedProgrammatically, WindowObject, inWindowObject} from './utils';
+import {isClientConnection, sendToClient, wasCreatedFromManifest, wasCreatedProgrammatically, WindowObject, inWindowObject, addToWindowObject} from './utils';
 
 const deregisteredWindows: WindowObject = {};
 
 export const deregisterWindow = (identity: WindowIdentity) => {
-    deregisteredWindows[identity.uuid] = Object.assign({}, deregisteredWindows[identity.uuid], {[identity.name]: true});
+    addToWindowObject(identity, deregisteredWindows);
 };
 
 export const getCurrentLayout = async(): Promise<Layout> => {
@@ -52,9 +52,9 @@ export const getCurrentLayout = async(): Promise<Layout> => {
         if (activeWindowRemoved && filteredTabs.length >= 1) {
             const newActiveWindow = filteredTabs[0];
             tabGroup.groupInfo.active = newActiveWindow;
-            newShowingWindows[newActiveWindow.uuid] = Object.assign({}, newShowingWindows[newActiveWindow.uuid], { [newActiveWindow.name]: true});
+            addToWindowObject(newActiveWindow, newShowingWindows);
             if (filteredTabs.length === 1) {
-                newUntabbedWindows[newActiveWindow.uuid] = Object.assign({}, newUntabbedWindows[newActiveWindow.uuid], { [newActiveWindow.name]: true});
+                addToWindowObject(newActiveWindow, newUntabbedWindows);                
             }
         }
 
@@ -65,7 +65,7 @@ export const getCurrentLayout = async(): Promise<Layout> => {
 
     filteredTabGroups.forEach((tabGroup) => {
         tabGroup.tabs.forEach(tabWindow => {
-            tabbedWindows[tabWindow.uuid] = Object.assign({}, tabbedWindows[tabWindow.uuid], {[tabWindow.name]: true});
+            addToWindowObject(tabWindow, tabbedWindows);
         });
     });
 

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -50,8 +50,9 @@ export const getCurrentLayout = async(): Promise<Layout> => {
 
         tabGroup.tabs.forEach(tabWindow => {
             const parentIsDeregistered = inWindowObject({uuid: tabWindow.uuid, name: tabWindow.uuid}, deregisteredWindows);
+            const windowIsDeregistered = inWindowObject(tabWindow, deregisteredWindows);
 
-            if (parentIsDeregistered) {
+            if (parentIsDeregistered || windowIsDeregistered) {
                 if (tabGroup.groupInfo.active.uuid === tabWindow.uuid && tabGroup.groupInfo.active.name === tabWindow.name) {
                     activeWindowRemoved = true;
                 }

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -141,10 +141,9 @@ export const restoreLayout = async(payload: Layout, identity: Identity): Promise
             if (isRunning) {
                 const appConnection = getClientConnection({uuid, name});
                 if (appConnection) {
-                    // CREATE CHILD WINDOW PLACEHOLDER IMAGES???
                     await positionWindow(app.mainWindow);
                     console.log('App is running:', app);
-                    // Send LayoutApp to connected application so it can handle child WIndows
+                    // Send LayoutApp to connected application so it can handle child windows
                     const response: LayoutApp|false = await providerChannel.dispatch(appConnection, 'restoreApp', app);
                     console.log('Response from restore:', response);
                     return response ? response : defaultResponse;
@@ -178,6 +177,8 @@ export const restoreLayout = async(payload: Layout, identity: Identity): Promise
                         console.error('Unable to restart programmatically launched app:', app);
                     }
                 }
+
+                // Set up listener for app window shown to run and position it.
                 if (ofAppNotRunning) {
                     const ofAppNRWindow = await ofAppNotRunning.getWindow();
                     const updateOptionsAndShow = async () => {
@@ -206,6 +207,6 @@ export const restoreLayout = async(payload: Layout, identity: Identity): Promise
     layout.apps = allAppResponses;
     // Regroup the windows
     await regroupLayout(allAppResponses).catch(console.log);
-    // send the layout back to the requester of the restore
+    // Send the layout back to the requester of the restore
     return layout;
 };

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -11,7 +11,7 @@ import {TabService} from '../tabbing/TabService';
 import {createTabGroupsFromTabBlob} from '../tabbing/TabUtilities';
 
 import {regroupLayout} from './group';
-import {childWindowPlaceholderCheck, childWindowPlaceholderCheckRunningApp, createNormalPlaceholder, createTabbedPlaceholderAndRecord, getClientConnection, inWindowObject, positionWindow, TabbedPlaceholders, wasCreatedProgrammatically, WindowObject, addToWindowObject} from './utils';
+import {addToWindowObject, childWindowPlaceholderCheck, childWindowPlaceholderCheckRunningApp, createNormalPlaceholder, createTabbedPlaceholderAndRecord, getClientConnection, inWindowObject, positionWindow, TabbedPlaceholders, wasCreatedProgrammatically, WindowObject} from './utils';
 
 const appsToRestore = new Map();
 

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -11,7 +11,7 @@ import {TabService} from '../tabbing/TabService';
 import {createTabGroupsFromTabBlob} from '../tabbing/TabUtilities';
 
 import {regroupLayout} from './group';
-import {childWindowPlaceholderCheck, childWindowPlaceholderCheckRunningApp, createNormalPlaceholder, createTabbedPlaceholderAndRecord, getClientConnection, inWindowObject, positionWindow, TabbedPlaceholders, wasCreatedProgrammatically, WindowObject} from './utils';
+import {childWindowPlaceholderCheck, childWindowPlaceholderCheckRunningApp, createNormalPlaceholder, createTabbedPlaceholderAndRecord, getClientConnection, inWindowObject, positionWindow, TabbedPlaceholders, wasCreatedProgrammatically, WindowObject, addToWindowObject} from './utils';
 
 const appsToRestore = new Map();
 
@@ -68,7 +68,7 @@ export const restoreLayout = async(payload: Layout, identity: Identity): Promise
     // Create tabbedWindows list so we don't have to iterate over all of the tabGroup/TabBlob arrays.
     layout.tabGroups.forEach((tabGroup) => {
         tabGroup.tabs.forEach(tabWindow => {
-            tabbedWindows[tabWindow.uuid] = Object.assign({}, tabbedWindows[tabWindow.uuid], {[tabWindow.name]: true});
+            addToWindowObject(tabWindow, tabbedWindows);
         });
     });
 

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -188,10 +188,12 @@ export interface TabbedPlaceholders {
 }
 
 // Helper function to determine if a window is supposed to be tabbed in an incoming layout.
-export function inWindowObject(win: {uuid: string, name: string}, windowObject: WindowObject|TabbedPlaceholders) {
-    if (windowObject[win.uuid]) {
-        if (windowObject[win.uuid][win.name]) {
-            return true;
+export function inWindowObject(win: Identity, windowObject: WindowObject|TabbedPlaceholders) {
+    if (win.name) {
+        if (windowObject[win.uuid]) {
+            if (windowObject[win.uuid][win.name]) {
+                return true;
+            }
         }
     }
     return false;

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -201,6 +201,11 @@ export function inWindowObject(win: Identity, windowObject: WindowObject|TabbedP
     return false;
 }
 
+// Helper function to add to a Window Object
+export function addToWindowObject(identity: WindowIdentity, windowObject: WindowObject) {
+    windowObject[identity.uuid] = Object.assign({}, windowObject[identity.uuid], {[identity.name]: true});
+}
+
 // Creates a tabbing placeholder and records the information for its corresponding window.
 export async function createTabbedPlaceholderAndRecord(win: WindowState, tabbedPlaceholdersToWindows: TabbedPlaceholders) {
     const tabPlaceholder = await createTabPlaceholder(win);

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -94,10 +94,11 @@ export const createNormalPlaceholder = async (win: WindowState) => {
         });
 
     const actualWindow = await fin.Window.wrap({uuid, name});
-    // @ts-ignore v2 types missing 'shown' event.
-    actualWindow.on('shown', () => {
-        placeholder.close();
-    });
+    const updateOptionsAndShow = async () => {
+        await actualWindow.removeListener('shown', updateOptionsAndShow);
+        await placeholder.close();
+    };
+    await actualWindow.addListener('shown', updateOptionsAndShow);
 
     return placeholder;
 };
@@ -127,11 +128,12 @@ export const createTabPlaceholder = async (win: WindowState) => {
         });
 
     const actualWindow = await fin.Window.wrap({uuid, name});
-    // @ts-ignore
-    actualWindow.on('shown', async () => {
+    const updateOptionsAndShow = async () => {
+        await actualWindow.removeListener('shown', updateOptionsAndShow);
         await swapTab(actualWindow.identity as TabIdentifier, placeholder);
-        placeholder.close();
-    });
+        await placeholder.close();
+    };
+    await actualWindow.addListener('shown', updateOptionsAndShow);
 
     return placeholder;
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,8 @@ module.exports = [
     utils.createConfig(`${outputDir}/provider`, {tabStrip: './src/provider/tabbing/tabstrip/main.ts'}, false),
     utils.createConfig(`${outputDir}/demo`, {LayoutsUI: './src/demo/LayoutsUI.ts'}, true, new CopyWebpackPlugin( [{ from: './res/demo' }]) ),
     utils.createConfig(`${outputDir}/demo`, {Snappable: './src/demo/Snappable.ts'}, true),
-    utils.createConfig(`${outputDir}/demo`, { tabapp1: './src/demo/tabapp1.ts' }, true),
-    utils.createConfig(`${outputDir}/demo`, { tabapp2: './src/demo/tabapp2.ts' }, true)
+    utils.createConfig(`${outputDir}/demo`, {deregisteredApp: './src/demo/deregisteredApp.ts'}, true),
+    utils.createConfig(`${outputDir}/demo`, {normalApp: './src/demo/normalApp.ts'}, true),
+    utils.createConfig(`${outputDir}/demo`, {tabapp1: './src/demo/tabapp1.ts'}, true),
+    utils.createConfig(`${outputDir}/demo`, {tabapp2: './src/demo/tabapp2.ts'}, true)
 ];


### PR DESCRIPTION
Deregister now deregisters a window from Save & Restore as well. If an application is deregistered, its child windows will not Save & Restore, even if they aren't deregistered.

- Implement deregister for normal windows
- Handle edge cases when restoring tab groups with a combination of valid windows and child windows of deregistered windows
- Separate LayoutsUI code from demo application/demo window code
- Refactor window object manipulation to a few util functions.