### PR TITLE
Fix app snapping timing bug

### DIFF
--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -188,6 +188,9 @@ export const restoreLayout = async(payload: Layout, identity: Identity): Promise
 
                 if (ofAppNotRunning) {
                     await ofAppNotRunning.run().catch(console.log);
+                    const ofWindowNotRunning = await ofAppNotRunning.getWindow();
+                    await ofWindowNotRunning.setBounds(app.mainWindow);
+                    await ofWindowNotRunning.showAt(app.mainWindow.left, app.mainWindow.top);
                 }
                 // SHOULD WE RETURN DEFAULT RESPONSE HERE?!?
                 return defaultResponse;


### PR DESCRIPTION
I originally moved some app.mainWindow positioning logic over to the placeholder window. However, this introduced a timing issue when trying to restore a layout with only main window apps. I have added back the positioning logic.