### PR TITLE
[SERVICE-266] Added support for virtualised environments

### DIFF
--- a/res/demo/LayoutsUI.html
+++ b/res/demo/LayoutsUI.html
@@ -32,6 +32,7 @@
     <h3>Tabbed Windows</h3>
     <div>
         <button onclick="LayoutsUI.createTabbedWindow('default')">Default UI</button>
+        <button onclick="LayoutsUI.createTabbedWindow('DisableFrame')">'disableFrame' Window</button>
         <button onclick="LayoutsUI.createTabbedWindow('App2')">New App 2</button>
         <button onclick="LayoutsUI.createTabbedWindow('App3')">New App 3</button>
         <button onclick="LayoutsUI.createTabbedWindow('noauto')">New App no init</button>

--- a/res/demo/tabbing/App/DisableFrame.html
+++ b/res/demo/tabbing/App/DisableFrame.html
@@ -1,0 +1,45 @@
+<html>
+
+<head>
+    <title></title>
+    <style>
+        body {
+            width: 100%;
+            height: 100%;
+            padding: 0;
+            margin: 0;
+        }
+    </style>
+
+</head>
+
+<body>
+
+    <script>
+        const randomColor = () => {
+            return '#' + ((1 << 24) * Math.random() | 0).toString(16);
+        };
+
+        document.addEventListener('DOMContentLoaded', () => {
+            document.body.style.backgroundColor = randomColor();
+        });
+
+        fin.desktop.main(() => {
+            const win = fin.Window.getCurrentSync();
+
+            win.addListener('disabled-frame-bounds-changed', handleDisabledFrameBoundsChanged.bind(win));
+            win.addListener('disabled-frame-bounds-changing', handleDisabledFrameBoundsChanging.bind(win));
+            win.disableFrame();
+        });
+
+        function handleDisabledFrameBoundsChanged(event) {
+            this.setBounds(event);
+        }
+
+        function handleDisabledFrameBoundsChanging(event) {
+            this.setBounds(event);
+        }
+    </script>
+</body>
+
+</html>

--- a/src/provider/Signal.ts
+++ b/src/provider/Signal.ts
@@ -29,6 +29,10 @@ class SignalBase<R, R2> {
         }
     }
 
