### PR TITLE
[SERVICE-300] Upgrade to runtime 37, remove 'emulateDragEvents' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This project consist of 3 parts:
 3. Layout Service Demo app, demonstrating the different features of OpenFin Layout
 
 ### Dependencies
-- OpenFin version for applications using Layouts = 9.61.36.36
-- OpenFin version used in the Layouts Service = 9.61.36.36
+- OpenFin version for applications using Layouts = 9.61.37.42
+- OpenFin version used in the Layouts Service = 9.61.37.42
 - RVM >= 4.4.1.1
 
 ### Features

--- a/res/demo/app.json
+++ b/res/demo/app.json
@@ -14,7 +14,7 @@
     },
     "runtime": {
         "arguments": "--v=1 --enable-crash-reporting --inspect=9222 --enable-aggressive-domstorage-flushing",
-        "version": "9.61.36.36"
+        "version": "9.61.37.42"
     },
     "services": [{"name": "layouts", "manifestUrl": "http://localhost:1337/provider/app.json"}],
     "shortcut": {

--- a/res/demo/app2.json
+++ b/res/demo/app2.json
@@ -13,7 +13,7 @@
     },
     "runtime": {
         "arguments": "--v=1 --enable-crash-reporting",
-        "version": "9.61.36.36"
+        "version": "9.61.37.42"
     },
     "services": [{"name": "layouts", "manifestUrl": "http://localhost:1337/provider/app.json"}]
 }

--- a/res/demo/app3.json
+++ b/res/demo/app3.json
@@ -13,7 +13,7 @@
     },
     "runtime": {
         "arguments": "--v=1 --enable-crash-reporting",
-        "version": "9.61.36.36"
+        "version": "9.61.37.42"
     },
     "services": [{"name": "layouts", "manifestUrl": "http://localhost:1337/provider/app.json"}]
 }

--- a/res/provider/app.json
+++ b/res/provider/app.json
@@ -14,6 +14,6 @@
     },
     "runtime": {
         "arguments": "--enable-aggressive-domstorage-flushing --high-dpi-support=1 --force-device-scale-factor=1",
-        "version": "9.61.36.36"
+        "version": "9.61.37.42"
     }
 }

--- a/res/provider/app.json
+++ b/res/provider/app.json
@@ -13,7 +13,7 @@
         "enableAppLogging": true
     },
     "runtime": {
-        "arguments": "--enable-aggressive-domstorage-flushing --high-dpi-support=1 --force-device-scale-factor=1",
+        "arguments": "--enable-aggressive-domstorage-flushing --high-dpi-support=1 --force-device-scale-factor=1 --disabled-frame-groups",
         "version": "9.61.37.42"
     }
 }

--- a/res/test/app.json
+++ b/res/test/app.json
@@ -1,7 +1,7 @@
 {
     "devtools_port": 9090,
     "runtime": {
-        "arguments": "--v=1 --enable-crash-reporting",
+        "arguments": "--v=1 --enable-crash-reporting --disabled-frame-groups",
         "version": "9.61.37.42"
     },
     "services":[{"name": "layouts", "manifestUrl": "http://localhost:1337/test/provider.json"}],

--- a/res/test/app.json
+++ b/res/test/app.json
@@ -2,7 +2,7 @@
     "devtools_port": 9090,
     "runtime": {
         "arguments": "--v=1 --enable-crash-reporting",
-        "version": "9.61.36.36"
+        "version": "9.61.37.42"
     },
     "services":[{"name": "layouts", "manifestUrl": "http://localhost:1337/test/provider.json"}],
     "startup_app": {

--- a/res/test/deregisteredApp1.json
+++ b/res/test/deregisteredApp1.json
@@ -2,7 +2,7 @@
     "devtools_port": 9090,
     "runtime": {
         "arguments": "--v=1 --enable-crash-reporting",
-        "version": "9.61.36.36"
+        "version": "9.61.37.42"
     },
     "services":[{"name": "layouts", "manifestUrl": "http://localhost:1337/test/provider.json"}],
     "startup_app": {

--- a/res/test/deregisteredApp2.json
+++ b/res/test/deregisteredApp2.json
@@ -2,7 +2,7 @@
     "devtools_port": 9090,
     "runtime": {
         "arguments": "--v=1 --enable-crash-reporting",
-        "version": "9.61.36.36"
+        "version": "9.61.37.42"
     },
     "services":[{"name": "layouts", "manifestUrl": "http://localhost:1337/test/provider.json"}],
     "startup_app": {

--- a/res/test/provider.json
+++ b/res/test/provider.json
@@ -20,7 +20,7 @@
         ]
     },
   "runtime": {
-    "arguments": "--v=1 --enable-crash-reporting",
+    "arguments": "--v=1 --enable-crash-reporting --disabled-frame-groups",
     "version": "9.61.37.42"
   },
     "shortcut": {}

--- a/res/test/provider.json
+++ b/res/test/provider.json
@@ -21,7 +21,7 @@
     },
   "runtime": {
     "arguments": "--v=1 --enable-crash-reporting",
-    "version": "9.61.36.36"
+    "version": "9.61.37.42"
   },
     "shortcut": {}
 }

