### PR TITLE
[SERIVCE-135] Respect window size constraints when snapping

### DIFF
--- a/src/fin.d.ts
+++ b/src/fin.d.ts
@@ -295,26 +295,7 @@ declare namespace fin {
         /**
          * Defines a region in pixels that will respond to user mouse interaction for resizing a frameless window.
          */
-        resizeRegion?: {
-            /**
-             * The size in pixels (Default: 2),
-             */
-            size?: number;
-            /**
-             * The size in pixels of an additional
-             * square resizable region located at the
-             * bottom right corner of a
-             * frameless window. (Default: 4)
-             */
-            bottomRightCorner?: number;
-
-            sides: {
-                top: boolean;
-                bottom: boolean;
-                left: boolean;
-                right: boolean;
-            }
-        };
+        resizeRegion?: ResizeRegion;
         /**
          * A flag to show the Window's icon in the taskbar. Default: true.
          */
@@ -346,6 +327,27 @@ declare namespace fin {
         backgroundThrottling?: boolean;
 
         backgroundColor?: string;
+    }
+
+    interface ResizeRegion {
+        /**
+         * The size in pixels (Default: 2),
+         */
+        size?: number;
+        /**
+         * The size in pixels of an additional
+         * square resizable region located at the
+         * bottom right corner of a
+         * frameless window. (Default: 4)
+         */
+        bottomRightCorner?: number;
+        
+        sides: {
+            top: boolean;
+            bottom: boolean;
+            left: boolean;
+            right: boolean;
+        };
     }
 
     /**

--- a/src/fin.d.ts
+++ b/src/fin.d.ts
@@ -307,6 +307,13 @@ declare namespace fin {
              * frameless window. (Default: 4)
              */
             bottomRightCorner?: number;
+
+            sides: {
+                top: boolean;
+                bottom: boolean;
+                left: boolean;
+                right: boolean;
+            }
         };
         /**
          * A flag to show the Window's icon in the taskbar. Default: true.

--- a/src/provider/model/DesktopSnapGroup.ts
+++ b/src/provider/model/DesktopSnapGroup.ts
@@ -30,12 +30,19 @@ interface TabState {
     previousState: TabData;
 }
 
+export interface ResizeConstraints {
+    resizable: boolean;
+    min: number;
+    max: number;
+}
+
 export interface Snappable {
     getId(): string;
     getIdentity(): WindowIdentity;
     getState(): WindowState;
     getTabGroup(): DesktopTabGroup|null;
     getSnapGroup(): DesktopSnapGroup;
+    getResizeConstraints(orientation: 'x' | 'y'): ResizeConstraints;
 
     // tslint:disable-next-line:no-any
     applyOverride(property: keyof WindowState, value: any): Promise<void>;

--- a/src/provider/model/DesktopSnapGroup.ts
+++ b/src/provider/model/DesktopSnapGroup.ts
@@ -42,7 +42,7 @@ export interface Snappable {
     getState(): WindowState;
     getTabGroup(): DesktopTabGroup|null;
     getSnapGroup(): DesktopSnapGroup;
-    getResizeConstraints(orientation: 'x' | 'y'): ResizeConstraints;
+    getResizeConstraints(orientation: 'x'|'y'): ResizeConstraints;
 
     // tslint:disable-next-line:no-any
     applyOverride(property: keyof WindowState, value: any): Promise<void>;

--- a/src/provider/model/DesktopSnapGroup.ts
+++ b/src/provider/model/DesktopSnapGroup.ts
@@ -30,19 +30,12 @@ interface TabState {
     previousState: TabData;
 }
 
-export interface ResizeConstraints {
-    resizable: boolean;
-    min: number;
-    max: number;
-}
-
 export interface Snappable {
     getId(): string;
     getIdentity(): WindowIdentity;
     getState(): WindowState;
     getTabGroup(): DesktopTabGroup|null;
     getSnapGroup(): DesktopSnapGroup;
-    getResizeConstraints(orientation: 'x'|'y'): ResizeConstraints;
 
     // tslint:disable-next-line:no-any
     applyOverride(property: keyof WindowState, value: any): Promise<void>;

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -11,7 +11,7 @@ import {Rectangle} from '../snapanddock/utils/RectUtils';
 
 import {DesktopEntity} from './DesktopEntity';
 import {DesktopModel} from './DesktopModel';
-import {DesktopSnapGroup, Snappable, ResizeConstraints} from './DesktopSnapGroup';
+import {DesktopSnapGroup, ResizeConstraints, Snappable} from './DesktopSnapGroup';
 import {DesktopTabGroup} from './DesktopTabGroup';
 
 export interface WindowState extends Rectangle {
@@ -510,7 +510,7 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
         }
     }
 
-    public getResizeConstraints(orientation: 'x' | 'y'): ResizeConstraints {
+    public getResizeConstraints(orientation: 'x'|'y'): ResizeConstraints {
         let min: number, max: number;
         let resizable: boolean = this.windowState.resizable;
 

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -30,9 +30,15 @@ export interface WindowState extends Rectangle {
     maxWidth: number;
     minHeight: number;
     maxHeight: number;
+    resizable: boolean;
+    resizeRegion: WindowResizeRegion;
 
     opacity: number;
     frameEnabled: boolean;  // If window will respond to move/resize events. Corresponds to enable/disableFrame, not WindowOptions.frame.
+}
+
+export interface WindowResizeRegion {
+    sides: {top: boolean; bottom: boolean; left: boolean; right: boolean;};
 }
 
 export interface WindowIdentity extends Identity {
@@ -167,6 +173,8 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
                     maxWidth: options.maxWidth!,
                     minHeight: options.minHeight!,
                     maxHeight: options.maxHeight!,
+                    resizable: options.resizable!,
+                    resizeRegion: options.resizeRegion!,
                     opacity: options.opacity!,
                     frameEnabled: true  // No way to query frame enabled/disabled state from API. Assume frame is enabled
                 };
@@ -337,6 +345,8 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
             maxWidth: -1,
             minHeight: 0,
             maxHeight: 0,
+            resizable: true,
+            resizeRegion: {sides: {top: true, bottom: true, left: true, right: true}},
             opacity: 1,
             frameEnabled: true
         };

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -352,8 +352,8 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
             title: '',
             showTaskbarIcon: true,
             resizeConstraints: {
-                x: {minSize: 0, maxSize: Number.MAX_SAFE_INTEGER, resizableMin: true, resizableMax: false},
-                y: {minSize: 0, maxSize: Number.MAX_SAFE_INTEGER, resizableMin: true, resizableMax: false}
+                x: {minSize: 0, maxSize: Number.MAX_SAFE_INTEGER, resizableMin: true, resizableMax: true},
+                y: {minSize: 0, maxSize: Number.MAX_SAFE_INTEGER, resizableMin: true, resizableMax: true}
             },
             opacity: 1,
             frameEnabled: true

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -11,7 +11,7 @@ import {Rectangle} from '../snapanddock/utils/RectUtils';
 
 import {DesktopEntity} from './DesktopEntity';
 import {DesktopModel} from './DesktopModel';
-import {DesktopSnapGroup, Snappable} from './DesktopSnapGroup';
+import {DesktopSnapGroup, Snappable, ResizeConstraints} from './DesktopSnapGroup';
 import {DesktopTabGroup} from './DesktopTabGroup';
 
 export interface WindowState extends Rectangle {
@@ -508,6 +508,22 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
         } else {
             return Promise.resolve();
         }
+    }
+
+    public getResizeConstraints(orientation: 'x' | 'y'): ResizeConstraints {
+        let min: number, max: number;
+        let resizable: boolean = this.windowState.resizable;
+
+        if (orientation === 'x') {
+            resizable = this.windowState.resizable && (this.windowState.resizeRegion.sides.top || this.windowState.resizeRegion.sides.bottom);
+            [min, max] = [this.windowState.minHeight, this.windowState.maxHeight];
+        } else {
+            resizable = this.windowState.resizable && (this.windowState.resizeRegion.sides.left || this.windowState.resizeRegion.sides.right);
+            [min, max] = [this.windowState.minWidth, this.windowState.maxWidth];
+        }
+        max = max < 0 ? Number.MAX_SAFE_INTEGER : max;
+
+        return {resizable, min, max};
     }
 
     private isModified(key: keyof WindowState, prevState: Partial<WindowState>, newState: WindowState): boolean {

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -33,7 +33,9 @@ export interface WindowState extends Rectangle {
 }
 
 export interface ResizeConstraint {
+    // Window is resizable by the edge closest to the origin (left/top)
     resizableMin: boolean;
+    // Window is resizable by the edge furthest from the origin (right/bottom)
     resizableMax: boolean;
     minSize: number;
     maxSize: number;

--- a/src/provider/snapanddock/Projector.ts
+++ b/src/provider/snapanddock/Projector.ts
@@ -116,7 +116,7 @@ export class Projector {
                                 const targetBorderLength = (border.max - border.min);
 
                                 // Only resize if it would not violate any constraints
-                                if ((resizableMin || resizableMax) && targetBorderLength > minSize && targetBorderLength < maxSize) {
+                                if ((resizableMin || resizableMax) && targetBorderLength >= minSize && targetBorderLength <= maxSize) {
                                     halfSize[border.opposite] = targetBorderLength / 2;
                                 }
                                 snapOffset[border.opposite] = ((border.min + border.max) / 2) - activeState.center[border.opposite];

--- a/src/provider/snapanddock/Projector.ts
+++ b/src/provider/snapanddock/Projector.ts
@@ -112,7 +112,7 @@ export class Projector {
                                 Math.abs((activeState.center[border.opposite] + activeState.halfSize[border.opposite]) - border.max) < ANCHOR_DISTANCE;
 
                             if (snapToMin && snapToMax) {
-                                halfSize[border.opposite] = (border.max - border.min) / 2;
+                                    halfSize[border.opposite] = (border.max - border.min) / 2;
                                 snapOffset[border.opposite] = ((border.min + border.max) / 2) - activeState.center[border.opposite];
                                 snapOffset[border.opposite] = ((border.min + border.max) / 2) - activeState.center[border.opposite] +
                                     (activeState.halfSize[border.opposite] - halfSize[border.opposite]);

--- a/src/provider/snapanddock/Projector.ts
+++ b/src/provider/snapanddock/Projector.ts
@@ -112,11 +112,11 @@ export class Projector {
                                 Math.abs((activeState.center[border.opposite] + activeState.halfSize[border.opposite]) - border.max) < ANCHOR_DISTANCE;
 
                             if (snapToMin && snapToMax) {
-                                const {min, max, resizable} = activeWindow.getResizeConstraints(border.orientation);
+                                const {minSize, maxSize, resizableMin, resizableMax} = activeState.resizeConstraints[border.opposite];
                                 const targetBorderLength = (border.max - border.min);
 
                                 // Only resize if it would not violate any constraints
-                                if (resizable && targetBorderLength > min && targetBorderLength < max) {
+                                if ((resizableMin || resizableMax) && targetBorderLength > minSize && targetBorderLength < maxSize) {
                                     halfSize[border.opposite] = targetBorderLength / 2;
                                 }
                                 snapOffset[border.opposite] = ((border.min + border.max) / 2) - activeState.center[border.opposite];

--- a/src/provider/snapanddock/Projector.ts
+++ b/src/provider/snapanddock/Projector.ts
@@ -116,11 +116,13 @@ export class Projector {
                                 const resizeRegions = activeState.resizeRegion.sides;
                                 const targetBorderLength = (border.max - border.min);
                                 // tslint:disable-next-line:prefer-const
-                                let [min, max] = border.orientation === 'x' ? [activeState.minHeight, activeState.maxHeight] : [activeState.minWidth, activeState.maxWidth];
+                                let [min, max] =
+                                    border.orientation === 'x' ? [activeState.minHeight, activeState.maxHeight] : [activeState.minWidth, activeState.maxWidth];
                                 max = max < 0 ? Number.MAX_SAFE_INTEGER : max;
 
                                 const violatesSizeConstraints = targetBorderLength < min || targetBorderLength > max;
-                                const canResizeInAxis = border.orientation === 'x' ? resizeRegions.top || resizeRegions.bottom : resizeRegions.left || resizeRegions.right;                                
+                                const canResizeInAxis =
+                                    border.orientation === 'x' ? resizeRegions.top || resizeRegions.bottom : resizeRegions.left || resizeRegions.right;
 
                                 if (activeState.resizable && !violatesSizeConstraints && canResizeInAxis) {
                                     halfSize[border.opposite] = (border.max - border.min) / 2;

--- a/src/provider/snapanddock/Projector.ts
+++ b/src/provider/snapanddock/Projector.ts
@@ -112,7 +112,19 @@ export class Projector {
                                 Math.abs((activeState.center[border.opposite] + activeState.halfSize[border.opposite]) - border.max) < ANCHOR_DISTANCE;
 
                             if (snapToMin && snapToMax) {
+                                // Determine if a resize would violate any constraints
+                                const resizeRegions = activeState.resizeRegion.sides;
+                                const targetBorderLength = (border.max - border.min);
+                                // tslint:disable-next-line:prefer-const
+                                let [min, max] = border.orientation === 'x' ? [activeState.minHeight, activeState.maxHeight] : [activeState.minWidth, activeState.maxWidth];
+                                max = max < 0 ? Number.MAX_SAFE_INTEGER : max;
+
+                                const violatesSizeConstraints = targetBorderLength < min || targetBorderLength > max;
+                                const canResizeInAxis = border.orientation === 'x' ? resizeRegions.top || resizeRegions.bottom : resizeRegions.left || resizeRegions.right;                                
+
+                                if (activeState.resizable && !violatesSizeConstraints && canResizeInAxis) {
                                     halfSize[border.opposite] = (border.max - border.min) / 2;
+                                }
                                 snapOffset[border.opposite] = ((border.min + border.max) / 2) - activeState.center[border.opposite];
                                 snapOffset[border.opposite] = ((border.min + border.max) / 2) - activeState.center[border.opposite] +
                                     (activeState.halfSize[border.opposite] - halfSize[border.opposite]);

--- a/src/provider/snapanddock/Projector.ts
+++ b/src/provider/snapanddock/Projector.ts
@@ -13,12 +13,6 @@ export enum eDirection {
     BOTTOM
 }
 
-interface AxisResizeConstraint {
-    resizable: boolean;
-    min: number;
-    max: number;
-}
-
 /**
  * Specialised util class for determining the closest windows in each direction of an active group.
  *
@@ -118,7 +112,7 @@ export class Projector {
                                 Math.abs((activeState.center[border.opposite] + activeState.halfSize[border.opposite]) - border.max) < ANCHOR_DISTANCE;
 
                             if (snapToMin && snapToMax) {
-                                const {min, max, resizable} = this.getResizeConstraint(activeState, border.orientation);
+                                const {min, max, resizable} = activeWindow.getResizeConstraints(border.orientation);
                                 const targetBorderLength = (border.max - border.min);
 
                                 // Only resize if it would not violate any constraints
@@ -187,22 +181,6 @@ export class Projector {
             borders[i].clip(borders[(i + 1) % 4]);
             borders[i].clip(borders[(i + 3) % 4]);
         }
-    }
-
-    private getResizeConstraint(state: WindowState, orientation: 'x'|'y'): AxisResizeConstraint {
-        let min: number, max: number;
-        let resizable: boolean = state.resizable;
-
-        if (orientation === 'x') {
-            resizable = resizable && (state.resizeRegion.sides.top || state.resizeRegion.sides.bottom);
-            [min, max] = [state.minHeight, state.maxHeight];
-        } else {
-            resizable = resizable && state.resizeRegion.sides.left && state.resizeRegion.sides.right;
-            [min, max] = [state.minWidth, state.maxWidth];
-        }
-        max = max < 0 ? Number.MAX_SAFE_INTEGER : max;
-
-        return {resizable, min, max};
     }
 }
 

--- a/test/demo/snapanddock/resizeOnSnap.test.ts
+++ b/test/demo/snapanddock/resizeOnSnap.test.ts
@@ -6,35 +6,85 @@ import {Side} from '../../provider/utils/SideUtils';
 import {CreateWindowData, createWindowTest} from '../utils/createWindowTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 
+// Width and Height of the windows when spawned
+const WINDOW_SIZE = 250;
+// Amount by which windows will grow/shrink before snapping.
+const RESIZE_AMOUNT = 50;
+
 interface ResizeOnSnapOptions extends CreateWindowData {
     side: Side;
     resizeDirection: 'small-to-big'|'big-to-small';
     windowCount: 2;
 }
 
+interface Constraints {
+    maxHeight?: number;
+    maxWidth?: number;
+    minHeight?: number;
+    minWidth?: number;
+    resizable?: boolean;
+    resizeRegion?: {sides: {top?: boolean; bottom?: boolean; left?: boolean; right?: boolean;}};
+}
+
+interface ResizeWithConstrainsOptions extends ResizeOnSnapOptions {
+    constraints: Constraints;
+    shouldResize: boolean;
+}
+
+// With window constraints
 testParameterized(
-    (testOptions: ResizeOnSnapOptions): string => `Resize on Snap - 2 windows - ${testOptions.frame ? 'framed' : 'frameless'} - ${
-        testOptions.resizeDirection.split('-').join(' ')} - ${testOptions.side}`,
+    (testOptions: ResizeWithConstrainsOptions): string => {
+        const frameString = testOptions.frame ? 'framed' : 'frameless';
+        const resizeDirectionString = testOptions.resizeDirection.split('-').join(' ');
+        let constraintsString;
+        if (Object.keys(testOptions.constraints).length === 0) {
+            constraintsString = 'No Constraints';
+        } else if (!!testOptions.constraints.resizeRegion) {
+            constraintsString = `Resize regions: ${Object.keys(testOptions.constraints.resizeRegion.sides).join(', ')}`;
+        } else {
+            constraintsString = `Constraints: ${JSON.stringify(testOptions.constraints).slice(1, -1)}`;
+        }
+    
+        return `Resize on Snap - ${frameString} - ${resizeDirectionString} - ${constraintsString}`;
+    },
     [
-        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'right'},
-        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'bottom'},
-        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'right'},
-        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'bottom'},
-        {frame: false, windowCount: 2, resizeDirection: 'big-to-small', side: 'right'},
-        {frame: false, windowCount: 2, resizeDirection: 'big-to-small', side: 'bottom'},
-        {frame: false, windowCount: 2, resizeDirection: 'small-to-big', side: 'right'},
-        {frame: false, windowCount: 2, resizeDirection: 'small-to-big', side: 'bottom'},
+        // No constraints. Normal resizing behaviour expected
+        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'right', constraints:{}, shouldResize: true},
+        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'bottom', constraints:{}, shouldResize: true},
+        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'right', constraints:{}, shouldResize: true},
+        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'bottom', constraints:{}, shouldResize: true},
+        // Resizable false. No resize should occur.
+        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'right', constraints: {resizable: false}, shouldResize: false},
+        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'bottom', constraints: {resizable: false}, shouldResize: false},
+        // Constraint in axis of resize.
+        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'right', constraints: {resizeRegion: {sides:{top:false, bottom: false}}}, shouldResize: false},
+        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'bottom', constraints: {resizeRegion: {sides:{left:false, right: false}}}, shouldResize: false},
+        // Constraint not in axis of resize
+        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'right', constraints: {resizeRegion: {sides:{left:false, right: false}}}, shouldResize: true},
+        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'bottom', constraints: {resizeRegion: {sides:{top:false, bottom: false}}}, shouldResize: true},
+        // Resize region only on perpendicular sides. Same as no constraint.
+        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'right', constraints: {resizeRegion: {sides:{left:false, top: false}}}, shouldResize: true},
+        // Size constraints
+        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'right', constraints: {minHeight: WINDOW_SIZE + RESIZE_AMOUNT/2}, shouldResize: false},
+        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'bottom', constraints: {minWidth: WINDOW_SIZE + RESIZE_AMOUNT/2}, shouldResize: false},
+        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'right', constraints: {maxHeight: WINDOW_SIZE - RESIZE_AMOUNT/2}, shouldResize: false},
+        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'bottom', constraints: {maxWidth: WINDOW_SIZE - RESIZE_AMOUNT/2}, shouldResize: false},
+        // Irrelevant size constraint
+        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'bottom', constraints: {minWidth: WINDOW_SIZE - RESIZE_AMOUNT/2}, shouldResize: true},
     ],
-    createWindowTest(async (t, testOptions: ResizeOnSnapOptions) => {
-        const {resizeDirection, side} = testOptions;
+    createWindowTest(async (t, testOptions: ResizeWithConstrainsOptions) => {
+        const {resizeDirection, side, shouldResize, constraints} = testOptions;
         const windows = t.context.windows;
 
         // Resize the second window based on the test params
         if (resizeDirection === 'big-to-small') {
-            await windows[1].resizeBy(50, 50, 'top-left');
+            await windows[1].resizeBy(RESIZE_AMOUNT, RESIZE_AMOUNT, 'top-left');
         } else {
-            await windows[1].resizeBy(-50, -50, 'top-left');
+            await windows[1].resizeBy(-RESIZE_AMOUNT, -RESIZE_AMOUNT, 'top-left');
         }
+
+        // Apply constraints
+        await windows[1].updateOptions(constraints);
 
         // Snap the windows together
         await dragSideToSide(windows[1], SideUtils.opposite(side), windows[0], side);
@@ -43,13 +93,20 @@ testParameterized(
         await assertAdjacent(t, windows[0], windows[1], side);
         await assertGrouped(t, windows[0], windows[1]);
 
-        // Check that the windows are now the same width/height (depending on side)
+
+        // Check that the windows are (not) now the same width/height (depending on constraints)
         const bounds = [await getBounds(windows[0]), await getBounds(windows[1])];
+        let windowResized: boolean;
         if (side === 'top' || side === 'bottom') {
-            t.is(bounds[0].left, bounds[1].left);
-            t.is(bounds[0].right, bounds[1].right);
+            windowResized = bounds[0].left === bounds[1].left && bounds[0].right === bounds[1].right;
         } else {
-            t.is(bounds[0].top, bounds[1].top);
-            t.is(bounds[0].bottom, bounds[1].bottom);
+            windowResized = bounds[0].top === bounds[1].top && bounds[0].bottom === bounds[1].bottom;
         }
-    }));
+        
+        if (windowResized === shouldResize) {
+            t.pass();
+        }
+        else {
+            t.fail(`Window was expected${shouldResize ? ' ' : ' not '}to resize, but did ${windowResized ? '' : 'not'}`);
+        }
+    }, {defaultHeight:WINDOW_SIZE, defaultWidth:WINDOW_SIZE}));

--- a/test/demo/snapanddock/resizeOnSnap.test.ts
+++ b/test/demo/snapanddock/resizeOnSnap.test.ts
@@ -177,15 +177,21 @@ testParameterized(
         await assertAdjacent(t, windows[0], windows[1], side);
         await assertGrouped(t, windows[0], windows[1]);
 
-        
+
         const bounds = [await getBounds(windows[0]), await getBounds(windows[1])];
 
-        t.true((boundsBefore.height !== bounds[1].height || boundsBefore.width !== bounds[1].width) === shouldResize, `Window${shouldResize ? ' not' : ''} resized when it should${shouldResize ? '' : 'n\'t'}`);
+        t.true(
+            (boundsBefore.height !== bounds[1].height || boundsBefore.width !== bounds[1].width) === shouldResize,
+            `Window${shouldResize ? ' not' : ''} resized when it should${shouldResize ? '' : 'n\'t'}`);
 
         // Check that the windows are (not) aligned (depending on constraints)
         if (side === 'top' || side === 'bottom') {
-            t.true((bounds[0].left === bounds[1].left && bounds[0].right === bounds[1].right) === shouldResize, `Windows${shouldResize ? ' not' : ''} aligned when they should${shouldResize ? '' : 'n\'t'} be`);
+            t.true(
+                (bounds[0].left === bounds[1].left && bounds[0].right === bounds[1].right) === shouldResize,
+                `Windows${shouldResize ? ' not' : ''} aligned when they should${shouldResize ? '' : 'n\'t'} be`);
         } else {
-            t.true((bounds[0].top === bounds[1].top && bounds[0].bottom === bounds[1].bottom) === shouldResize, `Windows${shouldResize ? ' not' : ''} aligned when they should${shouldResize ? '' : 'n\'t'} be`);
+            t.true(
+                (bounds[0].top === bounds[1].top && bounds[0].bottom === bounds[1].bottom) === shouldResize,
+                `Windows${shouldResize ? ' not' : ''} aligned when they should${shouldResize ? '' : 'n\'t'} be`);
         }
     }, {defaultHeight: WINDOW_SIZE, defaultWidth: WINDOW_SIZE}));

--- a/test/demo/snapanddock/resizeOnSnap.test.ts
+++ b/test/demo/snapanddock/resizeOnSnap.test.ts
@@ -25,13 +25,8 @@ interface Constraints {
     minHeight?: number;
     minWidth?: number;
     resizable?: boolean;
-    resizeRegion?: ResizeRegion;
+    resizeRegion?: fin.ResizeRegion;
 }
-
-interface ResizeRegion {
-    sides: {[K in ResizeSides]: boolean;};
-}
-type ResizeSides = 'top'|'bottom'|'left'|'right';
 
 interface ResizeWithConstrainsOptions extends ResizeOnSnapOptions {
     constraints: Constraints;
@@ -49,7 +44,7 @@ testParameterized(
                 constraintsString = 'No Constraints';
             } else if (!!testOptions.constraints.resizeRegion) {
                 const sides = testOptions.constraints.resizeRegion.sides;
-                constraintsString = `Resize regions: ${(Object.keys(sides) as ResizeSides[]).filter((side) => sides[side]).join(', ')}`;
+                constraintsString = `Resize regions: ${(Object.keys(sides) as (keyof fin.ResizeRegion['sides'])[]).filter((side) => sides[side]).join(', ')}`;
             } else {
                 constraintsString = `Constraints: ${JSON.stringify(testOptions.constraints).slice(1, -1)}`;
             }

--- a/test/demo/snapanddock/resizeOnSnap.test.ts
+++ b/test/demo/snapanddock/resizeOnSnap.test.ts
@@ -5,6 +5,7 @@ import * as SideUtils from '../../provider/utils/SideUtils';
 import {Side} from '../../provider/utils/SideUtils';
 import {CreateWindowData, createWindowTest} from '../utils/createWindowTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
+import { delay } from '../../provider/utils/delay';
 
 // Width and Height of the windows when spawned
 const WINDOW_SIZE = 250;
@@ -33,44 +34,115 @@ interface ResizeWithConstrainsOptions extends ResizeOnSnapOptions {
 
 // With window constraints
 testParameterized(
-    (testOptions: ResizeWithConstrainsOptions): string => {
-        const frameString = testOptions.frame ? 'framed' : 'frameless';
-        const resizeDirectionString = testOptions.resizeDirection.split('-').join(' ');
-        let constraintsString;
-        if (Object.keys(testOptions.constraints).length === 0) {
-            constraintsString = 'No Constraints';
-        } else if (!!testOptions.constraints.resizeRegion) {
-            constraintsString = `Resize regions: ${Object.keys(testOptions.constraints.resizeRegion.sides).join(', ')}`;
-        } else {
-            constraintsString = `Constraints: ${JSON.stringify(testOptions.constraints).slice(1, -1)}`;
-        }
-    
-        return `Resize on Snap - ${frameString} - ${resizeDirectionString} - ${constraintsString}`;
-    },
+    (testOptions: ResizeWithConstrainsOptions):
+        string => {
+            const frameString = testOptions.frame ? 'framed' : 'frameless';
+            const resizeDirectionString = testOptions.resizeDirection.split('-').join(' ');
+            let constraintsString;
+            if (Object.keys(testOptions.constraints).length === 0) {
+                constraintsString = 'No Constraints';
+            } else if (!!testOptions.constraints.resizeRegion) {
+                constraintsString = `Resize regions: ${Object.keys(testOptions.constraints.resizeRegion.sides).join(', ')}`;
+            } else {
+                constraintsString = `Constraints: ${JSON.stringify(testOptions.constraints).slice(1, -1)}`;
+            }
+
+            return `Resize on Snap - ${frameString} - ${resizeDirectionString} - ${constraintsString}`;
+        },
     [
         // No constraints. Normal resizing behaviour expected
-        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'right', constraints:{}, shouldResize: true},
-        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'bottom', constraints:{}, shouldResize: true},
-        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'right', constraints:{}, shouldResize: true},
-        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'bottom', constraints:{}, shouldResize: true},
+        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'right', constraints: {}, shouldResize: true},
+        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'bottom', constraints: {}, shouldResize: true},
+        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'right', constraints: {}, shouldResize: true},
+        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'bottom', constraints: {}, shouldResize: true},
         // Resizable false. No resize should occur.
         {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'right', constraints: {resizable: false}, shouldResize: false},
         {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'bottom', constraints: {resizable: false}, shouldResize: false},
         // Constraint in axis of resize.
-        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'right', constraints: {resizeRegion: {sides:{top:false, bottom: false}}}, shouldResize: false},
-        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'bottom', constraints: {resizeRegion: {sides:{left:false, right: false}}}, shouldResize: false},
+        {
+            frame: true,
+            windowCount: 2,
+            resizeDirection: 'small-to-big',
+            side: 'right',
+            constraints: {resizeRegion: {sides: {top: false, bottom: false}}},
+            shouldResize: false
+        },
+        {
+            frame: true,
+            windowCount: 2,
+            resizeDirection: 'small-to-big',
+            side: 'bottom',
+            constraints: {resizeRegion: {sides: {left: false, right: false}}},
+            shouldResize: false
+        },
         // Constraint not in axis of resize
-        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'right', constraints: {resizeRegion: {sides:{left:false, right: false}}}, shouldResize: true},
-        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'bottom', constraints: {resizeRegion: {sides:{top:false, bottom: false}}}, shouldResize: true},
+        {
+            frame: true,
+            windowCount: 2,
+            resizeDirection: 'big-to-small',
+            side: 'right',
+            constraints: {resizeRegion: {sides: {left: false, right: false}}},
+            shouldResize: true
+        },
+        {
+            frame: true,
+            windowCount: 2,
+            resizeDirection: 'big-to-small',
+            side: 'bottom',
+            constraints: {resizeRegion: {sides: {top: false, bottom: false}}},
+            shouldResize: true
+        },
         // Resize region only on perpendicular sides. Same as no constraint.
-        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'right', constraints: {resizeRegion: {sides:{left:false, top: false}}}, shouldResize: true},
+        {
+            frame: true,
+            windowCount: 2,
+            resizeDirection: 'big-to-small',
+            side: 'right',
+            constraints: {resizeRegion: {sides: {left: false, top: false}}},
+            shouldResize: true
+        },
         // Size constraints
-        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'right', constraints: {minHeight: WINDOW_SIZE + RESIZE_AMOUNT/2}, shouldResize: false},
-        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'bottom', constraints: {minWidth: WINDOW_SIZE + RESIZE_AMOUNT/2}, shouldResize: false},
-        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'right', constraints: {maxHeight: WINDOW_SIZE - RESIZE_AMOUNT/2}, shouldResize: false},
-        {frame: true, windowCount: 2, resizeDirection: 'small-to-big', side: 'bottom', constraints: {maxWidth: WINDOW_SIZE - RESIZE_AMOUNT/2}, shouldResize: false},
+        {
+            frame: true,
+            windowCount: 2,
+            resizeDirection: 'big-to-small',
+            side: 'right',
+            constraints: {minHeight: WINDOW_SIZE + RESIZE_AMOUNT / 2},
+            shouldResize: false
+        },
+        {
+            frame: true,
+            windowCount: 2,
+            resizeDirection: 'big-to-small',
+            side: 'bottom',
+            constraints: {minWidth: WINDOW_SIZE + RESIZE_AMOUNT / 2},
+            shouldResize: false
+        },
+        {
+            frame: true,
+            windowCount: 2,
+            resizeDirection: 'small-to-big',
+            side: 'right',
+            constraints: {maxHeight: WINDOW_SIZE - RESIZE_AMOUNT / 2},
+            shouldResize: false
+        },
+        {
+            frame: true,
+            windowCount: 2,
+            resizeDirection: 'small-to-big',
+            side: 'bottom',
+            constraints: {maxWidth: WINDOW_SIZE - RESIZE_AMOUNT / 2},
+            shouldResize: false
+        },
         // Irrelevant size constraint
-        {frame: true, windowCount: 2, resizeDirection: 'big-to-small', side: 'bottom', constraints: {minWidth: WINDOW_SIZE - RESIZE_AMOUNT/2}, shouldResize: true},
+        {
+            frame: true,
+            windowCount: 2,
+            resizeDirection: 'big-to-small',
+            side: 'bottom',
+            constraints: {minWidth: WINDOW_SIZE - RESIZE_AMOUNT / 2},
+            shouldResize: true
+        },
     ],
     createWindowTest(async (t, testOptions: ResizeWithConstrainsOptions) => {
         const {resizeDirection, side, shouldResize, constraints} = testOptions;
@@ -85,6 +157,8 @@ testParameterized(
 
         // Apply constraints
         await windows[1].updateOptions(constraints);
+
+        await delay(500);
 
         // Snap the windows together
         await dragSideToSide(windows[1], SideUtils.opposite(side), windows[0], side);
@@ -102,11 +176,10 @@ testParameterized(
         } else {
             windowResized = bounds[0].top === bounds[1].top && bounds[0].bottom === bounds[1].bottom;
         }
-        
+
         if (windowResized === shouldResize) {
             t.pass();
-        }
-        else {
+        } else {
             t.fail(`Window was expected${shouldResize ? ' ' : ' not '}to resize, but did ${windowResized ? '' : 'not'}`);
         }
-    }, {defaultHeight:WINDOW_SIZE, defaultWidth:WINDOW_SIZE}));
+    }, {defaultHeight: WINDOW_SIZE, defaultWidth: WINDOW_SIZE}));

--- a/test/demo/utils/modelUtils.ts
+++ b/test/demo/utils/modelUtils.ts
@@ -1,0 +1,17 @@
+import { Identity } from "hadouken-js-adapter";
+import { WindowIdentity } from "../../../src/provider/model/DesktopWindow";
+import { executeJavascriptOnService } from "./serviceUtils";
+
+
+export function refreshWindowState(identity: Identity) {
+    function remoteFunc(this:ProviderWindow, identity: WindowIdentity):Promise<void> {
+        const desktopWindow = this.model.getWindow(identity);
+        if (desktopWindow) {
+            return desktopWindow.refresh();
+        } else {
+            throw new Error(`Attempted to refresh state of non-existent or deregistered window: ${identity.uuid}/${identity.name}`);
+        }
+    }
+
+    executeJavascriptOnService(remoteFunc, identity as WindowIdentity);
+}

--- a/test/demo/utils/modelUtils.ts
+++ b/test/demo/utils/modelUtils.ts
@@ -1,10 +1,10 @@
-import { Identity } from "hadouken-js-adapter";
-import { WindowIdentity } from "../../../src/provider/model/DesktopWindow";
-import { executeJavascriptOnService } from "./serviceUtils";
+import {Identity} from 'hadouken-js-adapter';
+import {WindowIdentity} from '../../../src/provider/model/DesktopWindow';
+import {executeJavascriptOnService} from './serviceUtils';
 
 
 export function refreshWindowState(identity: Identity) {
-    function remoteFunc(this:ProviderWindow, identity: WindowIdentity):Promise<void> {
+    function remoteFunc(this: ProviderWindow, identity: WindowIdentity): Promise<void> {
         const desktopWindow = this.model.getWindow(identity);
         if (desktopWindow) {
             return desktopWindow.refresh();


### PR DESCRIPTION
Summary of changes: 
 - Updated the model's windowState interface to include resizable and resizeRegion.
 - Added public method on DesktopWindow to allow getting constraints data in a more manageable format.
 - Added checks to projector that block resizing if it would violate these constraints, or min/max height/width.