### PR TITLE
[SERVICE-220] Fix bug where grouped windows could overlap when snapping to anchor points.

### DIFF
--- a/test/demo/snapanddock/advancedSnapAndDock.test.ts
+++ b/test/demo/snapanddock/advancedSnapAndDock.test.ts
@@ -1,0 +1,90 @@
+import {assertAllContiguous, assertGrouped, assertNoOverlap, assertNotGrouped} from '../../provider/utils/assertions';
+import {delay} from '../../provider/utils/delay';
+import {dragSideToSide} from '../../provider/utils/dragWindowTo';
+import {getBounds} from '../../provider/utils/getBounds';
+import {CreateWindowData, createWindowTest} from '../utils/createWindowTest';
+import {testParameterized} from '../utils/parameterizedTestUtils';
+
+// Using testParameterized more for type safety than parameterization
+// since this just one very specific test
+testParameterized(
+    (testOptions: CreateWindowData) => 'Cannot snap windows so they overlap - shape: U',
+    [{windowCount: 5, frame: true}],
+    createWindowTest(async (t, testOptions: CreateWindowData) => {
+        const windows = t.context.windows;
+
+        // Sizes for the windows to make it work
+        await Promise.all([
+            windows[0].resizeTo(230, 210, 'top-left'),
+            windows[1].resizeTo(210, 170, 'top-left'),
+            windows[2].resizeTo(260, 170, 'top-left'),
+            windows[3].resizeTo(200, 270, 'top-left'),
+            windows[4].resizeTo(220, 170, 'top-left')
+        ]);
+
+        await delay(500);
+
+        // Arrange the windows into a horseshoe shape
+        await windows[0].moveTo(700, 300);
+        await delay(500);
+        await dragSideToSide(windows[1], 'top', windows[0], 'bottom', {x: 110, y: 5});
+        await dragSideToSide(windows[2], 'right', windows[1], 'left', {x: -5, y: 50});
+        await dragSideToSide(windows[3], 'right', windows[2], 'left', {x: 0, y: -210});
+
+        await assertGrouped(t, ...windows.slice(0, -1));
+        await assertAllContiguous(t, windows.slice(0, -1));
+        await assertNotGrouped(windows[4], t);
+
+        // This is a safety check in case snapping behavior changes and the magic numbers above
+        // no longer do what theyre supposed to. Window should be offset or this test will pass but not
+        // actually test for the defect.
+        t.not(
+            (await getBounds(windows[1])).left,
+            (await getBounds(windows[0])).left,
+            'Window 1 resized when snapped - should be offset - snap/anchor distance may have changed');
+
+        // Drag remaining window into the middle of the horshoe and check it snaps with no overlap
+        await dragSideToSide(windows[4], 'bottom', windows[2], 'top', {x: 10, y: -5});
+        await delay(500);
+
+        await assertGrouped(t, ...windows);
+        await assertAllContiguous(t, windows);
+        await assertNoOverlap(t, windows);
+    }));
+
+testParameterized(
+    (testOptions: CreateWindowData) => 'Cannot snap windows so they overlap - shape: O',
+    [{windowCount: 5, frame: true}],
+    createWindowTest(async (t, testOptions: CreateWindowData) => {
+        const windows = t.context.windows;
+
+        // Sizes for the windows to make it work
+        await Promise.all([
+            windows[0].resizeTo(200, 300, 'top-left'),
+            windows[1].resizeTo(300, 170, 'top-left'),
+            windows[2].resizeTo(200, 300, 'top-left'),
+            windows[3].resizeTo(300, 170, 'top-left'),
+            windows[4].resizeTo(220, 220, 'top-left')
+        ]);
+
+        await delay(500);
+
+        // Arrange the windows into a hollow circle shape
+        await windows[0].moveTo(800, 300);
+        await delay(500);
+        await dragSideToSide(windows[1], 'top', windows[0], 'bottom', {x: -230, y: 5});
+        await dragSideToSide(windows[2], 'right', windows[1], 'left', {x: -5, y: -230});
+        await dragSideToSide(windows[3], 'bottom', windows[2], 'top', {x: 120, y: -5});
+
+        await assertGrouped(t, ...windows.slice(0, -1));
+        await assertAllContiguous(t, windows.slice(0, -1));
+        await assertNotGrouped(windows[4], t);
+
+        // Drag remaining window into the middle of the horshoe and check it snaps with no overlap
+        await dragSideToSide(windows[4], 'bottom', windows[1], 'top', {x: 15, y: -10});
+        await delay(500);
+
+        await assertGrouped(t, ...windows);
+        await assertAllContiguous(t, windows);
+        await assertNoOverlap(t, windows);
+    }));

--- a/test/provider/utils/assertions.ts
+++ b/test/provider/utils/assertions.ts
@@ -10,6 +10,7 @@ import {getBounds, NormalizedBounds} from './getBounds';
 import {Win} from './getWindow';
 import {isAdjacentTo} from './isAdjacentTo';
 import {getContiguousWindows} from './isContiguousGroup';
+import {isOverlappedWith} from './isOverlappedWith';
 import {Side} from './SideUtils';
 
 /**
@@ -153,5 +154,13 @@ export async function assertAllContiguous(t: TestContext, windows: Window[]) {
         t.fail(`Windows do not form a contiguous group. \nExpected: ${expectedGroupsString} \nActual: ${actualGroupsString}`);
     } else {
         t.pass();
+    }
+}
+
+export async function assertNoOverlap(t: TestContext, windows: Window[]) {
+    for (let i = 0; i < windows.length - 1; i++) {
+        for (let j = i + 1; j < windows.length; j++) {
+            t.false(await isOverlappedWith(windows[i], windows[j]), `Window ${i} is overlapped with window ${j}`);
+        }
     }
 }

--- a/test/provider/utils/isOverlappedWith.ts
+++ b/test/provider/utils/isOverlappedWith.ts
@@ -6,11 +6,5 @@ export async function isOverlappedWith(win1: Window, win2: Window) {
     const bounds1 = await getBounds(win1);
     const bounds2 = await getBounds(win2);
 
-    bounds1.right = bounds1.right || bounds1.left + bounds1.width;
-    bounds1.bottom = bounds1.bottom || bounds1.top + bounds1.height;
-
-    bounds2.right = bounds2.right || bounds2.left + bounds2.width;
-    bounds2.bottom = bounds2.bottom || bounds2.top + bounds2.height;
-
-    return !(bounds2.left > bounds1.right || bounds2.right < bounds1.left || bounds2.top > bounds1.bottom || bounds2.bottom < bounds1.top);
+    return !(bounds2.left >= bounds1.right || bounds2.right <= bounds1.left || bounds2.top >= bounds1.bottom || bounds2.bottom <= bounds1.top);
 }


### PR DESCRIPTION
Adjusted the projector logic so it now includes windows within the anchor distance when determining new bounds. 

Note: the distance at which a window is snapped has not changed, just the windows we consider when doing overlap checks.