### PR TITLE
Fix hanging tests

### DIFF
--- a/res/test/testApp.js
+++ b/res/test/testApp.js
@@ -1,4 +1,12 @@
 const main = async () => {
+    fin.desktop.InterApplicationBus.Channel.connect('of-layouts-service-v1').then(client => {
+        client.send('deregister');
+        client.register('savingLayout', () => {});
+        client.register('restoreApp', (...args) => args);
+    })
+    
+
+
     let provider = await fin.desktop.InterApplicationBus.Channel.create('test-app-comms');
 
     provider.register('createWindow', (payload) => new Promise((res, rej) => {

--- a/res/test/testApp.js
+++ b/res/test/testApp.js
@@ -2,8 +2,8 @@ const main = async () => {
     fin.desktop.InterApplicationBus.Channel.connect('of-layouts-service-v1').then(client => {
         client.send('deregister');
         client.register('savingLayout', () => {});
-        client.register('restoreApp', (...args) => args);
-    })
+        client.register('restoreApp', (a) => a);
+    });
     
 
 


### PR DESCRIPTION
Issue with calling generateLayout. Fixed by registering onAppSave and onAppRestore callbacks on the testApp.

Currently causing tests in CI to hang intermittently.