### PR TITLE
[SERVICE-289] Add config schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -126,6 +126,11 @@
         }
       }
     },
+    "@types/cli-color": {
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@types/cli-color/-/cli-color-0.3.29.tgz",
+      "integrity": "sha1-yDpx/gLIx+HM7ASN1qJFjR9sluo="
+    },
     "@types/events": {
       "version": "1.2.0",
       "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
@@ -164,6 +169,11 @@
       "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
       "dev": true
     },
+    "@types/json-schema": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.1.tgz",
+      "integrity": "sha512-NVQEMviDWjuen3UW+mU1J6fZ0WhOfG1yRce/2OTcbaz+fgmTw2cahx6N2wh0Yl+a+hg2UZj/oElZmtULWyGIsA=="
+    },
     "@types/lodash": {
       "version": "4.14.117",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.117.tgz",
@@ -182,10 +192,28 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
+    },
+    "@types/mz": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.32.tgz",
+      "integrity": "sha512-cy3yebKhrHuOcrJGkfwNHhpTXQLgmXSv1BX+4p32j+VUQ6aP2eJ5cL7OvGcAQx75fCTFaAIIAKewvqL+iwSd4g==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "9.6.35",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.35.tgz",
       "integrity": "sha512-h5zvHS8wXHGa+Gcqs9K8vqCgOtqjr0+NqG/DDJmQIX1wpR9HivAfgV8bjcD3mGM4bPfQw5Aneb2Pn8355L83jA=="
+    },
+    "@types/prettier": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.15.2.tgz",
+      "integrity": "sha512-XIB0ZCaFZmWUHAa9dBqP5UKXXHwuukmVlP+XcyU94dui2k+l2lG+CHAbt2ffenHPUqoIs5Beh8Pdf2YEq/CZ7A=="
     },
     "@types/shelljs": {
       "version": "0.8.0",
@@ -442,8 +470,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -453,6 +480,11 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "anymatch": {
       "version": "1.3.2",
@@ -527,7 +559,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -1713,6 +1744,11 @@
         "estraverse": "^4.0.0"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+    },
     "call-signature": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
@@ -1871,6 +1907,19 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
+    },
+    "cli-color": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
+      "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+      "requires": {
+        "ansi-regex": "^2.1.1",
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.14",
+        "timers-ext": "^0.1.5"
+      }
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -2338,6 +2387,14 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "requires": {
+        "es5-ext": "^0.10.9"
+      }
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -2662,11 +2719,51 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es5-ext": {
+      "version": "0.10.46",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
+      "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
+      }
+    },
     "es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2705,8 +2802,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "espurify": {
       "version": "1.8.1",
