### PR TITLE
[SERVICE-270] Exclude OpenFin error dialogs from the service

### DIFF
--- a/res/test/crash.html
+++ b/res/test/crash.html
@@ -1,0 +1,13 @@
+<!-- This file will crash the whole render process if loaded!! Use with caution. -->
+<html>
+<body>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            a = [];
+            while(true) {
+                a.push(100000000000);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -5,6 +5,7 @@ import {DesktopSnapGroup} from '../model/DesktopSnapGroup';
 import {SignalSlot} from '../Signal';
 import {Point} from '../snapanddock/utils/PointUtils';
 import {RectUtils} from '../snapanddock/utils/RectUtils';
+import {deregisterWindow as deregisterFromWorkspaces} from '../workspaces/create';
 
 import {DesktopTabGroup} from './DesktopTabGroup';
 import {DesktopWindow, WindowIdentity, WindowState} from './DesktopWindow';
@@ -39,10 +40,11 @@ export class DesktopModel {
         const serviceUUID: string = fin.Application.me.uuid;
 
         // Listen for any new windows created and register them with the service
-        fin.System.addListener('window-created', (evt: WindowEvent<'system', 'window-created'>) => {        
+        fin.System.addListener('window-created', (evt: WindowEvent<'system', 'window-created'>) => {
             // Filter out error windows (which should never register)
             if (this.isErrorWindow(evt.uuid)) {
                 console.log('Ignoring error window: ' + evt.uuid);
+                deregisterFromWorkspaces({name: evt.name, uuid: evt.uuid});
                 return;
             }
 

--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -54,7 +54,7 @@ export class DesktopModel {
         fin.System.getAllWindows().then(apps => {
             apps.forEach((app) => {
                 // Ignore openfin error windows, the main service window, and all of it's children
-                if (this.isErrorWindow(app.uuid) && app.uuid !== serviceUUID) {
+                if (!this.isErrorWindow(app.uuid) && app.uuid !== serviceUUID) {
                     // Register the main window
                     this.registerWindow({uuid: app.uuid, name: app.mainWindow.name});
 

--- a/test/provider/ignoreErrorWindows.test.ts
+++ b/test/provider/ignoreErrorWindows.test.ts
@@ -25,7 +25,7 @@ test('Error windows are not registered with layouts', async t => {
     let count = 0;
     // Check every second for the error window and wrap it when it appears
     do {
-        // If it takes more than 10 seconds to crash, we will throw an error and fail the test.
+        // If it takes more than 10 seconds to crash, we will fail the test and break out of the loop.
         if (count++ > 10) {
             t.fail('Error window not found after 10 seconds. App may not have crashed or error window signature may have changed');
             break;

--- a/test/provider/ignoreErrorWindows.test.ts
+++ b/test/provider/ignoreErrorWindows.test.ts
@@ -1,0 +1,50 @@
+import {test} from 'ava';
+import {Application, Fin} from 'hadouken-js-adapter';
+import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
+
+import {isWindowRegistered} from '../demo/utils/snapServiceUtils';
+
+import {getConnection} from './utils/connect';
+import {delay} from './utils/delay';
+
+let fin: Fin;
+let crashApp: Application|undefined = undefined;
+
+test.before(async t => {
+    fin = await getConnection();
+});
+
+test('Error windows are not registered with layouts', async t => {
+    crashApp = await fin.Application.create(
+        {uuid: 'crash-app-1', name: 'crash-app-1', url: 'http://localhost:1337/test/crash.html', mainWindowOptions: {autoShow: true}});
+
+    // We fire-and-forget since it will crash and may block the test if awaited
+    crashApp.run();
+
+    let errorWindow: _Window|undefined = undefined;
+    let count = 0;
+    // Check every second for the error window and wrap it when it appears
+    do {
+        // If it takes more than 10 seconds to crash, we will throw an error and fail the test.
+        if (count++ > 10) {
+            t.fail('Error window not found after 10 seconds. App may not have crashed or error window signature may have changed');
+            break;
+        }
+        const allApps = await fin.System.getAllApplications();
+        const errorAppInfo = allApps.find(appInfo => appInfo.uuid.startsWith('error-app-'));
+        if (errorAppInfo) {
+            errorWindow = fin.Window.wrapSync({uuid: errorAppInfo.uuid, name: errorAppInfo.uuid});
+        }
+        await delay(1000);
+    } while (errorWindow === undefined);
+
+    if (errorWindow) {
+        t.false(await isWindowRegistered(errorWindow.identity), `Error window with identity "${errorWindow.identity.uuid}" was registered with the service.`);
+    }
+});
+
+test.afterEach.always(async t => {
+    if (crashApp) {
+        crashApp.close(true);
+    }
+});

--- a/test/provider/ignoreErrorWindows.test.ts
+++ b/test/provider/ignoreErrorWindows.test.ts
@@ -71,9 +71,7 @@ test('Error windows are not included in generateLayout', async t => {
     } while (errorWindow === undefined);
 
     if (errorWindow) {
-        await delay(1000);
         const layout = await sendServiceMessage<undefined, Layout>('generateLayout', undefined);
-        console.log(layout);
 
         t.false(isErrorInLayout(errorWindow.identity.uuid, layout), 'Error window found in generated layout');
 

--- a/test/provider/ignoreErrorWindows.test.ts
+++ b/test/provider/ignoreErrorWindows.test.ts
@@ -2,6 +2,8 @@ import {test} from 'ava';
 import {Application, Fin} from 'hadouken-js-adapter';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
+import {Layout} from '../../src/client/types';
+import {sendServiceMessage} from '../demo/utils/serviceUtils';
 import {isWindowRegistered} from '../demo/utils/snapServiceUtils';
 
 import {getConnection} from './utils/connect';
@@ -14,7 +16,7 @@ test.before(async t => {
     fin = await getConnection();
 });
 
-test('Error windows are not registered with layouts', async t => {
+test('Error windows are not registered with S&D or Tabbing', async t => {
     crashApp = await fin.Application.create(
         {uuid: 'crash-app-1', name: 'crash-app-1', url: 'http://localhost:1337/test/crash.html', mainWindowOptions: {autoShow: true}});
 
@@ -44,8 +46,47 @@ test('Error windows are not registered with layouts', async t => {
     }
 });
 
+test('Error windows are not included in generateLayout', async t => {
+    crashApp = await fin.Application.create(
+        {uuid: 'crash-app-1', name: 'crash-app-1', url: 'http://localhost:1337/test/crash.html', mainWindowOptions: {autoShow: true}});
+
+    // We fire-and-forget since it will crash and may block the test if awaited
+    crashApp.run();
+
+    let errorWindow: _Window|undefined = undefined;
+    let count = 0;
+    // Check every second for the error window and wrap it when it appears
+    do {
+        // If it takes more than 10 seconds to crash, we will fail the test and break out of the loop.
+        if (count++ > 10) {
+            t.fail('Error window not found after 10 seconds. App may not have crashed or error window signature may have changed');
+            break;
+        }
+        const allApps = await fin.System.getAllApplications();
+        const errorAppInfo = allApps.find(appInfo => appInfo.uuid.startsWith('error-app-'));
+        if (errorAppInfo) {
+            errorWindow = fin.Window.wrapSync({uuid: errorAppInfo.uuid, name: errorAppInfo.uuid});
+        }
+        await delay(1000);
+    } while (errorWindow === undefined);
+
+    if (errorWindow) {
+        await delay(1000);
+        const layout = await sendServiceMessage<undefined, Layout>('generateLayout', undefined);
+        console.log(layout);
+
+        t.false(isErrorInLayout(errorWindow.identity.uuid, layout), 'Error window found in generated layout');
+
+        await errorWindow.close();
+    }
+});
+
 test.afterEach.always(async t => {
     if (crashApp && await crashApp.isRunning()) {
         crashApp.close(true);
     }
 });
+
+function isErrorInLayout(errorUuid: string, layout: Layout) {
+    return layout.apps.some(app => app.uuid === errorUuid);
+}

--- a/test/provider/ignoreErrorWindows.test.ts
+++ b/test/provider/ignoreErrorWindows.test.ts
@@ -40,11 +40,12 @@ test('Error windows are not registered with layouts', async t => {
 
     if (errorWindow) {
         t.false(await isWindowRegistered(errorWindow.identity), `Error window with identity "${errorWindow.identity.uuid}" was registered with the service.`);
+        await errorWindow.close();
     }
 });
 
 test.afterEach.always(async t => {
-    if (crashApp) {
+    if (crashApp && await crashApp.isRunning()) {
         crashApp.close(true);
     }
 });


### PR DESCRIPTION
Added checks when registering windows to ensure the service ignores any windows with uuid/name matching the pattern `error-app-{UUIDv4}`.