### PR TITLE
[SERVICE-286] Add layout schema versioning

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -86,7 +86,12 @@ export interface Layout {
     type: 'layout';
 
     /**
-     * TODO: document this
+     * Used to determine compatability of generated layouts when restoring on different versions of the service.
+     * 
+     * Any layout JSON produced by the service will contain a schema version number. This is a separate version number 
+     * from the service itself, and is incremented only on any change sto the JSON format.
+     * 
+     * The version string follows [semver conventions](https://semver.org), and any breaking changes to the schema will always coincide with a major version increment.
      */
     schemaVersion: string;
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -87,11 +87,12 @@ export interface Layout {
 
     /**
      * Used to determine compatability of generated layouts when restoring on different versions of the service.
-     * 
-     * Any layout JSON produced by the service will contain a schema version number. This is a separate version number 
+     *
+     * Any layout JSON produced by the service will contain a schema version number. This is a separate version number
      * from the service itself, and is incremented only on any change sto the JSON format.
-     * 
-     * The version string follows [semver conventions](https://semver.org), and any breaking changes to the schema will always coincide with a major version increment.
+     *
+     * The version string follows [semver conventions](https://semver.org), and any breaking changes to the schema will
+     * always coincide with a major version increment.
      */
     schemaVersion: string;
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -86,6 +86,11 @@ export interface Layout {
     type: 'layout';
 
     /**
+     * TODO: document this
+     */
+    schemaVersion: string;
+
+    /**
      * Stores details about any connected monitors.
      *
      * Note: This data isn't yet used by the service, it is here to allow for future improvements to the workspaces

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -86,10 +86,10 @@ export interface Layout {
     type: 'layout';
 
     /**
-     * Used to determine compatability of generated layouts when restoring on different versions of the service.
+     * Used to determine compatibility of generated layouts when restoring on different versions of the service.
      *
      * Any layout JSON produced by the service will contain a schema version number. This is a separate version number
-     * from the service itself, and is incremented only on any change sto the JSON format.
+     * from the service itself, and is incremented only on any changes to the JSON format.
      *
      * The version string follows [semver conventions](https://semver.org), and any breaking changes to the schema will
      * always coincide with a major version increment.

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -12,6 +12,8 @@ import {promiseMap} from '../snapanddock/utils/async';
 import {getGroup} from './group';
 import {addToWindowObject, inWindowObject, wasCreatedFromManifest, wasCreatedProgrammatically, WindowObject} from './utils';
 
+export const LAYOUTS_SCHEMA_VERSION = '1.0.0';
+
 const deregisteredWindows: WindowObject = {};
 
 /**
@@ -144,7 +146,7 @@ export const getCurrentLayout = async(): Promise<Layout> => {
     console.log('Pre-Layout Save Apps:', apps);
     console.log('Post-Layout Valid Apps:', validApps);
 
-    const layoutObject: Layout = {type: 'layout', apps: validApps, monitorInfo, tabGroups: filteredTabGroups};
+    const layoutObject: Layout = {type: 'layout', schemaVersion: LAYOUTS_SCHEMA_VERSION, apps: validApps, monitorInfo, tabGroups: filteredTabGroups};
     return layoutObject;
 };
 

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -10,9 +10,9 @@ import {WindowIdentity} from '../model/DesktopWindow';
 import {promiseMap} from '../snapanddock/utils/async';
 
 import {getGroup} from './group';
-import {addToWindowObject, inWindowObject, wasCreatedFromManifest, wasCreatedProgrammatically, WindowObject, parseVersionString} from './utils';
+import {addToWindowObject, inWindowObject, parseVersionString, wasCreatedFromManifest, wasCreatedProgrammatically, WindowObject} from './utils';
 
-// This value should be updated any time changes are made to the layout schema. 
+// This value should be updated any time changes are made to the layout schema.
 // Major version indicates breaking changes.
 export const LAYOUTS_SCHEMA_VERSION = '1.0.0';
 export const SCHEMA_MAJOR_VERSION = parseVersionString(LAYOUTS_SCHEMA_VERSION).major;

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -10,9 +10,12 @@ import {WindowIdentity} from '../model/DesktopWindow';
 import {promiseMap} from '../snapanddock/utils/async';
 
 import {getGroup} from './group';
-import {addToWindowObject, inWindowObject, wasCreatedFromManifest, wasCreatedProgrammatically, WindowObject} from './utils';
+import {addToWindowObject, inWindowObject, wasCreatedFromManifest, wasCreatedProgrammatically, WindowObject, parseVersionString} from './utils';
 
+// This value should be updated any time changes are made to the layout schema. 
+// Major version indicates breaking changes.
 export const LAYOUTS_SCHEMA_VERSION = '1.0.0';
+export const SCHEMA_MAJOR_VERSION = parseVersionString(LAYOUTS_SCHEMA_VERSION).major;
 
 const deregisteredWindows: WindowObject = {};
 

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -9,7 +9,7 @@ import {promiseMap} from '../snapanddock/utils/async';
 
 import {LAYOUTS_SCHEMA_VERSION, SCHEMA_MAJOR_VERSION} from './create';
 import {regroupLayout} from './group';
-import {addToWindowObject, childWindowPlaceholderCheck, childWindowPlaceholderCheckRunningApp, createNormalPlaceholder, createTabbedPlaceholderAndRecord, inWindowObject, parseVersionString, positionWindow, TabbedPlaceholders, wasCreatedProgrammatically, WindowObject} from './utils';
+import {addToWindowObject, childWindowPlaceholderCheck, childWindowPlaceholderCheckRunningApp, createNormalPlaceholder, createTabbedPlaceholderAndRecord, inWindowObject, parseVersionString, positionWindow, TabbedPlaceholders, wasCreatedProgrammatically, WindowObject, SchemaVersion} from './utils';
 
 const appsToRestore = new Map();
 const appsCurrentlyRestoring = new Map();
@@ -64,11 +64,11 @@ export const restoreLayout = async(payload: Layout, identity: Identity): Promise
         throw new Error('Received invalid layout object: layout.schemaVersion is undefined');
     } else {
         try {
-            const providedSchemaVersion = parseVersionString(payload.schemaVersion);
-            // Only checks major version. Serivce is assumed to work with minor and patch version changes.
+            const providedSchemaVersion: SchemaVersion = parseVersionString(payload.schemaVersion);
+            // Only checks major version. Service is assumed to work with minor and patch version changes.
             if (providedSchemaVersion.major > SCHEMA_MAJOR_VERSION) {
                 throw new Error(`Received incompatible layout object. Provided schemaVersion is ${
-                    payload.schemaVersion}, but the service only supports versions ${SCHEMA_MAJOR_VERSION}.x.x`);
+                    payload.schemaVersion}, but this version of the service only supports versions up to ${SCHEMA_MAJOR_VERSION}.x.x`);
             }
         } catch (e) {
             if (e.message.includes('semver')) {

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -9,7 +9,7 @@ import {promiseMap} from '../snapanddock/utils/async';
 
 import {LAYOUTS_SCHEMA_VERSION, SCHEMA_MAJOR_VERSION} from './create';
 import {regroupLayout} from './group';
-import {addToWindowObject, childWindowPlaceholderCheck, childWindowPlaceholderCheckRunningApp, createNormalPlaceholder, createTabbedPlaceholderAndRecord, inWindowObject, parseVersionString, positionWindow, TabbedPlaceholders, wasCreatedProgrammatically, WindowObject, SchemaVersion} from './utils';
+import {addToWindowObject, childWindowPlaceholderCheck, childWindowPlaceholderCheckRunningApp, createNormalPlaceholder, createTabbedPlaceholderAndRecord, inWindowObject, parseVersionString, positionWindow, TabbedPlaceholders, wasCreatedProgrammatically, WindowObject, Semver} from './utils';
 
 const appsToRestore = new Map();
 const appsCurrentlyRestoring = new Map();
@@ -63,18 +63,20 @@ export const restoreLayout = async(payload: Layout, identity: Identity): Promise
     if (!payload.schemaVersion) {
         throw new Error('Received invalid layout object: layout.schemaVersion is undefined');
     } else {
+        let providedSchemaVersion: Semver;
         try {
-            const providedSchemaVersion: SchemaVersion = parseVersionString(payload.schemaVersion);
-            // Only checks major version. Service is assumed to work with minor and patch version changes.
-            if (providedSchemaVersion.major > SCHEMA_MAJOR_VERSION) {
-                throw new Error(`Received incompatible layout object. Provided schemaVersion is ${
-                    payload.schemaVersion}, but this version of the service only supports versions up to ${SCHEMA_MAJOR_VERSION}.x.x`);
-            }
+            providedSchemaVersion = parseVersionString(payload.schemaVersion);
         } catch (e) {
             if (e.message.includes('semver')) {
                 throw new Error('Received invalid layout object: schemaVersion string does not comply with semver format ("a.b.c")');
             }
             throw new Error('Unexpected error restoring layout: ' + e.message);
+        }
+
+        // Only checks major version. Service is assumed to work with minor and patch version changes.
+        if (providedSchemaVersion.major > SCHEMA_MAJOR_VERSION) {
+            throw new Error(`Received incompatible layout object. Provided schemaVersion is ${
+                payload.schemaVersion}, but this version of the service only supports versions up to ${SCHEMA_MAJOR_VERSION}.x.x`);
         }
     }
 

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -7,9 +7,9 @@ import {apiHandler, model, tabService} from '../main';
 import {DesktopSnapGroup} from '../model/DesktopSnapGroup';
 import {promiseMap} from '../snapanddock/utils/async';
 
-import {LAYOUTS_SCHEMA_VERSION, SCHEMA_MAJOR_VERSION} from './create';
+import {SCHEMA_MAJOR_VERSION} from './create';
 import {regroupLayout} from './group';
-import {addToWindowObject, childWindowPlaceholderCheck, childWindowPlaceholderCheckRunningApp, createNormalPlaceholder, createTabbedPlaceholderAndRecord, inWindowObject, parseVersionString, positionWindow, TabbedPlaceholders, wasCreatedProgrammatically, WindowObject, Semver} from './utils';
+import {addToWindowObject, childWindowPlaceholderCheck, childWindowPlaceholderCheckRunningApp, createNormalPlaceholder, createTabbedPlaceholderAndRecord, inWindowObject, parseVersionString, positionWindow, SemVer, TabbedPlaceholders, wasCreatedProgrammatically, WindowObject} from './utils';
 
 const appsToRestore = new Map();
 const appsCurrentlyRestoring = new Map();
@@ -63,14 +63,11 @@ export const restoreLayout = async(payload: Layout, identity: Identity): Promise
     if (!payload.schemaVersion) {
         throw new Error('Received invalid layout object: layout.schemaVersion is undefined');
     } else {
-        let providedSchemaVersion: Semver;
+        let providedSchemaVersion: SemVer;
         try {
             providedSchemaVersion = parseVersionString(payload.schemaVersion);
         } catch (e) {
-            if (e.message.includes('semver')) {
-                throw new Error('Received invalid layout object: schemaVersion string does not comply with semver format ("a.b.c")');
-            }
-            throw new Error('Unexpected error restoring layout: ' + e.message);
+            throw new Error('Received invalid layout object: schemaVersion string does not comply with semver format ("a.b.c")');
         }
 
         // Only checks major version. Service is assumed to work with minor and patch version changes.

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -7,7 +7,7 @@ import {model, tabService} from '../main';
 import {DesktopSnapGroup} from '../model/DesktopSnapGroup';
 import {WindowIdentity} from '../model/DesktopWindow';
 
-export interface SchemaVersion {
+export interface Semver {
     major: number;
     minor: number;
     patch: number;
@@ -227,7 +227,7 @@ export async function childWindowPlaceholderCheckRunningApp(
     }
 }
 
-export function parseVersionString(versionString: string): SchemaVersion {
+export function parseVersionString(versionString: string): Semver {
     const match = /([1-9]+)\.([0-9]+)\.([0-9]+)/.exec(versionString);
     if (!match) {
         throw new Error('Invalid version string. Must be in semver format ("a.b.c")');

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -7,7 +7,7 @@ import {model, tabService} from '../main';
 import {DesktopSnapGroup} from '../model/DesktopSnapGroup';
 import {WindowIdentity} from '../model/DesktopWindow';
 
-export interface Semver {
+export interface SemVer {
     major: number;
     minor: number;
     patch: number;
@@ -227,7 +227,7 @@ export async function childWindowPlaceholderCheckRunningApp(
     }
 }
 
-export function parseVersionString(versionString: string): Semver {
+export function parseVersionString(versionString: string): SemVer {
     const match = /([1-9]+)\.([0-9]+)\.([0-9]+)/.exec(versionString);
     if (!match) {
         throw new Error('Invalid version string. Must be in semver format ("a.b.c")');

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -7,6 +7,12 @@ import {model, tabService} from '../main';
 import {DesktopSnapGroup} from '../model/DesktopSnapGroup';
 import {WindowIdentity} from '../model/DesktopWindow';
 
+export interface SchemaVersion {
+    major: number;
+    minor: number;
+    patch: number;
+}
+
 // Positions a window when it is restored.
 export const positionWindow = async (win: LayoutWindow) => {
     try {
@@ -221,11 +227,11 @@ export async function childWindowPlaceholderCheckRunningApp(
     }
 }
 
-export function parseVersionString(versionString: string) {
+export function parseVersionString(versionString: string): SchemaVersion {
     const match = /([1-9]+)\.([0-9]+)\.([0-9]+)/.exec(versionString);
     if (!match) {
         throw new Error('Invalid version string. Must be in semver format ("a.b.c")');
     }
 
-    return {major: match[1], minor: match[2], patch: match[3]};
+    return {major: Number.parseInt(match[1], 10), minor: Number.parseInt(match[2], 10), patch: Number.parseInt(match[3], 10)};
 }

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -220,3 +220,12 @@ export async function childWindowPlaceholderCheckRunningApp(
         return;
     }
 }
+
+export function parseVersionString(versionString: string) {
+    const match = /([1-9]+)\.([0-9]+)\.([0-9]+)/.exec(versionString);
+    if (!match) {
+        throw new Error('Invalid version string. Must be in semver format ("a.b.c")');
+    }
+
+    return {major: match[1], minor: match[2], patch: match[3]};
+}

--- a/test/demo/worspaces/schemaVersion.test.ts
+++ b/test/demo/worspaces/schemaVersion.test.ts
@@ -23,6 +23,7 @@ testParameterized(
     async (t, testOptions: SchemaVersionTestOptions) => {
         const layoutToRestore = {...layoutBase, schemaVersion: testOptions.versionString};
 
+        // This should be replaced with a proper client call once SERVICE-200 is merged (it has the import logic)
         const restorePromise = sendServiceMessage<Layout, Layout>('restoreLayout', layoutToRestore as Layout);
         if (testOptions.shouldError) {
             await t.throws(restorePromise);

--- a/test/demo/worspaces/schemaVersion.test.ts
+++ b/test/demo/worspaces/schemaVersion.test.ts
@@ -1,0 +1,40 @@
+import {MonitorInfo} from 'hadouken-js-adapter/out/types/src/api/system/monitor';
+
+import {Layout} from '../../../src/client/types';
+import {testParameterized} from '../utils/parameterizedTestUtils';
+import {sendServiceMessage} from '../utils/serviceUtils';
+
+interface SchemaVersionTestOptions {
+    versionString: string|undefined;
+    shouldError: boolean;
+}
+
+testParameterized(
+    (testOptions: SchemaVersionTestOptions) =>
+        `Layout schemaVersion tests - versionString: "${testOptions.versionString}" - expected ${testOptions.shouldError ? '' : 'not '}to error`,
+    [
+        {versionString: '1.0.0', shouldError: false},
+        {versionString: '1.3.2', shouldError: false},
+        {versionString: '2.0.0', shouldError: true},
+        {versionString: '9.61.37.37', shouldError: true},
+        {versionString: 'invalid string', shouldError: true},
+        {versionString: undefined, shouldError: true},
+    ],
+    async (t, testOptions: SchemaVersionTestOptions) => {
+        const layoutToRestore = {...layoutBase, schemaVersion: testOptions.versionString};
+
+        const restorePromise = sendServiceMessage<Layout, Layout>('restoreLayout', layoutToRestore as Layout);
+        if (testOptions.shouldError) {
+            await t.throws(restorePromise);
+        } else {
+            await t.notThrows(restorePromise);
+        }
+    });
+
+const layoutBase: Layout = {
+    'apps': [],
+    'monitorInfo': {} as MonitorInfo,
+    'schemaVersion': '',
+    'tabGroups': [],
+    'type': 'layout'
+};


### PR DESCRIPTION
Added versioning to layout objects generated by the service. 

When `restoreLayout` is called, the version in the provided object is checked against a hard-coded version in `create.ts` (separate to the service version) and will error if they are not compatible.