### PR TITLE
Fixed issue in global hotkeys

### DIFF
--- a/src/fin.d.ts
+++ b/src/fin.d.ts
@@ -717,7 +717,7 @@ declare namespace fin {
          */
         updateProxySettings(type: string, address: string, port: number, callback?: () => void, errorCallback?: (reason: string) => void): void;
 
-        getFocusedWindow(): Promise<{uuid: string, name: string} | null>;
+        getFocusedWindow(callback?: (window: {uuid: string; name: string}|null) => void, errorCallback?: (reason: string) => void): void;
     }
 
     interface CacheOptions {

--- a/src/provider/snapanddock/SnapService.ts
+++ b/src/provider/snapanddock/SnapService.ts
@@ -103,7 +103,7 @@ export class SnapService {
             .register(
                 'CommandOrControl+Shift+U',
                 () => {
-                    fin.desktop.System.getFocusedWindow().then(focusedWindow => {
+                    fin.desktop.System.getFocusedWindow(focusedWindow => {
                         if (focusedWindow !== null && this.getSnapWindow(focusedWindow)) {
                             console.log('Global hotkey invoked on window', focusedWindow);
                             this.undock(focusedWindow);


### PR DESCRIPTION
Seems maybe there was a merge conflict that wasn't resolved properly, global hotkeys was using a weird mix of v1 and v2 API's.

Fixed implementation to use V1 API, updated .d.ts accordingly.