@@ -2743,6 +2839,15 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "events": {
       "version": "1.1.1",
@@ -3048,6 +3153,11 @@
       "requires": {
         "for-in": "^1.0.1"
       }
+    },
+    "format-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
+      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -4559,8 +4669,7 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -4635,8 +4744,9 @@
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-      "dev": true,
       "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsesc": {
@@ -4651,6 +4761,60 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-schema-ref-parser": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.0.2.tgz",
+      "integrity": "sha512-EENU7mrmuBAdjSsAEJD8mMvodZyDhLBEfuSUBSIMuXqjs+cfMbFaxS8f6+ky675jetRzGzCdhzAU3y2VEtquvQ==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.12.0",
+        "ono": "^4.0.10"
+      }
+    },
+    "json-schema-to-typescript": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-6.1.0.tgz",
+      "integrity": "sha512-tm38r+dliwHwSaxiprTRoq2+6ZIEgIPx6oC+sSaBhqRigKl8OuFdqL2lgB5TV9HivLFiQ89yERp7V+43nwFZdQ==",
+      "requires": {
+        "@types/cli-color": "^0.3.29",
+        "@types/json-schema": "^7.0.1",
+        "@types/lodash": "^4.14.118",
+        "@types/minimist": "^1.2.0",
+        "@types/mz": "0.0.32",
+        "@types/node": "^10.12.6",
+        "@types/prettier": "^1.13.2",
+        "cli-color": "^1.4.0",
+        "json-schema-ref-parser": "^6.0.2",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.11",
+        "minimist": "^1.2.0",
+        "mz": "^2.7.0",
+        "prettier": "^1.15.2",
+        "stdin": "0.0.1"
+      },
+      "dependencies": {
+        "@types/lodash": {
+          "version": "4.14.119",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.119.tgz",
+          "integrity": "sha512-Z3TNyBL8Vd/M9D9Ms2S3LmFq2sSMzahodD6rCS9V2N44HUMINb75jNkSuwAx7eo2ufqTdfOdtGQpNbieUjPQmw=="
+        },
+        "@types/node": {
+          "version": "10.12.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+          "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
     "json5": {
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -4663,6 +4827,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "kind-of": {
@@ -4743,8 +4908,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -4824,18 +4988,6 @@
       "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
       "dev": true
     },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-      "dev": true
-    },
-    "lodash.union": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
-      "dev": true
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4869,6 +5021,14 @@
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "requires": {
+        "es5-ext": "~0.10.2"
       }
     },
     "make-dir": {
@@ -4970,6 +5130,21 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
+    },
+    "memoizee": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
+      "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.45",
+        "es6-weak-map": "^2.0.2",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.1",
+        "lru-queue": "0.1",
+        "next-tick": "1",
+        "timers-ext": "^0.1.5"
+      }
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -5294,6 +5469,16 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "nan": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
@@ -5350,6 +5535,11 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
       "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
       "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -5462,8 +5652,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -5585,6 +5774,14 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "ono": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
+      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
+      "requires": {
+        "format-util": "^1.0.3"
       }
     },
     "optimist": {
@@ -5958,6 +6155,11 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
+    },
+    "prettier": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
+      "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg=="
     },
     "pretty-ms": {
       "version": "3.2.0",
@@ -7224,8 +7426,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "ssri": {
       "version": "5.3.0",
@@ -7268,6 +7469,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
       "dev": true
+    },
+    "stdin": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz",
+      "integrity": "sha1-0wQZgarsPf28d6GzjWNy449ftx4="
     },
     "stream-browserify": {
       "version": "2.0.1",
@@ -7493,6 +7699,22 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -7528,6 +7750,15 @@
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
+      }
+    },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
       }
     },
     "tmp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5370,8 +5370,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -5426,7 +5425,6 @@
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "start": "node server.js",
     "launch": "node launch.js",
     "zip": "node scripts/createProviderZip.js",
-    "generate": "npm run gen:config && npm run gen:scope",
+    "generate": "mkdir -p dist/config-schema && npm run gen:config && npm run gen:scope",
     "gen:config": "json2ts --input res/config-schema/layouts-config.schema.json -o dist/config-schema/layouts-config.d.ts --cwd res/config-schema",
     "gen:scope": "json2ts --input res/config-schema/scope.schema.json -o dist/config-schema/scope.d.ts --cwd res/config-schema"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "watch": "webpack --watch --mode development",
     "start": "node server.js",
     "launch": "node launch.js",
-    "zip": "node scripts/createProviderZip.js"
+    "zip": "node scripts/createProviderZip.js",
+    "generate": "npm run gen:config && npm run gen:scope",
+    "gen:config": "json2ts --input res/config-schema/layouts-config.schema.json -o dist/config-schema/layouts-config.d.ts --cwd res/config-schema",
+    "gen:scope": "json2ts --input res/config-schema/scope.schema.json -o dist/config-schema/scope.d.ts --cwd res/config-schema"
   },
   "keywords": [],
   "license": "Apache-2.0",
