### PR TITLE
Added display scaling runtime flags to provider app

### DIFF
--- a/res/provider/app.json
+++ b/res/provider/app.json
@@ -15,7 +15,7 @@
         }
     },
     "runtime": {
-        "arguments": "--enable-aggressive-domstorage-flushing",
+        "arguments": "--enable-aggressive-domstorage-flushing --high-dpi-support=1 --force-device-scale-factor=1",
         "version": "9.61.34.25"
     }
 }


### PR DESCRIPTION
Prevents 'window drifting' issues when using display scaling with non-integer ratios.