### PR TITLE
[SERVICE-269] Tabbed window detaches from tabstrip when global undock hotkey is pressed

### DIFF
--- a/src/provider/snapanddock/SnapService.ts
+++ b/src/provider/snapanddock/SnapService.ts
@@ -61,7 +61,7 @@ export class SnapService {
                 'CommandOrControl+Shift+U',
                 () => {
                     fin.desktop.System.getFocusedWindow(focusedWindow => {
-                        if (focusedWindow !== null) {
+                        if (focusedWindow !== null && model.getWindow(focusedWindow)) {
                             console.log('Global hotkey invoked on window', focusedWindow);
                             this.undock(focusedWindow);
                         }

--- a/src/provider/snapanddock/SnapService.ts
+++ b/src/provider/snapanddock/SnapService.ts
@@ -61,9 +61,13 @@ export class SnapService {
                 'CommandOrControl+Shift+U',
                 () => {
                     fin.desktop.System.getFocusedWindow(focusedWindow => {
-                        if (focusedWindow !== null && this.model.getWindow(focusedWindow)) {
+                        if (focusedWindow !== null) {
                             console.log('Global hotkey invoked on window', focusedWindow);
-                            this.undock(focusedWindow);
+                            const focusedDesktopWindow =  this.model.getWindow(focusedWindow);
+                            // Ignore this event for tabbed windows until tab/snap is properly integrated
+                            if (focusedDesktopWindow && focusedDesktopWindow.getTabGroup() === null) {
+                                this.undock(focusedWindow);
+                            }
                         }
                     });
                 })


### PR DESCRIPTION
Ignore undock global hotkey event for windows in tabsets until tab/snap is fully integrated.