### PR TITLE
[SERVICE-271] Make S&R placeholder tab titles more user-friendly

### DIFF
--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -453,7 +453,16 @@ export class DesktopTabGroup {
 
     private getTabProperties(tab: DesktopWindow): TabProperties {
         const savedProperties: string|null = localStorage.getItem(tab.getId());
-        return savedProperties ? JSON.parse(savedProperties) : {icon: tab.getState().icon, title: tab.getState().title.match(/^Placeholder\-/) ? "Placeholder" : tab.getState().title};
+        if( savedProperties ) {
+            return JSON.parse(savedProperties);
+        }
+        
+        
+        const {icon, title} = tab.getState();
+        const properties:TabProperties =  savedProperties ? JSON.parse(savedProperties) : {icon: tab.getState().icon, title: tab.getState().title};
+        // Special handling for S&R placeholder windows
+        const modifiedTitle = tab.getIdentity().uuid === fin.Window.me.uuid && properties.title.match(/^Placeholder\-/) ? "Loading..." : title;
+        return {icon, title: modifiedTitle};
     }
 
     private onWindowTeardown(window: DesktopWindow): void {

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -453,7 +453,7 @@ export class DesktopTabGroup {
 
     private getTabProperties(tab: DesktopWindow): TabProperties {
         const savedProperties: string|null = localStorage.getItem(tab.getId());
-        return savedProperties ? JSON.parse(savedProperties) : {icon: tab.getState().icon, title: tab.getState().title};
+        return savedProperties ? JSON.parse(savedProperties) : {icon: tab.getState().icon, title: tab.getState().title.match(/^Placeholder\-/) ? "Placeholder" : tab.getState().title};
     }
 
     private onWindowTeardown(window: DesktopWindow): void {

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -457,11 +457,9 @@ export class DesktopTabGroup {
             return JSON.parse(savedProperties);
         }
         
-        
         const {icon, title} = tab.getState();
-        const properties:TabProperties =  savedProperties ? JSON.parse(savedProperties) : {icon: tab.getState().icon, title: tab.getState().title};
         // Special handling for S&R placeholder windows
-        const modifiedTitle = tab.getIdentity().uuid === fin.Window.me.uuid && properties.title.match(/^Placeholder\-/) ? "Loading..." : title;
+        const modifiedTitle = tab.getIdentity().uuid === fin.Window.me.uuid && title.startsWith('Placeholder-') ? "Loading..." : title;
         return {icon, title: modifiedTitle};
     }
 

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -453,13 +453,13 @@ export class DesktopTabGroup {
 
     private getTabProperties(tab: DesktopWindow): TabProperties {
         const savedProperties: string|null = localStorage.getItem(tab.getId());
-        if( savedProperties ) {
+        if (savedProperties) {
             return JSON.parse(savedProperties);
         }
-        
+
         const {icon, title} = tab.getState();
         // Special handling for S&R placeholder windows
-        const modifiedTitle = tab.getIdentity().uuid === fin.Window.me.uuid && title.startsWith('Placeholder-') ? "Loading..." : title;
+        const modifiedTitle = tab.getIdentity().uuid === fin.Window.me.uuid && title.startsWith('Placeholder-') ? 'Loading...' : title;
         return {icon, title: modifiedTitle};
     }
 


### PR DESCRIPTION
UX improvement to change the tab placeholders from `Placeholder-[random alphanumeric characters]` to something more user friendly. 

Went with `Loading...` for a first attempt and looks pretty good in my opinion. Open to other suggestions. Image of what it looks like is below.

![image](https://user-images.githubusercontent.com/38854624/47657742-8600c500-db89-11e8-9b15-2cfc015c3eac.png)