--- a/res/test/registeredApp1.json
+++ b/res/test/registeredApp1.json
@@ -2,7 +2,7 @@
     "devtools_port": 9090,
     "runtime": {
         "arguments": "--v=1 --enable-crash-reporting",
-        "version": "9.61.36.36"
+        "version": "9.61.37.42"
     },
     "services":[{"name": "layouts", "manifestUrl": "http://localhost:1337/test/provider.json"}],
     "startup_app": {

--- a/res/test/registeredApp2.json
+++ b/res/test/registeredApp2.json
@@ -2,7 +2,7 @@
     "devtools_port": 9090,
     "runtime": {
         "arguments": "--v=1 --enable-crash-reporting",
-        "version": "9.61.36.36"
+        "version": "9.61.37.42"
     },
     "services":[{"name": "layouts", "manifestUrl": "http://localhost:1337/test/provider.json"}],
     "startup_app": {

--- a/src/provider/main.ts
+++ b/src/provider/main.ts
@@ -27,9 +27,6 @@ fin.desktop.main(main);
 interface SupportedArguments {
     disableTabbingOperations: boolean;
     disableDockingOperations: boolean;
-    emulateDragEvents: boolean;
-    disableBoundsDelay: number;
-    disableBoundsRateLimit: number;
 }
 type Stringified<T> = {
     [P in keyof T]?: string;
@@ -66,15 +63,6 @@ export async function main() {
             }
             if (args.disableDockingOperations) {
                 snapService.disableDockingOperations = args.disableDockingOperations === 'true';
-            }
-            if (args.emulateDragEvents) {
-                DesktopWindow.emulateDragEvents = args.emulateDragEvents === 'true';
-            }
-            if (args.disableBoundsDelay) {
-                DesktopWindow.disableBoundsDelay = Number.parseInt(args.disableBoundsDelay, 10);
-            }
-            if (args.disableBoundsRateLimit) {
-                DesktopWindow.disableBoundsRateLimit = Number.parseInt(args.disableBoundsRateLimit, 10);
             }
         }
     }

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -29,7 +29,6 @@ export interface WindowState extends Rectangle {
     resizeConstraints: Point<ResizeConstraint>;
 
     opacity: number;
-    frameEnabled: boolean;  // If window will respond to move/resize events. Corresponds to enable/disableFrame, not WindowOptions.frame.
 
     alwaysOnTop: boolean;
 }
@@ -114,40 +113,6 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
     public static readonly onCreated: Signal1<DesktopWindow> = new Signal1();
     public static readonly onDestroyed: Signal1<DesktopWindow> = new Signal1();
 
-    /**
-     * Flag to enable special behaviour in environments where the Windows "Show window contents while dragging"
-     * performance option is disabled.
-     *
-     * Will enable 'disableFrame()' on each window registered with the service, and handle all window movements
-     * programatically.
-     */
-    public static emulateDragEvents = false;
-
-    /**
-     * When in 'emulateDragEvents' mode, the service needs to call disableFrame on every window that is registered
-     * with the service. However, this may cause issues with applications that are already using 'disableFrame'.
-     *
-     * Service assumes that any window that uses disableFrame will call it immediately after creating the window. If
-     * disableFrame() has not been called after waiting this many milliseconds, the service assumes it can take control
-     * of disabling the frame and moving/resizing the window.
-     */
-    public static disableBoundsDelay = 500;
-
-    /**
-     * When in 'emulateDragEvents' mode the service needs to programatically move each window. This can result in a
-     * lot of messages being passed through the core, which may degrade performance.
-     *
-     * This parameter limits the rate at which a window can be moved - the service will perform no more than this many
-     * window updates per second.
-     */
-    public static disableBoundsRateLimit = 30;
-
-    /**
-     * Service is blocked from moving a 'disableFrame' window until after this time (see DISABLE_BOUNDS_RATE_LIMIT)
-     */
-    private static nextMoveTime = 0;
-
-
     public static async getWindowState(window: Window): Promise<WindowState> {
         return Promise.all([window.getOptions(), window.isShowing(), window.getBounds()])
             .then((results: [fin.WindowOptions, boolean, fin.WindowBounds]): WindowState => {
@@ -190,7 +155,6 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
                     title: options.name!,
                     showTaskbarIcon: options.showTaskbarIcon!,
                     opacity: options.opacity!,
-                    frameEnabled: true,  // No way to query frame enabled/disabled state from API. Assume frame is enabled
                     alwaysOnTop: options.alwaysOnTop!
                 };
             });
@@ -361,7 +325,6 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
                 y: {minSize: 0, maxSize: Number.MAX_SAFE_INTEGER, resizableMin: true, resizableMax: true}
             },
             opacity: 1,
