### PR TITLE
[SERVICE-274] Tab title in tabstrip UI doesn't update if a tab is renamed by an application

### DIFF
--- a/src/client/APITypes.ts
+++ b/src/client/APITypes.ts
@@ -1,9 +1,4 @@
-export enum TabApiEvents {
-    TABADDED = 'TABADDED',
-    TABREMOVED = 'TABREMOVED',
-    PROPERTIESUPDATED = 'PROPERTIESUPDATED',
-    TABACTIVATED = 'TABACTIVATED'
-}
+
 
 export enum AppApiEvents {
     CLIENTINIT = 'CLIENTINIT',

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -2,7 +2,7 @@ import {Identity} from 'hadouken-js-adapter';
 import {ChannelClient} from 'hadouken-js-adapter/out/types/src/api/interappbus/channel/client';
 
 import {TabAPI} from './APITypes';
-import {AddTabPayload, ApplicationUIConfig, CHANNEL_NAME, CustomData, DropPosition, EndDragPayload, JoinTabGroupPayload, Layout, LayoutApp, LayoutName, SetTabClientPayload, TabGroupEventPayload, TabProperties, UpdateTabPropertiesPayload, TabPropertiesUpdatedPayload} from './types';
+import {AddTabPayload, ApplicationUIConfig, CHANNEL_NAME, CustomData, DropPosition, EndDragPayload, JoinTabGroupPayload, Layout, LayoutApp, LayoutName, SetTabClientPayload, TabGroupEventPayload, TabProperties, TabPropertiesUpdatedPayload, UpdateTabPropertiesPayload} from './types';
 import {version} from './version';
 
 if (typeof fin === 'undefined') {

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -2,7 +2,7 @@ import {Identity} from 'hadouken-js-adapter';
 import {ChannelClient} from 'hadouken-js-adapter/out/types/src/api/interappbus/channel/client';
 
 import {TabAPI} from './APITypes';
-import {AddTabPayload, ApplicationUIConfig, CHANNEL_NAME, CustomData, DropPosition, EndDragPayload, JoinTabGroupPayload, Layout, LayoutApp, LayoutName, SetTabClientPayload, TabGroupEventPayload, TabProperties, UpdateTabPropertiesPayload} from './types';
+import {AddTabPayload, ApplicationUIConfig, CHANNEL_NAME, CustomData, DropPosition, EndDragPayload, JoinTabGroupPayload, Layout, LayoutApp, LayoutName, SetTabClientPayload, TabGroupEventPayload, TabProperties, UpdateTabPropertiesPayload, TabPropertiesUpdatedPayload} from './types';
 import {version} from './version';
 
 if (typeof fin === 'undefined') {
@@ -38,6 +38,9 @@ const channelPromise: Promise<ChannelClient> = fin.InterApplicationBus.Channel.c
     });
     channel.register('tab-activated', (payload: TabGroupEventPayload) => {
         window.dispatchEvent(new CustomEvent<TabGroupEventPayload>('tab-activated', {detail: payload}));
+    });
+    channel.register('tab-properties-updated', (payload: TabPropertiesUpdatedPayload) => {
+        window.dispatchEvent(new CustomEvent<TabPropertiesUpdatedPayload>('tab-properties-updated', {detail: payload}));
     });
 
     // Any unregistered action will simply return false
@@ -89,7 +92,7 @@ export async function deregister(identity: Identity = getId()): Promise<void> {
  */
 // export async function addEventListener(eventType: 'join-tab-group' | 'leave-tab-group', callback: (customEvent: TabEvent) => void): Promise<void>;
 export async function addEventListener(
-    eventType: 'join-snap-group'|'leave-snap-group'|'join-tab-group'|'leave-tab-group'|'tab-activated',
+    eventType: 'tab-properties-updated'|'join-snap-group'|'leave-snap-group'|'join-tab-group'|'leave-tab-group'|'tab-activated',
     callback: (customEvent: Event|CustomEvent<TabGroupEventPayload>) => void): Promise<void> {
     // Use native js event system to pass internal events around.
     // Without this we would need to handle multiple registration ourselves.

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -199,6 +199,10 @@ export interface UpdateTabPropertiesPayload {
     properties: Partial<TabProperties>;
 }
 
+export interface TabPropertiesUpdatedPayload extends TabGroupEventPayload {
+    properties: TabProperties;
+}
+
 export interface EndDragPayload {
     event: DropPosition;
     window: Identity;

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -1,6 +1,5 @@
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
-import {TabApiEvents} from '../../client/APITypes';
-import {ApplicationUIConfig, JoinTabGroupPayload, TabGroupEventPayload, TabIdentifier, TabProperties} from '../../client/types';
+import {ApplicationUIConfig, JoinTabGroupPayload, TabGroupEventPayload, TabIdentifier, TabProperties, TabPropertiesUpdatedPayload} from '../../client/types';
 import {Signal1} from '../Signal';
 import {Point} from '../snapanddock/utils/PointUtils';
 import {Rectangle, RectUtils} from '../snapanddock/utils/RectUtils';
@@ -115,7 +114,8 @@ export class DesktopTabGroup {
         Object.assign(tabProps, properties);
         localStorage.setItem(tab.getId(), JSON.stringify(tabProps));
 
-        fin.InterApplicationBus.send({uuid: fin.Application.me.uuid, name: this.ID}, TabApiEvents.PROPERTIESUPDATED, {tabID: this.ID, tabProps: properties});
+        const payload: TabPropertiesUpdatedPayload = {tabGroupId: this.ID, tabID: tab.getIdentity(), properties: tabProps }
+        this.sendTabEvent(tab, WindowMessages.TAB_PROPERTIES_UPDATED, payload);
     }
 
     /**

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -114,7 +114,7 @@ export class DesktopTabGroup {
         Object.assign(tabProps, properties);
         localStorage.setItem(tab.getId(), JSON.stringify(tabProps));
 
-        const payload: TabPropertiesUpdatedPayload = {tabGroupId: this.ID, tabID: tab.getIdentity(), properties: tabProps }
+        const payload: TabPropertiesUpdatedPayload = {tabGroupId: this.ID, tabID: tab.getIdentity(), properties: tabProps};
         this.sendTabEvent(tab, WindowMessages.TAB_PROPERTIES_UPDATED, payload);
     }
 

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -67,7 +67,8 @@ export const enum WindowMessages {
     LEAVE_TAB_GROUP = 'leave-tab-group',
 
     // Tabbing (tabstrip messages)
-    TAB_ACTIVATED = 'tab-activated'
+    TAB_ACTIVATED = 'tab-activated',
+    TAB_PROPERTIES_UPDATED = 'tab-properties-updated'
 }
 
 

--- a/src/provider/tabbing/tabstrip/main.ts
+++ b/src/provider/tabbing/tabstrip/main.ts
@@ -1,5 +1,5 @@
 import * as layouts from '../../../client/main';  //The equivalent of 'openfin-layouts' NPM package outside of this project.
-import {JoinTabGroupPayload, TabGroupEventPayload, TabIdentifier} from '../../../client/types';
+import {JoinTabGroupPayload, TabGroupEventPayload, TabIdentifier, TabPropertiesUpdatedPayload} from '../../../client/types';
 
 import {TabManager} from './TabManager';
 
@@ -32,6 +32,18 @@ const createLayoutsEventListeners = () => {
         const customEvent: CustomEvent<TabGroupEventPayload> = event as CustomEvent<TabGroupEventPayload>;
         const tabInfo: TabIdentifier = customEvent.detail.tabID;
         tabManager.setActiveTab(tabInfo);
+    });
+
+    layouts.addEventListener('tab-properties-updated', (event: CustomEvent<TabPropertiesUpdatedPayload>|Event) => {
+        const customEvent: CustomEvent<TabPropertiesUpdatedPayload> = event as CustomEvent<TabPropertiesUpdatedPayload>;
+
+        const tab = tabManager.getTab(customEvent.detail.tabID as TabIdentifier);
+        const props = customEvent.detail.properties;
+        
+        if(tab){
+            if(props.icon) tab.updateIcon(props.icon);
+            if(props.title) tab.updateText(props.title);
+        }
     });
 };
 

--- a/src/provider/tabbing/tabstrip/main.ts
+++ b/src/provider/tabbing/tabstrip/main.ts
@@ -39,10 +39,10 @@ const createLayoutsEventListeners = () => {
 
         const tab = tabManager.getTab(customEvent.detail.tabID as TabIdentifier);
         const props = customEvent.detail.properties;
-        
-        if(tab){
-            if(props.icon) tab.updateIcon(props.icon);
-            if(props.title) tab.updateText(props.title);
+
+        if (tab) {
+            if (props.icon) tab.updateIcon(props.icon);
+            if (props.title) tab.updateText(props.title);
         }
     });
 };

--- a/test/demo/utils/tabServiceUtils.ts
+++ b/test/demo/utils/tabServiceUtils.ts
@@ -1,9 +1,11 @@
 import {Identity} from 'hadouken-js-adapter';
 
+import {TabAPI} from '../../../src/client/APITypes';
+import {TabProperties, UpdateTabPropertiesPayload} from '../../../src/client/types';
 import {DesktopTabGroup} from '../../../src/provider/model/DesktopTabGroup';
 import {DesktopWindow, WindowIdentity} from '../../../src/provider/model/DesktopWindow';
 
-import {executeJavascriptOnService} from './serviceUtils';
+import {executeJavascriptOnService, sendServiceMessage} from './serviceUtils';
 
 export async function getTabGroupID(identity: Identity): Promise<string|null> {
     function remoteFunc(this: ProviderWindow, identity: WindowIdentity): string|null {
@@ -30,4 +32,12 @@ export async function getTabbedWindows(identity: Identity): Promise<Identity[]> 
         }
     }
     return executeJavascriptOnService<WindowIdentity, Identity[]>(remoteFunc, identity as WindowIdentity);
+}
+
+
+/**
+ * Send a message to the service requesting a provided tabs properties be updated, aka updateTabProperties API call.
+ */
+export async function updateTabProperties(identity: Identity, properties: Partial<TabProperties>) {
+    await sendServiceMessage<UpdateTabPropertiesPayload, void>(TabAPI.UPDATETABPROPERTIES, {window: identity, properties});
 }

--- a/test/provider/updateTabProperties.test.ts
+++ b/test/provider/updateTabProperties.test.ts
@@ -26,11 +26,7 @@ test.beforeEach(async () => {
 test.afterEach.always(async () => {
     // Try and close all the windows.  If the window is already closed then it will throw an error which we catch and ignore.
     await Promise.all(wins.map(win => {
-        try {
-            return win.close();
-        } catch (e) {
-            return;
-        }
+        return win.close().catch(() => {});
     }));
 
     wins = [];

--- a/test/provider/updateTabProperties.test.ts
+++ b/test/provider/updateTabProperties.test.ts
@@ -1,0 +1,71 @@
+import {test} from 'ava';
+import {Fin} from 'hadouken-js-adapter';
+import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
+
+import {WindowIdentity} from '../../src/provider/model/DesktopWindow';
+import {executeJavascriptOnService} from '../demo/utils/serviceUtils';
+import {updateTabProperties} from '../demo/utils/tabServiceUtils';
+
+import {getConnection} from './utils/connect';
+import {tabWindowsTogether} from './utils/tabWindowsTogether';
+import {WindowInitializer} from './utils/WindowInitializer';
+
+let fin: Fin;
+
+let wins: _Window[] = [];
+
+const windowInitializer = new WindowInitializer();
+
+test.before(async () => {
+    fin = await getConnection();
+});
+test.beforeEach(async () => {
+    wins = await windowInitializer.initWindows(2);
+});
+
+test.afterEach.always(async () => {
+    // Try and close all the windows.  If the window is already closed then it will throw an error which we catch and ignore.
+    await Promise.all(wins.map(win => {
+        try {
+            return win.close();
+        } catch (e) {
+            return;
+        }
+    }));
+
+    wins = [];
+});
+
+test('Update Tab Properties - property changes reflected in tabstrip DOM', async t => {
+    // Drag wins[0] over wins[1] to make a tabset (in valid drop region)
+    await tabWindowsTogether(wins[0], wins[1]);
+
+    const newProps = {title: '' + Math.random() * 10, icon: 'https://thumbs.gfycat.com/HeftyLightHorsemouse-size_restricted.gif'};
+
+    // Update first windows Tab Properties (icon, title);
+    await updateTabProperties(wins[0].identity, newProps);
+
+    function remoteFunc(this: ProviderWindow, identity: WindowIdentity) {
+        const tabGroup = this.model.getWindow(identity as WindowIdentity)!.getTabGroup();
+
+        if (tabGroup) {
+            //@ts-ignore Accessing private variables in the name of testing.
+            const tabDOM: Document = tabGroup._window.window.nativeWindow.document;
+
+            return Array.from(tabDOM.getElementsByClassName('tab-content-wrap')).map((el) => {
+                return {
+                    title: el.getElementsByClassName('tab-content')[0].textContent,
+                    icon: (el.getElementsByClassName('tab-favicon')[0] as HTMLElement).style.backgroundImage
+                };
+            });
+        }
+
+        return [];
+    }
+
+    // Execute remote to fetch all tab titles, icons from DOM
+    const result = await executeJavascriptOnService(remoteFunc, wins[0].identity as WindowIdentity);
+
+    // Assert that at least one of the tabs match the properties we updated with.
+    await t.true(result.some(el => el.title === newProps.title && el.icon!.includes(newProps.icon)));
+});

--- a/test/provider/updateTabProperties.test.ts
+++ b/test/provider/updateTabProperties.test.ts
@@ -40,7 +40,7 @@ test('Update Tab Properties - property changes reflected in service', async t =>
     // Drag wins[0] over wins[1] to make a tabset (in valid drop region)
     await tabWindowsTogether(wins[0], wins[1]);
 
-    const newProps = {title: '' + Math.random() * 10, icon: 'https://thumbs.gfycat.com/HeftyLightHorsemouse-size_restricted.gif'};
+    const newProps = {title: '' + Math.random() * 10, icon: 'http://cdn.openfin.co/favicon.ico'};
 
     // Update first windows Tab Properties (icon, title);
     await updateTabProperties(wins[0].identity, newProps);
@@ -64,7 +64,7 @@ test('Update Tab Properties - property changes reflected in tabstrip DOM', async
     // Drag wins[0] over wins[1] to make a tabset (in valid drop region)
     await tabWindowsTogether(wins[0], wins[1]);
 
-    const newProps = {title: '' + Math.random() * 10, icon: 'https://thumbs.gfycat.com/HeftyLightHorsemouse-size_restricted.gif'};
+    const newProps = {title: '' + Math.random() * 10, icon: 'http://cdn.openfin.co/favicon.ico'};
 
     // Update first windows Tab Properties (icon, title);
     await updateTabProperties(wins[0].identity, newProps);


### PR DESCRIPTION
This PR adds an event listener `tab-properties-updated` which will receive events when the API method `updateTabProperties` is used.  This will resolve the issue previously noted for the tab strip not updating correctly when the API method was called externally.