+    protected hasInternal(callback: Function, context?: Context): boolean {
+        return this.slots.findIndex((c) => c.callback === callback && c.context === context) >= 0;
+    }
+
     // tslint:disable-next-line:no-any
     protected emitInternal(...args: any[]): R2|null {
         const callbacks = this.slots.slice();  // Clone array, in case a callback modifies this signal
@@ -59,6 +63,10 @@ export class Signal0<R = void, R2 = R> extends SignalBase<R, R2> {
         super.removeInternal(listener, context);
     }
 
+    public has(listener: () => R, context?: Context): boolean {
+        return super.hasInternal(listener, context);
+    }
+
     public emit(): R2|null {
         return super.emitInternal();
     }
@@ -75,6 +83,10 @@ export class Signal1<A1, R = void, R2 = R> extends SignalBase<R, R2> {
 
     public remove(listener: (arg1: A1) => R, context?: Context): void {
         super.removeInternal(listener, context);
+    }
+
+    public has(listener: (arg1: A1) => R, context?: Context): boolean {
+        return super.hasInternal(listener, context);
     }
 
     public emit(arg1: A1): R2|null {
@@ -95,6 +107,10 @@ export class Signal2<A1, A2, R = void, R2 = R> extends SignalBase<R, R2> {
         super.removeInternal(listener, context);
     }
 
+    public has(listener: (arg1: A1, arg2: A2) => R, context?: Context): boolean {
+        return super.hasInternal(listener, context);
+    }
+
     public emit(arg1: A1, arg2: A2): R2|null {
         return super.emitInternal(arg1, arg2);
     }
@@ -113,6 +129,10 @@ export class Signal3<A1, A2, A3, A4, R = void, R2 = R> extends SignalBase<R, R2>
         super.removeInternal(listener, context);
     }
 
+    public has(listener: (arg1: A1, arg2: A2, arg3: A3) => R, context?: Context): boolean {
+        return super.hasInternal(listener, context);
+    }
+
     public emit(arg1: A1, arg2: A2, arg3: A3): R2|null {
         return super.emitInternal(arg1, arg2, arg3);
     }
@@ -129,6 +149,10 @@ export class Signal4<A1, A2, A3, A4, R = void, R2 = R> extends SignalBase<R, R2>
 
     public remove(listener: (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => R, context?: Context): void {
         super.removeInternal(listener, context);
+    }
+
+    public has(listener: (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => R, context?: Context): boolean {
+        return super.hasInternal(listener, context);
     }
 
     public emit(arg1: A1, arg2: A2, arg3: A3, arg4: A4): R2|null {

--- a/src/provider/main.ts
+++ b/src/provider/main.ts
@@ -27,6 +27,8 @@ interface SupportedArguments {
     disableTabbingOperations: boolean;
     disableDockingOperations: boolean;
     emulateDragEvents: boolean;
+    disableBoundsDelay: number;
+    disableBoundsRateLimit: number;
 }
 type Stringified<T> = {
     [P in keyof T]?: string;
@@ -55,6 +57,8 @@ export async function main() {
 
     function processUserArgs(args: Stringified<SupportedArguments>): void {
         if (args) {
+            console.log('Using URL config:', args);
+
             if (args.disableTabbingOperations) {
                 tabService.disableTabbingOperations = args.disableTabbingOperations === 'true';
             }
@@ -63,6 +67,12 @@ export async function main() {
             }
             if (args.emulateDragEvents) {
                 DesktopWindow.emulateDragEvents = args.emulateDragEvents === 'true';
+            }
+            if (args.disableBoundsDelay) {
+                DesktopWindow.disableBoundsDelay = Number.parseInt(args.disableBoundsDelay, 10);
+            }
+            if (args.disableBoundsRateLimit) {
+                DesktopWindow.disableBoundsRateLimit = Number.parseInt(args.disableBoundsRateLimit, 10);
             }
         }
     }

--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -80,8 +80,15 @@ export class DesktopModel {
         return `${identity.uuid}/${identity.name}`;
     }
 
-    public getWindow(identity: WindowIdentity): DesktopWindow|null {
-        const id = this.getId(identity);
+    /**
+     * Fetches the model object for the given window, or null if no window currently exists within the service.
+     *
+     * Window to find can be identified by
+     *
+     * @param identity Window identifier - either a UUID/name object, or a stringified identity as created by @see getId
+     */
+    public getWindow(identity: WindowIdentity|string): DesktopWindow|null {
+        const id = typeof identity === 'string' ? identity : this.getId(identity);
         return this.windows.find(window => window.getId() === id) || null;
     }
 

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -103,17 +103,40 @@ type OpenFinWindowEventHandler = <K extends keyof fin.OpenFinWindowEventMap>(eve
 export class DesktopWindow extends DesktopEntity implements Snappable {
     public static readonly onCreated: Signal1<DesktopWindow> = new Signal1();
     public static readonly onDestroyed: Signal1<DesktopWindow> = new Signal1();
-    public static emulateDragEvents: boolean;
 
     /**
-     * When in 'emulateDragEvents' mode, the service needs to call disableFrame on every window that is registered 
+     * Flag to enable special behaviour in environments where the Windows "Show window contents while dragging"
+     * performance option is disabled.
+     *
+     * Will enable 'disableFrame()' on each window registered with the service, and handle all window movements
+     * programatically.
+     */
+    public static emulateDragEvents = false;
+
+    /**
+     * When in 'emulateDragEvents' mode, the service needs to call disableFrame on every window that is registered
      * with the service. However, this may cause issues with applications that are already using 'disableFrame'.
-     * 
+     *
      * Service assumes that any window that uses disableFrame will call it immediately after creating the window. If
      * disableFrame() has not been called after waiting this many milliseconds, the service assumes it can take control
      * of disabling the frame and moving/resizing the window.
      */
-    private static readonly DISABLE_BOUNDS_DELAY = 1000;
+    public static disableBoundsDelay = 500;
+
+    /**
+     * When in 'emulateDragEvents' mode the service needs to programatically move each window. This can result in a
+     * lot of messages being passed through the core, which may degrade performance.
+     *
+     * This parameter limits the rate at which a window can be moved - the service will perform no more than this many
+     * window updates per second.
+     */
+    public static disableBoundsRateLimit = 30;
+
+    /**
+     * Service is blocked from moving a 'disableFrame' window until after this time (see DISABLE_BOUNDS_RATE_LIMIT)
+     */
+    private static nextMoveTime = 0;
+
 
     public static async getWindowState(window: Window): Promise<WindowState> {
         return Promise.all([window.getOptions(), window.isShowing(), window.getBounds()])
@@ -734,7 +757,7 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
         if (DesktopWindow.emulateDragEvents) {
             function disableFrame(this: DesktopWindow) {
                 // Check window hasn't been closed/de-registered whilst we were waiting
-                const isRegistered: boolean = this.model.getWindow(this.id) !== null;
+                const isRegistered: boolean = this.model.getWindow(this.id) !== null || !DesktopWindow.disableBoundsDelay;
 
                 if (isRegistered && this.windowState.frameEnabled) {
                     console.log('Disabling frame on ' + this.id);
@@ -755,12 +778,12 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
                 }
             }
 
-            if (this.identity.uuid === TabServiceID.UUID) {
+            if (this.identity.uuid === TabServiceID.UUID || !DesktopWindow.disableBoundsDelay) {
                 // Can disable frame on tabstrips immediately, without waiting to see what application does.
                 disableFrame.call(this);
             } else {
                 // Wait and see what the application does, and then disable frame only if application hasn't already.
-                setTimeout(disableFrame.bind(this), DesktopWindow.DISABLE_BOUNDS_DELAY);
+                setTimeout(disableFrame.bind(this), DesktopWindow.disableBoundsDelay);
             }
         }
     }
@@ -830,7 +853,11 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
 
         if (this.applicationState.frameEnabled) {
             // Service must move the window, as application (presumably) won't have registered any 'disabled-*' listeners registered
-            this.updateState({center, halfSize}, ActionOrigin.SERVICE);
+            const now: number = Date.now();
+            if (now >= DesktopWindow.nextMoveTime) {
+                DesktopWindow.nextMoveTime = now + (1000 / DesktopWindow.disableBoundsRateLimit);
+                this.updateState({center, halfSize}, ActionOrigin.SERVICE);
+            }
         }
 
         // Assume that all disabled-frame-bounds-* events are user-initiated

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -31,6 +31,7 @@ export interface WindowState extends Rectangle {
     maxHeight: number;
 
     opacity: number;
+    frameEnabled: boolean;  // If window will respond to move/resize events. Corresponds to enable/disableFrame, not WindowOptions.frame.
 }
 
 export interface WindowIdentity extends Identity {
@@ -102,6 +103,17 @@ type OpenFinWindowEventHandler = <K extends keyof fin.OpenFinWindowEventMap>(eve
 export class DesktopWindow extends DesktopEntity implements Snappable {
     public static readonly onCreated: Signal1<DesktopWindow> = new Signal1();
     public static readonly onDestroyed: Signal1<DesktopWindow> = new Signal1();
+    public static emulateDragEvents: boolean;
+
+    /**
+     * When in 'emulateDragEvents' mode, the service needs to call disableFrame on every window that is registered 
+     * with the service. However, this may cause issues with applications that are already using 'disableFrame'.
+     * 
+     * Service assumes that any window that uses disableFrame will call it immediately after creating the window. If
+     * disableFrame() has not been called after waiting this many milliseconds, the service assumes it can take control
+     * of disabling the frame and moving/resizing the window.
+     */
+    private static readonly DISABLE_BOUNDS_DELAY = 1000;
 
     public static async getWindowState(window: Window): Promise<WindowState> {
         return Promise.all([window.getOptions(), window.isShowing(), window.getBounds()])
@@ -131,7 +143,8 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
                     maxWidth: options.maxWidth!,
                     minHeight: options.minHeight!,
                     maxHeight: options.maxHeight!,
-                    opacity: options.opacity!
+                    opacity: options.opacity!,
+                    frameEnabled: true  // No way to query frame enabled/disabled state from API. Assume frame is enabled
                 };
             });
     }
@@ -232,16 +245,18 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
                 this.window = window;
                 this.windowState = await DesktopWindow.getWindowState(window);
                 this.applicationState = {...this.windowState};
-                this.addListeners();
+
                 this.ready = true;
+                this.addListeners();
             }));
         } else if (!initialState) {
             this.window = window as Window;
             this.addPendingActions('Fetch initial window state ' + this.id, DesktopWindow.getWindowState(this.window).then((state: WindowState) => {
                 this.windowState = state;
                 this.applicationState = {...this.windowState};
-                this.addListeners();
+
                 this.ready = true;
+                this.addListeners();
             }));
         } else {
             this.window = window as Window;
@@ -298,7 +313,8 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
             maxWidth: -1,
             minHeight: 0,
             maxHeight: 0,
-            opacity: 1
+            opacity: 1,
+            frameEnabled: true
         };
     }
 
@@ -560,7 +576,7 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
         // Apply changes to the window (unless we're reacting to an external change that has already happened)
         if (origin !== ActionOrigin.APPLICATION) {
             const window = this.window;
-            const {center, halfSize, state, hidden, ...options} = delta;
+            const {center, halfSize, state, hidden, frameEnabled, ...options} = delta;
             const optionsToChange: (keyof WindowState)[] = Object.keys(options) as (keyof WindowState)[];
 
             // Apply visibility
@@ -584,6 +600,11 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
                         console.warn('Invalid window state: ' + state);
                         break;
                 }
+            }
+
+            // Apply window frame
+            if (frameEnabled !== undefined) {
+                actions.push(frameEnabled ? window.enableFrame() : window.disableFrame());
             }
 
             // Apply bounds
@@ -670,13 +691,15 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
         this.registerListener('bounds-changed', this.handleBoundsChanged.bind(this));
         this.registerListener('bounds-changing', this.handleBoundsChanging.bind(this));
         this.registerListener('closed', this.handleClosed.bind(this));
+        this.registerListener('disabled-frame-bounds-changed', this.handleDisabledFrameBoundsChanged.bind(this));
+        this.registerListener('disabled-frame-bounds-changing', this.handleDisabledFrameBoundsChanging.bind(this));
         this.registerListener('focused', this.handleFocused.bind(this));
         this.registerListener('frame-disabled', () => {
-            this.updateState({frame: true}, ActionOrigin.APPLICATION);
+            this.updateState({frameEnabled: false}, ActionOrigin.APPLICATION);
             this.onModified.emit(this);
         });
         this.registerListener('frame-enabled', () => {
-            this.updateState({frame: true}, ActionOrigin.APPLICATION);
+            this.updateState({frameEnabled: true}, ActionOrigin.APPLICATION);
             this.onModified.emit(this);
         });
         this.registerListener('group-changed', this.handleGroupChanged.bind(this));
@@ -707,6 +730,39 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
             });
         });
         this.registerListener('shown', () => this.updateState({hidden: false}, ActionOrigin.APPLICATION));
+
+        if (DesktopWindow.emulateDragEvents) {
+            function disableFrame(this: DesktopWindow) {
+                // Check window hasn't been closed/de-registered whilst we were waiting
+                const isRegistered: boolean = this.model.getWindow(this.id) !== null;
+
+                if (isRegistered && this.windowState.frameEnabled) {
+                    console.log('Disabling frame on ' + this.id);
+
+                    // Application isn't using 'disableFrame', safe for the service to enable it on behalf of the application
+                    this.applyProperties({frameEnabled: false});
+
+                    // Re-enable the frame if window window gets de-registered in the future
+                    this.onTeardown.add(window => {
+                        if (window.ready) {
+                            window.window.enableFrame().catch(console.warn);
+                        }
+                    });
+                } else if (isRegistered) {
+                    console.log('Window has already disabled its frame ' + this.id);
+                } else {
+                    console.log('Window deregistered before frame check could occur ' + this.id);
+                }
+            }
+
+            if (this.identity.uuid === TabServiceID.UUID) {
+                // Can disable frame on tabstrips immediately, without waiting to see what application does.
+                disableFrame.call(this);
+            } else {
+                // Wait and see what the application does, and then disable frame only if application hasn't already.
+                setTimeout(disableFrame.bind(this), DesktopWindow.DISABLE_BOUNDS_DELAY);
+            }
+        }
     }
 
     private registerListener<K extends keyof fin.OpenFinWindowEventMap>(eventType: K, handler: (event: fin.OpenFinWindowEventMap[K]) => void) {
@@ -732,10 +788,7 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
         this.updateState({center, halfSize}, ActionOrigin.APPLICATION);
 
         if (this.userInitiatedBoundsChange) {
-            // Convert 'changeType' into our enum type
-            const type: Mask<eTransformType> = event.changeType + 1;
-
-            this.onCommit.emit(this, type);
+            this.onCommit.emit(this, this.getTransformType(event));
 
             // Setting this here instead of in 'end-user-bounds-changing' event to ensure we are still synced when this method is called.
             this.userInitiatedBoundsChange = false;
@@ -749,14 +802,44 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
         const halfSize: Point = {x: bounds.width / 2, y: bounds.height / 2};
         const center: Point = {x: bounds.left + halfSize.x, y: bounds.top + halfSize.y};
 
-        // Convert 'changeType' into our enum type
-        const type: Mask<eTransformType> = event.changeType + 1;
-
         this.updateState({center, halfSize}, ActionOrigin.APPLICATION);
 
         if (this.userInitiatedBoundsChange) {
-            this.onTransform.emit(this, type);
+            this.onTransform.emit(this, this.getTransformType(event));
         }
+    }
+
+    private handleDisabledFrameBoundsChanged(event: fin.WindowBoundsEvent): void {
+        const bounds: fin.WindowBounds = this.checkBounds(event);
+        const halfSize: Point = {x: bounds.width / 2, y: bounds.height / 2};
+        const center: Point = {x: bounds.left + halfSize.x, y: bounds.top + halfSize.y};
+
+        if (this.applicationState.frameEnabled) {
+            // Service must move the window, as application (presumably) won't have registered any 'disabled-*' listeners registered
+            this.updateState({center, halfSize}, ActionOrigin.SERVICE);
+        }
+
+        // Assume that all disabled-frame-bounds-* events are user-initiated
+        this.onCommit.emit(this, this.getTransformType(event));
+    }
+
+    private handleDisabledFrameBoundsChanging(event: fin.WindowBoundsEvent): void {
+        const bounds: fin.WindowBounds = this.checkBounds(event);
+        const halfSize: Point = {x: bounds.width / 2, y: bounds.height / 2};
+        const center: Point = {x: bounds.left + halfSize.x, y: bounds.top + halfSize.y};
+
+        if (this.applicationState.frameEnabled) {
+            // Service must move the window, as application (presumably) won't have registered any 'disabled-*' listeners registered
+            this.updateState({center, halfSize}, ActionOrigin.SERVICE);
+        }
+
+        // Assume that all disabled-frame-bounds-* events are user-initiated
+        this.onTransform.emit(this, this.getTransformType(event));
+    }
+
+    private getTransformType(event: fin.WindowBoundsEvent): Mask<eTransformType> {
+        // Convert 'changeType' into our enum type
+        return event.changeType + 1;
     }
 
     private handleBeginUserBoundsChanging(event: fin.WindowBoundsEvent) {


### PR DESCRIPTION
Added additional option to support environments where the Windows "Show window contents while dragging" performance option is disabled.

### Fix description
Fix works by calling `disableFrame()` for all windows managed by the service, and then managing the movement/resizing of windows programatically. This works since these events are still dispatched as normal when running in this mode, whereas normal `bounds-changing` events are not.

The `disableFrame()` call is not made immediately, as the service must support windows that are using this method within the application itself. The service will wait a short time before checking if the window has enabled `disableFrame()` behaviour. Have added an extra button to the demo app that creates an app window that uses `disableFrame()`. De-registering a window from the service will re-enable the frame on any window where the service disabled the frame.

### Configuration
The above fix adds overhead to window movements, and so is disabled by default. The above behaviour is exposed via a temporary configuration option, which will be replaced once we have a formal mechanism for service configuration options.

New flags are:
* **emulateDragEvents**: Enables the `disableFrame()` behaviour described above. Subsequent options will have no effect without this also being enabled.
* **disableBoundsDelay**: How long to wait (in ms) before calling `distableFrame()` on a window. If you know there will be no applications using `disableFrame()` anywhere on the desktop, this can be set to 0.
* **disableBoundsRateLimit**: Using this workaround adds a performance penalty. This flag can be used to limit to rate at which windows are moved, in an attempt to mitigate performance impact. This parameter is the maximum number of times a window can be moved per second. Default value is 30hz, set to 0 to disable rate limiting and to apply every `disabled-frame-bounds-changing` update to the window directly.

### Testing
No new tests have been added, as there is no change in functionality. The existing tests all pass even when running in "Show window contents while dragging" disabled mode. The delay before registering windows can cause issues though, and needs to be disabled in order for tests to pass reliably. Add the options `$$emulateDragEvents=true&$$disableBoundsDelay=0` to `manifestUrl` in `res/test/app.json` when running the tests in "Show window contents while dragging" disabled mode.