-            frameEnabled: true,
             alwaysOnTop: false
         };
     }
@@ -620,7 +583,7 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
         // Apply changes to the window (unless we're reacting to an external change that has already happened)
         if (origin !== ActionOrigin.APPLICATION) {
             const window = this.window;
-            const {center, halfSize, state, hidden, frameEnabled, ...options} = delta;
+            const {center, halfSize, state, hidden, ...options} = delta;
             const optionsToChange: (keyof WindowState)[] = Object.keys(options) as (keyof WindowState)[];
 
             // Apply visibility
@@ -644,11 +607,6 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
                         console.warn('Invalid window state: ' + state);
                         break;
                 }
-            }
-
-            // Apply window frame
-            if (frameEnabled !== undefined) {
-                actions.push(frameEnabled ? window.enableFrame() : window.disableFrame());
             }
 
             // Apply bounds
@@ -735,17 +693,7 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
         this.registerListener('bounds-changed', this.handleBoundsChanged.bind(this));
         this.registerListener('bounds-changing', this.handleBoundsChanging.bind(this));
         this.registerListener('closed', this.handleClosed.bind(this));
-        this.registerListener('disabled-frame-bounds-changed', this.handleDisabledFrameBoundsChanged.bind(this));
-        this.registerListener('disabled-frame-bounds-changing', this.handleDisabledFrameBoundsChanging.bind(this));
         this.registerListener('focused', this.handleFocused.bind(this));
-        this.registerListener('frame-disabled', () => {
-            this.updateState({frameEnabled: false}, ActionOrigin.APPLICATION);
-            this.onModified.emit(this);
-        });
-        this.registerListener('frame-enabled', () => {
-            this.updateState({frameEnabled: true}, ActionOrigin.APPLICATION);
-            this.onModified.emit(this);
-        });
         this.registerListener('group-changed', this.handleGroupChanged.bind(this));
         this.registerListener('hidden', () => this.updateState({hidden: true}, ActionOrigin.APPLICATION));
         this.registerListener('maximized', () => {
@@ -774,39 +722,6 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
             });
         });
         this.registerListener('shown', () => this.updateState({hidden: false}, ActionOrigin.APPLICATION));
