### PR TITLE
Fixed build failure during tsdoc generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,8 +25,8 @@ pipeline {
                     STAGING_JSON = env.DSERVICE_S3_ROOT + "layouts/app.staging.json"
                 }
                 sh "npm i --ignore-scripts"
-                sh "npm run docs"
                 sh "SERVICE_VERSION=${PREREL_VERSION} npm run build"
+                sh "npm run docs"
                 sh "echo ${GIT_SHORT_SHA} > ./build/SHA.txt"
                 sh "aws s3 cp ./build/provider ${S3_LOC}/ --recursive"
                 sh "aws s3 cp ./build/docs ${S3_LOC}/docs/ --recursive"
@@ -46,7 +46,6 @@ pipeline {
             when { branch "master" }
             steps {
                 sh "npm i --ignore-scripts"
-                sh "npm run docs"
                 script {
                     GIT_SHORT_SHA = sh ( script: "git rev-parse --short HEAD", returnStdout: true ).trim()
                     VERSION = sh ( script: "node -pe \"require('./package.json').version\"", returnStdout: true ).trim()
@@ -54,6 +53,7 @@ pipeline {
                     PROD_JSON = env.DSERVICE_S3_ROOT + "layouts/app.json"
                 }
                 sh "SERVICE_VERSION=${VERSION} npm run build"
+                sh "npm run docs"
                 sh "echo ${GIT_SHORT_SHA} > ./build/SHA.txt"
                 sh "aws s3 cp ./build/provider ${S3_LOC}/ --recursive"
                 sh "aws s3 cp ./build/docs ${S3_LOC}/docs/ --recursive"


### PR DESCRIPTION
Moved document generation to after the build within Jenkinsfile. Otherwise docs step fails due to code referencing a file that is generated during the build process.