### PR TITLE
[SERVICE-265] Add temporary mechanism for disabling docking

### DIFF
--- a/src/provider/main.ts
+++ b/src/provider/main.ts
@@ -29,9 +29,14 @@ export async function main() {
         tabService.disableTabbingOperations = message;
     });
 
+    fin.desktop.InterApplicationBus.subscribe('*', 'layoutsService:experimental:disableDocking', (message, uuid, name) => {
+        snapService.disableDockingOperations = message;
+    });
+
     fin.desktop.Application.getCurrent().addEventListener('run-requested', (event) => {
         if (event.userAppConfigArgs && event.userAppConfigArgs.disableTabbingOperations) {
             tabService.disableTabbingOperations = event.userAppConfigArgs.disableTabbingOperations ? true : false;
+            snapService.disableDockingOperations = event.userAppConfigArgs.disableDockingOperations ? true : false;
         }
     });
 
@@ -50,6 +55,7 @@ export async function main() {
     }
 
     tabService.disableTabbingOperations = getParameter('disableTabbingOperations') ? true : false;
+    snapService.disableDockingOperations = getParameter('disableDockingOperations') ? true : false;
 
     await win10Check;
     await apiHandler.register();

--- a/src/provider/model/DesktopSnapGroup.ts
+++ b/src/provider/model/DesktopSnapGroup.ts
@@ -40,7 +40,8 @@ export interface Snappable {
     // tslint:disable-next-line:no-any
     applyOverride(property: keyof WindowState, value: any): Promise<void>;
     resetOverride(property: keyof WindowState): Promise<void>;
-    setSnapGroup(group: DesktopSnapGroup, offset?: Point, newHalfSize?: Point, synthetic?: boolean): void;
+    dockToGroup(group: DesktopSnapGroup, offset?: Point, newHalfSize?: Point, synthetic?: boolean): void;
+    snapToGroup(group: DesktopSnapGroup, offset?: Point, newHalfSize?: Point): void;
 }
 
 export class DesktopSnapGroup {
@@ -177,7 +178,7 @@ export class DesktopSnapGroup {
             this._windows.push(window);
             this.checkRoot();
             if (window.getSnapGroup() !== this) {
-                window.setSnapGroup(this);
+                window.dockToGroup(this);
             }
 
             // Will need to re-calculate cached properties

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -415,7 +415,7 @@ export class DesktopTabGroup {
             await tab.applyProperties({center, halfSize, frame: false});
         }
 
-        tab.setSnapGroup(this._window.getSnapGroup());
+        tab.dockToGroup(this._window.getSnapGroup());
         await tab.setTabGroup(this);
 
         const addTabPromise: Promise<void> = (async () => {
@@ -437,7 +437,7 @@ export class DesktopTabGroup {
     private async removeTabInternal(tab: DesktopWindow, index: number): Promise<void> {
         this._tabs.splice(index, 1);
         delete this._tabProperties[tab.getId()];
-        tab.setSnapGroup(new DesktopSnapGroup());
+        tab.dockToGroup(new DesktopSnapGroup());
         tab.onTeardown.remove(this.onWindowTeardown, this);
         await tab.setTabGroup(null);
 

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -346,7 +346,7 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
      * @param offset An offset to apply to this windows position (use this to enusre window is in correct position)
      * @param newHalfSize Can also simultaneously change the size of the window
      */
-    public setSnapGroup(group: DesktopSnapGroup, offset?: Point, newHalfSize?: Point): Promise<void> {
+    public dockToGroup(group: DesktopSnapGroup, offset?: Point, newHalfSize?: Point): Promise<void> {
         if (group !== this.snapGroup) {
             this.addToSnapGroup(group);
 
@@ -357,20 +357,7 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
             }
 
             if (offset || newHalfSize) {
-                const delta: Partial<WindowState> = {};
-
-                if (offset) {
-                    delta.center = {x: this.windowState.center.x + offset.x, y: this.windowState.center.y + offset.y};
-                }
-                if (newHalfSize) {
-                    delta.center = delta.center || {...this.windowState.center};
-                    delta.halfSize = newHalfSize;
-
-                    delta.center.x += newHalfSize.x - this.windowState.halfSize.x;
-                    delta.center.y += newHalfSize.y - this.windowState.halfSize.y;
-                }
-
-                return this.updateState(delta, ActionOrigin.SERVICE).then(async () => {
+                this.snapToGroup(group, offset, newHalfSize).then(async () => {
                     if (group.windows.length >= 2) {
                         await this.snap();
                     }
@@ -381,6 +368,23 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
         }
 
         return Promise.resolve();
+    }
+
+    public snapToGroup(group: DesktopSnapGroup, offset?: Point, newHalfSize?: Point): Promise<void> {
+        const delta: Partial<WindowState> = {};
+
+        if (offset) {
+            delta.center = {x: this.windowState.center.x + offset.x, y: this.windowState.center.y + offset.y};
+        }
+        if (newHalfSize) {
+            delta.center = delta.center || {...this.windowState.center};
+            delta.halfSize = newHalfSize;
+
+            delta.center.x += newHalfSize.x - this.windowState.halfSize.x;
+            delta.center.y += newHalfSize.y - this.windowState.halfSize.y;
+        }
+
+        return this.updateState(delta, ActionOrigin.SERVICE);
     }
 
     public setTabGroup(group: DesktopTabGroup|null): Promise<void> {


### PR DESCRIPTION
Add support to disable docking via application manifest. Uses similar mechanisms to disableTabbing:

Requires manifestUrl to be set with the service & RVM.

```
    "services": [{"name": "layouts", "manifestUrl": "http://.../app.json?$$disableDockingOperations=true"}]
```

In environments without an RVM, you can use the IAB topic to enable/disable tabs.

```
fin.desktop.InterApplicationBus.publish("layoutsService:experimental:disableDocking", true);
```