@@ -45,6 +48,7 @@
   "dependencies": {
     "fast-deep-equal": "^2.0.1",
     "hadouken-js-adapter": "0.36.1-alpha.1",
+    "json-schema-to-typescript": "^6.1.0",
     "sortablejs": "^1.7.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "start": "node server.js",
     "launch": "node launch.js",
     "zip": "node scripts/createProviderZip.js",
-    "generate": "mkdir -p dist/config-schema && npm run gen:config && npm run gen:scope",
+    "generate": "mkdirp dist/config-schema && npm run gen:config && npm run gen:scope",
     "gen:config": "json2ts --input res/config-schema/layouts-config.schema.json -o dist/config-schema/layouts-config.d.ts --cwd res/config-schema",
     "gen:scope": "json2ts --input res/config-schema/scope.schema.json -o dist/config-schema/scope.d.ts --cwd res/config-schema"
   },
@@ -49,6 +49,7 @@
     "fast-deep-equal": "^2.0.1",
     "hadouken-js-adapter": "0.36.1-alpha.1",
     "json-schema-to-typescript": "^6.1.0",
+    "mkdirp": "^0.5.1",
     "sortablejs": "^1.7.0"
   },
   "jest": {

--- a/res/config-schema/common.schema.json
+++ b/res/config-schema/common.schema.json
@@ -6,7 +6,7 @@
             "description": "JSON representation of a regular expression.",
             "type": "object",
             "required": [
-                "regex"
+                "expression"
             ],
             "properties": {
                 "expression": {

--- a/res/config-schema/common.schema.json
+++ b/res/config-schema/common.schema.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "definitions": {
+        "pattern": {
+            "title": "RegEx",
+            "description": "JSON representation of a regular expression.",
+            "type": "object",
+            "required": [
+                "regex"
+            ],
+            "properties": {
+                "expression": {
+                    "type": "string"
+                },
+                "flags": {
+                    "type": "string",
+                    "default": ""
+                },
+                "invert": {
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/res/config-schema/layouts-config.schema.json
+++ b/res/config-schema/layouts-config.schema.json
@@ -23,14 +23,15 @@
                     "description": "Enables/disables all Layouts Service behaviour for the given scope."
                 },
                 "features": {
+                    "description": "A set of specific features that can be toggled on/off as desired",
                     "properties": {
                         "dock": {
                             "type": "boolean",
-                            "description": "Disables the docking functionality of the service. Windows will still snap side-by-side, but will not be grouped as a result."
+                            "description": "Toggles the docking functionality of the service. Windows will still snap side-by-side, but will not be grouped as a result."
                         },
                         "tab": {
                             "type": "boolean",
-                            "description": "Disables the ability to tab windows by drag-and-drop. Windows can still be tabbed programmatically using the layouts client api."
+                            "description": "Toggles the ability to tab windows by drag-and-drop. Windows can still be tabbed programmatically using the layouts client api."
                         }
                     },
                     "default": {

--- a/res/config-schema/layouts-config.schema.json
+++ b/res/config-schema/layouts-config.schema.json
@@ -1,0 +1,88 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "layouts-config",
+    "type": "object",
+    "title": "Layouts Config",
+    "description": "Configuration for the OpenFin Layouts Service, allowing the service and/or specific features to be enabled/disabled.",
+    "definitions": {
+        "rule": {
+            "$ref": "./rule.schema.json#"
+        },
+        "scope": {
+            "title": "Scope",
+            "$ref": "./scope.schema.json#"
+        },
+        "configuration-object": {
+            "title": "ConfigurationObject",
+            "description": "An instance of Layouts Service configuration.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enables/disables all Layouts Service behaviour for the given scope."
+                },
+                "features": {
+                    "properties": {
+                        "dock": {
+                            "type": "boolean",
+                            "description": "Disables the docking functionality of the service. Windows will still snap side-by-side, but will not be grouped as a result."
+                        },
+                        "tab": {
+                            "type": "boolean",
+                            "description": "Disables the ability to tab windows by drag-and-drop. Windows can still be tabbed programmatically using the layouts client api."
+                        }
+                    },
+                    "default": {
+                        "dock": true,
+                        "tab": true
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "scoped-configuration-object": {
+            "title": "ScopedConfigurationObject",
+            "description": "A set of service options and a scope specifying where they should be applied.",
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "scope": {
+                            "$ref": "#/definitions/rule"
+                        }
+                    },
+                    "required": [
+                        "scope"
+                    ],
+                    "additionalProperties": false
+                },
+                {
+                    "$ref": "#/definitions/configuration-object"
+                }
+            ],
+            "additionalProperties": false
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "#/definitions/configuration-object"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "rules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/scoped-configuration-object"
+                    },
+                    "minItems": 0,
+                    "default": []
+                }
+            },
+            "additionalProperties": false
+        }
+    ],
+    "additionalProperties": false
+}

--- a/res/config-schema/rule.schema.json
+++ b/res/config-schema/rule.schema.json
@@ -1,0 +1,104 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "Rule",
+    "type": "object",
+    "oneOf": [
+        {
+            "$ref": "#/definitions/rule-app"
+        },
+        {
+            "$ref": "#/definitions/rule-window"
+        },
+        {
+            "$ref": "#/definitions/rule-other"
+        }
+    ],
+    "definitions": {
+        "pattern": {
+            "$ref": "./common.schema.json#/definitions/pattern"
+        },
+        "rule-app": {
+            "title": "ApplicationRule",
+            "description": "A rule targeting an application (or set of applications) by UUID.",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "enum": [
+                        "application"
+                    ]
+                },
+                "uuid": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/definitions/pattern"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "level",
+                "uuid"
+            ],
+            "additionalProperties": false
+        },
+        "rule-window": {
+            "title": "WindowRule",
+            "description": "A rule targeting a window (or set of winodws) by UUID-Name pair.",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "enum": [
+                        "window"
+                    ]
+                },
+                "uuid": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/definitions/pattern"
+                        }
+                    ]
+                },
+                "name": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/definitions/pattern"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "level",
+                "uuid",
+                "name"
+            ],
+            "additionalProperties": false
+        },
+        "rule-other": {
+            "title": "OtherRule",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "enum": [
+                        "service",
+                        "desktop",
+                        "realm",
+                        "platform"
+                    ]
+                }
+            },
+            "required": [
+                "level"
+            ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/res/config-schema/scope.schema.json
+++ b/res/config-schema/scope.schema.json
@@ -1,0 +1,78 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "Scope",
+    "type": "object",
+    "oneOf": [
+        {
+            "$ref": "#/definitions/scope-app"
+        },
+        {
+            "$ref": "#/definitions/scope-window"
+        },
+        {
+            "$ref": "#/definitions/scope-other"
+        }
+    ],
+    "definitions": {
+        "scope-app": {
+            "title": "ApplicationScope",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "enum": [
+                        "application"
+                    ]
+                },
+                "uuid": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "level",
+                "uuid"
+            ],
+            "additionalProperties": false
+        },
+        "scope-window": {
+            "title": "WindowScope",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "enum": [
+                        "window"
+                    ]
+                },
+                "uuid": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "level",
+                "uuid",
+                "name"
+            ],
+            "additionalProperties": false
+        },
+        "scope-other": {
+            "title": "OtherScope",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "enum": [
+                        "service",
+                        "desktop",
+                        "realm",
+                        "platform"
+                    ]
+                }
+            },
+            "required": [
+                "level"
+            ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/res/config-schema/scope.schema.json
+++ b/res/config-schema/scope.schema.json
@@ -16,6 +16,7 @@
     "definitions": {
         "scope-app": {
             "title": "ApplicationScope",
+            "description": "A scope targeting a specific OpenFin application and all of its windows",
             "properties": {
                 "level": {
                     "type": "string",
@@ -35,6 +36,7 @@
         },
         "scope-window": {
             "title": "WindowScope",
+            "description": "A scope targeting a specific OpenFin window",
             "properties": {
                 "level": {
                     "type": "string",
@@ -58,6 +60,7 @@
         },
         "scope-other": {
             "title": "OtherScope",
+            "description": "A scope for all levels with no extra data required (e.g. desktop-level configuration)",
             "properties": {
                 "level": {
                     "type": "string",


### PR DESCRIPTION
Initial attempt at a config schema built from Phil's POC/prototype work.

Run `npm run generate` to create the output .d.ts files. They are currently put in `/dist/config-schema`, but that is up for discussion.