-
-        if (DesktopWindow.emulateDragEvents) {
-            function disableFrame(this: DesktopWindow) {
-                // Check window hasn't been closed/de-registered whilst we were waiting
-                const isRegistered: boolean = this.model.getWindow(this.id) !== null || !DesktopWindow.disableBoundsDelay;
-
-                if (isRegistered && this.windowState.frameEnabled) {
-                    console.log('Disabling frame on ' + this.id);
-
-                    // Application isn't using 'disableFrame', safe for the service to enable it on behalf of the application
-                    this.applyProperties({frameEnabled: false});
-
-                    // Re-enable the frame if window window gets de-registered in the future
-                    this.onTeardown.add(window => {
-                        if (window.ready) {
-                            window.window.enableFrame().catch(console.warn);
-                        }
-                    });
-                } else if (isRegistered) {
-                    console.log('Window has already disabled its frame ' + this.id);
-                } else {
-                    console.log('Window deregistered before frame check could occur ' + this.id);
-                }
-            }
-
-            if (this.identity.uuid === SERVICE_IDENTITY.uuid || !DesktopWindow.disableBoundsDelay) {
-                // Can disable frame on tabstrips immediately, without waiting to see what application does.
-                disableFrame.call(this);
-            } else {
-                // Wait and see what the application does, and then disable frame only if application hasn't already.
-                setTimeout(disableFrame.bind(this), DesktopWindow.disableBoundsDelay);
-            }
-        }
     }
 
     private registerListener<K extends keyof fin.OpenFinWindowEventMap>(eventType: K, handler: (event: fin.OpenFinWindowEventMap[K]) => void) {
@@ -851,38 +766,6 @@ export class DesktopWindow extends DesktopEntity implements Snappable {
         if (this.userInitiatedBoundsChange) {
             this.onTransform.emit(this, this.getTransformType(event));
         }
-    }
-
-    private handleDisabledFrameBoundsChanged(event: fin.WindowBoundsEvent): void {
-        const bounds: fin.WindowBounds = this.checkBounds(event);
-        const halfSize: Point = {x: bounds.width / 2, y: bounds.height / 2};
-        const center: Point = {x: bounds.left + halfSize.x, y: bounds.top + halfSize.y};
-
-        if (this.applicationState.frameEnabled) {
-            // Service must move the window, as application (presumably) won't have registered any 'disabled-*' listeners registered
-            this.updateState({center, halfSize}, ActionOrigin.SERVICE);
-        }
-
-        // Assume that all disabled-frame-bounds-* events are user-initiated
-        this.onCommit.emit(this, this.getTransformType(event));
-    }
-
-    private handleDisabledFrameBoundsChanging(event: fin.WindowBoundsEvent): void {
-        const bounds: fin.WindowBounds = this.checkBounds(event);
-        const halfSize: Point = {x: bounds.width / 2, y: bounds.height / 2};
-        const center: Point = {x: bounds.left + halfSize.x, y: bounds.top + halfSize.y};
-
-        if (this.applicationState.frameEnabled) {
-            // Service must move the window, as application (presumably) won't have registered any 'disabled-*' listeners registered
-            const now: number = Date.now();
-            if (now >= DesktopWindow.nextMoveTime) {
-                DesktopWindow.nextMoveTime = now + (1000 / DesktopWindow.disableBoundsRateLimit);
-                this.updateState({center, halfSize}, ActionOrigin.SERVICE);
-            }
-        }
-
-        // Assume that all disabled-frame-bounds-* events are user-initiated
-        this.onTransform.emit(this, this.getTransformType(event));
     }
 
     private getTransformType(event: fin.WindowBoundsEvent): Mask<eTransformType> {

--- a/src/provider/snapanddock/SnapService.ts
+++ b/src/provider/snapanddock/SnapService.ts
@@ -71,7 +71,7 @@ export class SnapService {
             .catch(console.error);
     }
 
-    public undock(target: WindowIdentity): void {
+    public async undock(target: WindowIdentity): Promise<void> {
         const window: DesktopWindow|null = this.model.getWindow(target);
 
         // Do nothing for tabbed windows until tab/snap is properly integrated
@@ -88,7 +88,7 @@ export class SnapService {
                 }
 
                 // Move window to it's own group, whilst applying offset
-                window.dockToGroup(new DesktopSnapGroup(), offset);
+                await window.dockToGroup(new DesktopSnapGroup(), offset);
             } catch (error) {
                 console.error(`Unexpected error when undocking window: ${error}`);
                 throw new Error(`Unexpected error when undocking window: ${error}`);

--- a/test/demo/snapanddock/resizeSnapGroup.test.ts
+++ b/test/demo/snapanddock/resizeSnapGroup.test.ts
@@ -15,12 +15,12 @@ testParameterized(
         `Resize SnapGroup - ${testOptions.windowCount} windows - ${testOptions.frame ? 'framed' : 'frameless'} - ${testOptions.resizeType.join('-')} resize`,
     [
         // These two tests are passing, but for the wrong reasons. Should be revisited once win10 bounds fix is in place.
-        {frame: true, windowCount: 2, resizeType: ['inner', 'horizontal'], skip: true},
-        {frame: true, windowCount: 2, resizeType: ['inner', 'vertical'], skip: true},
+        {frame: true, windowCount: 2, resizeType: ['inner', 'horizontal']},
+        {frame: true, windowCount: 2, resizeType: ['inner', 'vertical']},
         {frame: true, windowCount: 2, resizeType: ['outer', 'horizontal']},
         {frame: true, windowCount: 2, resizeType: ['outer', 'vertical']},
-        {frame: true, windowCount: 4, resizeType: ['inner', 'horizontal'], failing: true},
-        {frame: true, windowCount: 4, resizeType: ['inner', 'vertical'], failing: true},
+        {frame: true, windowCount: 4, resizeType: ['inner', 'horizontal']},
+        {frame: true, windowCount: 4, resizeType: ['inner', 'vertical']},
         {frame: true, windowCount: 4, resizeType: ['outer', 'horizontal']},
         {frame: true, windowCount: 4, resizeType: ['outer', 'vertical']},
         {frame: false, windowCount: 2, resizeType: ['inner', 'horizontal']},
@@ -29,8 +29,7 @@ testParameterized(
         {frame: false, windowCount: 2, resizeType: ['outer', 'vertical']},
         {frame: false, windowCount: 4, resizeType: ['inner', 'horizontal']},
         {frame: false, windowCount: 4, resizeType: ['inner', 'vertical']},
-        // Runs fine locally, but consistently fails when running on CI. Needs further investigation:
-        {frame: false, windowCount: 4, resizeType: ['outer', 'horizontal'], skip: true},
+        {frame: false, windowCount: 4, resizeType: ['outer', 'horizontal']},
         {frame: false, windowCount: 4, resizeType: ['outer', 'vertical']},
     ],
     createWindowTest(async (t, testOptions: ResizeGroupOptions) => {

--- a/test/demo/tabbing/createTabFromMultipleWindows.test.ts
+++ b/test/demo/tabbing/createTabFromMultipleWindows.test.ts
@@ -22,8 +22,8 @@ test.afterEach.always(async () => {
 
 test('Create tab group from 2 windows', async (assert) => {
     // Arrange
-    const app1: Application = await createTabbingWindow('default', 'App0', 200);
-    const app2: Application = await createTabbingWindow('default', 'App1', 500);
+    const app1: Application = await createTabbingWindow('default', 'tabapp1', 200);
+    const app2: Application = await createTabbingWindow('default', 'tabapp2', 500);
 
     await Promise.all([app1.run(), app2.run()]);
 
@@ -95,7 +95,7 @@ test('Create tab group from 2 windows', async (assert) => {
  */
 async function createTabbingWindow(page: string, uuid: string, left: number): Promise<Application> {
     return fin.Application.create({
-        url: `http://localhost:1337/demo/tabbing/App/${page}.html`,
+        url: `http://localhost:1337/demo/tabbing/${page}.html`,
         uuid,
         name: uuid,
         mainWindowOptions: {

--- a/test/provider/nativeGroupListeners.test.ts
+++ b/test/provider/nativeGroupListeners.test.ts
@@ -161,10 +161,7 @@ function runNativeGroupListenerTest(groupType: GroupingType, firstUngroupType: U
         });
 }
 
-test.failing('Native window group works the same as snapService grouping  (native merge, undock, native, 1)', async t => {
-    // FAILING - Runtime behaviour: native group merge does not raise an event
-    // when grouping two ungrouped windows
-
+test('Native window group works the same as snapService grouping  (native merge, undock, native, 1)', async t => {
     // Native group the windows
     win1.mergeGroups(win2);
 

--- a/test/provider/nativeGroupListeners.test.ts
+++ b/test/provider/nativeGroupListeners.test.ts
@@ -161,7 +161,10 @@ function runNativeGroupListenerTest(groupType: GroupingType, firstUngroupType: U
         });
 }
 
-test('Native window group works the same as snapService grouping  (native merge, undock, native, 1)', async t => {
+test.failing('Native window group works the same as snapService grouping  (native merge, undock, native, 1)', async t => {
+    // FAILING - Runtime behaviour: native group merge does not raise an event
+    // when grouping two ungrouped windows
+
     // Native group the windows
     win1.mergeGroups(win2);
 

--- a/test/provider/tabOnDragOver.test.ts
+++ b/test/provider/tabOnDragOver.test.ts
@@ -36,7 +36,7 @@ test.beforeEach(async () => {
         defaultLeft: 400,
         defaultHeight: 200,
         defaultWidth: 200,
-        url: 'http://localhost:1337/demo/tabbing/App/default.html',
+        url: 'http://localhost:1337/demo/tabbing/default.html',
         frame: true
     });
     await delay(500);
@@ -79,7 +79,7 @@ test('Drag window into tabgroup - should create 3 tab tabgroup', async t => {
         defaultLeft: 500,
         defaultHeight: 200,
         defaultWidth: 200,
-        url: 'http://localhost:1337/demo/tabbing/App/default.html',
+        url: 'http://localhost:1337/demo/tabbing/default.html',
         frame: true
     });
 
@@ -105,7 +105,7 @@ test('Drag window into tabgroup, invalid region - should not create 3 tab tabgro
         defaultLeft: 50,
         defaultHeight: 200,
         defaultWidth: 200,
-        url: 'http://localhost:1337/demo/tabbing/App/default.html',
+        url: 'http://localhost:1337/demo/tabbing/default.html',
         frame: true
     });
 
@@ -153,7 +153,7 @@ test('Tearout tab dragged into singleton window - should create new tab group', 
         defaultLeft: 500,
         defaultHeight: 200,
         defaultWidth: 200,
-        url: 'http://localhost:1337/demo/tabbing/App/default.html',
+        url: 'http://localhost:1337/demo/tabbing/default.html',
         frame: true
     });
 
@@ -188,7 +188,7 @@ test('Tearout tab dragged into singleton window, invalid ragion - should not cre
         defaultLeft: 500,
         defaultHeight: 200,
         defaultWidth: 200,
-        url: 'http://localhost:1337/demo/tabbing/App/default.html',
+        url: 'http://localhost:1337/demo/tabbing/default.html',
         frame: true
     });
 
@@ -222,7 +222,7 @@ test('test Tearout tab dragged into tab group - should add tab to tabgroup', asy
         defaultLeft: 500,
         defaultHeight: 200,
         defaultWidth: 200,
-        url: 'http://localhost:1337/demo/tabbing/App/default.html',
+        url: 'http://localhost:1337/demo/tabbing/default.html',
         frame: true
     });
 
@@ -233,7 +233,7 @@ test('test Tearout tab dragged into tab group - should add tab to tabgroup', asy
         defaultLeft: 600,
         defaultHeight: 200,
         defaultWidth: 200,
-        url: 'http://localhost:1337/demo/tabbing/App/default.html',
+        url: 'http://localhost:1337/demo/tabbing/default.html',
         frame: true
     });
 
@@ -268,7 +268,7 @@ test('Tearout tab dragged into tab group, invalid region - should not add tab to
         defaultLeft: 500,
         defaultHeight: 200,
         defaultWidth: 200,
-        url: 'http://localhost:1337/demo/tabbing/App/default.html',
+        url: 'http://localhost:1337/demo/tabbing/default.html',
         frame: true
     });
 
@@ -279,7 +279,7 @@ test('Tearout tab dragged into tab group, invalid region - should not add tab to
         defaultLeft: 600,
         defaultHeight: 200,
         defaultWidth: 200,
-        url: 'http://localhost:1337/demo/tabbing/App/default.html',
+        url: 'http://localhost:1337/demo/tabbing/default.html',
         frame: true
     });
 
@@ -340,7 +340,7 @@ test('3 tab tabgroup, Tab closed - should retain tabgroup', async t => {
         defaultLeft: 500,
         defaultHeight: 200,
         defaultWidth: 200,
-        url: 'http://localhost:1337/demo/tabbing/App/default.html',
+        url: 'http://localhost:1337/demo/tabbing/default.html',
         frame: true
     });
 
@@ -366,7 +366,7 @@ test('3 tab tabgroup, Tab tearout - should retain tabgroup', async t => {
         defaultLeft: 500,
         defaultHeight: 200,
         defaultWidth: 200,
-        url: 'http://localhost:1337/demo/tabbing/App/default.html',
+        url: 'http://localhost:1337/demo/tabbing/default.html',
         frame: true
     });
 
@@ -428,7 +428,7 @@ test('Close tab then retab - should create tabgroup', async t => {
         defaultLeft: 500,
         defaultHeight: 200,
         defaultWidth: 200,
-        url: 'http://localhost:1337/demo/tabbing/App/default.html',
+        url: 'http://localhost:1337/demo/tabbing/default.html',
         frame: true
     });
 

--- a/test/provider/updateTabProperties.test.ts
+++ b/test/provider/updateTabProperties.test.ts
@@ -55,8 +55,12 @@ test('Update Tab Properties - property changes reflected in service', async t =>
     t.deepEqual(result, newProps);
 });
 
-
-test('Update Tab Properties - property changes reflected in tabstrip DOM', async t => {
+/**
+ * Cannot access document in Runtime 37+
+ *
+ * TODO: See if there is an alternate way of testing this.
+ */
+test.failing('Update Tab Properties - property changes reflected in tabstrip DOM', async t => {
     // Drag wins[0] over wins[1] to make a tabset (in valid drop region)
     await tabWindowsTogether(wins[0], wins[1]);
 

--- a/test/provider/userBoundsChanging.test.ts
+++ b/test/provider/userBoundsChanging.test.ts
@@ -33,7 +33,7 @@ test.beforeEach(async () => {
         defaultLeft: 400,
         defaultHeight: 200,
         defaultWidth: 200,
-        url: 'http://localhost:1337/demo/tabbing/App/default.html',
+        url: 'http://localhost:1337/demo/tabbing/default.html',
         frame: true
     });
     await delay(500);


### PR DESCRIPTION
Runtime 37 contains a root-cause fix for the issue that the emulateDragEvents mode was added to work-around - and this workaround now causes issues within the service, even when disabled.

This PR simultaneously upgrades to the latest runtime version, and removes the previous work-around.

Note: The runtime used here is still pre-stable, so there may be further updates to come. Doing the upgrade now to prevent further blockers. 