### PR TITLE
[SERVICE-279] Add Visual Previews for tab-to-window Tab "drop area" actions

### DIFF
--- a/res/provider/tabbing/drag.html
+++ b/res/provider/tabbing/drag.html
@@ -12,18 +12,6 @@
         </style>
     </head>
     <body>
-        <script>
-            document.body.addEventListener("dragover", (ev)=>{
-                ev.preventDefault();
-                ev.stopPropagation();
-                return true;
-            });
 
-            document.body.addEventListener("drop", (ev)=>{
-                ev.preventDefault();
-                ev.stopPropagation();
-                return true;
-            });
-        </script>
     </body>
 </html>

--- a/src/provider/APIHandler.ts
+++ b/src/provider/APIHandler.ts
@@ -300,6 +300,6 @@ export class APIHandler {
         }
 
         tabService.dragWindowManager.hideWindow();
-        tabService.ejectTab(payload.window, {x: payload.event.screenX, y: payload.event.screenY});
+        tabService.ejectTab(payload.window);
     }
 }

--- a/src/provider/Preview.ts
+++ b/src/provider/Preview.ts
@@ -1,9 +1,9 @@
 import {DesktopSnapGroup} from './model/DesktopSnapGroup';
+import {SnapTarget} from './snapanddock/Resolver';
 import {Point, PointUtils} from './snapanddock/utils/PointUtils';
 import {Rectangle} from './snapanddock/utils/RectUtils';
+import {TabTarget} from './tabbing/TabService';
 import {eTargetType, Target} from './WindowHandler';
-import { TabTarget } from './tabbing/TabService';
-import { SnapTarget } from './snapanddock/Resolver';
 
 const PREVIEW_SUCCESS = '#3D4059';
 const PREVIEW_SUCCESS_RESIZE = PREVIEW_SUCCESS;

--- a/src/provider/Preview.ts
+++ b/src/provider/Preview.ts
@@ -2,6 +2,8 @@ import {DesktopSnapGroup} from './model/DesktopSnapGroup';
 import {Point, PointUtils} from './snapanddock/utils/PointUtils';
 import {Rectangle} from './snapanddock/utils/RectUtils';
 import {eTargetType, Target} from './WindowHandler';
+import { TabTarget } from './tabbing/TabService';
+import { SnapTarget } from './snapanddock/Resolver';
 
 const PREVIEW_SUCCESS = '#3D4059';
 const PREVIEW_SUCCESS_RESIZE = PREVIEW_SUCCESS;
@@ -12,6 +14,8 @@ interface PreviewWindow {
     nativeWindow: Window|null;
     halfSize: Point;
 }
+
+export type PreviewableTarget = SnapTarget|TabTarget;
 
 /**
  * Visual indicator of the current stap target.
@@ -44,11 +48,9 @@ export class Preview {
      * The 'isValid' parameter determines the color of the rectangles. The class also caches the group
      * argument to avoid having to re-create the rectangle objects on every call if the group hasn't changed.
      */
-    public show(target: Target): void {
+    public show(target: PreviewableTarget): void {
         const activeGroup = target.activeWindow.getSnapGroup();
         const groupHalfSize = activeGroup.halfSize;  // TODO: Will need to change once 'activeGroup' can have multiple windows (SERVICE-128)
-
-        const previewWindowRect = this.generatePreviewRect(target);
 
         if (!this.tempWindowIsActive || this.activeGroup !== activeGroup) {
             this.tempWindowIsActive = true;
@@ -116,7 +118,7 @@ export class Preview {
         return preview;
     }
 
-    private positionPreview(target: Target) {
+    private positionPreview(target: PreviewableTarget) {
         const previewRect = this.generatePreviewRect(target);
         PointUtils.assign(this.tempWindow.halfSize, previewRect.halfSize);
 
@@ -127,7 +129,7 @@ export class Preview {
             previewRect.halfSize.y * 2);
     }
 
-    private generatePreviewRect(target: Target): Rectangle {
+    private generatePreviewRect(target: PreviewableTarget): Rectangle {
         if (target.type === eTargetType.SNAP) {
             const activeGroup = target.activeWindow.getSnapGroup();
             const prevHalfSize = activeGroup.halfSize;

--- a/src/provider/View.ts
+++ b/src/provider/View.ts
@@ -1,6 +1,6 @@
 import {DesktopSnapGroup, Snappable} from './model/DesktopSnapGroup';
 import {Preview, PreviewableTarget} from './Preview';
-import {Target, eTargetType} from './WindowHandler';
+import {eTargetType, Target} from './WindowHandler';
 
 export class View {
     private activeGroup: DesktopSnapGroup|null;  // The group being moved
@@ -24,7 +24,7 @@ export class View {
      * original opacities once the active/target group(s) change or get reset.
      */
     public update(activeGroup: DesktopSnapGroup|null, target: Target|null): void {
-        if(target && target.type === eTargetType.EJECT){
+        if (target && target.type === eTargetType.EJECT) {
             activeGroup = target = null;
         }
 
@@ -47,7 +47,8 @@ export class View {
 
         // Detect change of target group
         if ((this.target && this.isPreviewable(this.target) && this.target.group) !== (target && target.group)) {
-            const targetGroup = this.target && this.isPreviewable(this.target) ? this.target.group : null;// && this.target.type !== eTargetType.EJECT ? this.target.group : null;
+            const targetGroup = this.target && this.isPreviewable(this.target) ? this.target.group :
+                                                                                 null;  // && this.target.type !== eTargetType.EJECT ? this.target.group : null;
 
             // Reset alwaysOnTop override, as our activeGroup window is now in the target group.
             this.setAlwaysOnTop(targetGroup, false);

--- a/src/provider/WindowHandler.ts
+++ b/src/provider/WindowHandler.ts
@@ -89,7 +89,7 @@ export class WindowHandler {
 
     private onTabDrag(window: DesktopWindow, mousePosition: Point) {
         const activeGroup = window.getSnapGroup();
-        const target = tabService.getTarget(activeGroup);
+        const target = tabService.getTarget(window);
         this.view.update(activeGroup, target);
     }
 
@@ -103,7 +103,9 @@ export class WindowHandler {
      */
     private getTarget(activeGroup: DesktopSnapGroup): Target|null {
         const snapTarget: Target|null = snapService.getTarget(activeGroup);
-        const tabTarget: Target|null = tabService.getTarget(activeGroup);
+
+        // activeGroup.windows[0] we know is the activeWindow as you cannot tab a tab group (only a single window);  Case of Drag & Drop targets are handled above.
+        const tabTarget: Target|null = tabService.getTarget(activeGroup.windows[0]);
 
         return snapTarget || tabTarget;
     }

--- a/src/provider/WindowHandler.ts
+++ b/src/provider/WindowHandler.ts
@@ -93,7 +93,7 @@ export class WindowHandler {
         this.view.update(activeGroup, target);
     }
 
-    private onTabDrop(window: DesktopWindow, mousePosition: Point) {
+    private onTabDrop() {
         this.view.update(null, null);
     }
 

--- a/src/provider/WindowHandler.ts
+++ b/src/provider/WindowHandler.ts
@@ -3,10 +3,10 @@ import {DesktopModel} from './model/DesktopModel';
 import {DesktopSnapGroup, Snappable} from './model/DesktopSnapGroup';
 import {DesktopWindow, eTransformType, Mask} from './model/DesktopWindow';
 import {SnapTarget} from './snapanddock/Resolver';
-import {TabTarget, EjectTarget} from './tabbing/TabService';
+import {Point} from './snapanddock/utils/PointUtils';
+import {DragWindowManager} from './tabbing/DragWindowManager';
+import {EjectTarget, TabTarget} from './tabbing/TabService';
 import {View} from './View';
-import { DragWindowManager } from './tabbing/DragWindowManager';
-import { Point } from './snapanddock/utils/PointUtils';
 
 /**
  * The existing interfaces for what a target can be.
@@ -72,7 +72,7 @@ export class WindowHandler {
         if (target) {
             if (target.type === eTargetType.TAB) {
                 // TODO: Change this to accept a target (SERVICE-279)
-                tabService.tabDroppedWindow(activeGroup.windows[0] as DesktopWindow);
+                tabService.tabDroppedWindow(target);
             } else if (target.type === eTargetType.SNAP) {
                 snapService.applySnapTarget(target);
             }
@@ -86,7 +86,6 @@ export class WindowHandler {
         const target = tabService.getTarget(window);
 
         this.view.update(activeGroup, target);
-
     }
 
     private onTabDrop() {
@@ -100,7 +99,8 @@ export class WindowHandler {
     private getTarget(activeGroup: DesktopSnapGroup): Target|null {
         const snapTarget: Target|null = snapService.getTarget(activeGroup);
 
-        // activeGroup.windows[0] we know is the activeWindow as you cannot tab a tab group (only a single window);  Case of Drag & Drop targets are handled above.
+        // activeGroup.windows[0] we know is the activeWindow as you cannot tab a tab group (only a single window);  Case of Drag & Drop targets are handled
+        // above.
         const tabTarget: Target|null = tabService.getTarget(activeGroup.windows[0]);
 
         return snapTarget || tabTarget;

--- a/src/provider/WindowHandler.ts
+++ b/src/provider/WindowHandler.ts
@@ -11,7 +11,7 @@ import { Point } from './snapanddock/utils/PointUtils';
 /**
  * The existing interfaces for what a target can be.
  */
-export type Target = SnapTarget|TabTarget;
+export type Target = SnapTarget|TabTarget|EjectTarget;
 
 export enum eTargetType {
     TAB = 'TAB',
@@ -84,7 +84,9 @@ export class WindowHandler {
     private onTabDrag(window: DesktopWindow, mousePosition: Point) {
         const activeGroup = window.getSnapGroup();
         const target = tabService.getTarget(window);
+
         this.view.update(activeGroup, target);
+
     }
 
     private onTabDrop() {

--- a/src/provider/WindowHandler.ts
+++ b/src/provider/WindowHandler.ts
@@ -5,6 +5,8 @@ import {DesktopWindow, eTransformType, Mask} from './model/DesktopWindow';
 import {SnapTarget} from './snapanddock/Resolver';
 import {TabTarget} from './tabbing/TabService';
 import {View} from './View';
+import { DragWindowManager } from './tabbing/DragWindowManager';
+import { Point } from './snapanddock/utils/PointUtils';
 
 /**
  * The existing interfaces for what a target can be.
@@ -49,6 +51,8 @@ export class WindowHandler {
         this.model = model;
         this.view = new View();
 
+        DragWindowManager.onDragOver.add(this.onTabDrag, this);
+        DragWindowManager.onDragDrop.add(this.onTabDrop, this);
         // Register lifecycle listeners
         DesktopSnapGroup.onCreated.add(this.onSnapGroupCreated, this);
         DesktopSnapGroup.onDestroyed.add(this.onSnapGroupDestroyed, this);
@@ -80,6 +84,16 @@ export class WindowHandler {
             }
         }
 
+        this.view.update(null, null);
+    }
+
+    private onTabDrag(window: DesktopWindow, mousePosition: Point) {
+        const activeGroup = window.getSnapGroup();
+        const target = tabService.getTarget(activeGroup);
+        this.view.update(activeGroup, target);
+    }
+
+    private onTabDrop(window: DesktopWindow, mousePosition: Point) {
         this.view.update(null, null);
     }
 

--- a/src/provider/WindowHandler.ts
+++ b/src/provider/WindowHandler.ts
@@ -3,7 +3,7 @@ import {DesktopModel} from './model/DesktopModel';
 import {DesktopSnapGroup, Snappable} from './model/DesktopSnapGroup';
 import {DesktopWindow, eTransformType, Mask} from './model/DesktopWindow';
 import {SnapTarget} from './snapanddock/Resolver';
-import {TabTarget} from './tabbing/TabService';
+import {TabTarget, EjectTarget} from './tabbing/TabService';
 import {View} from './View';
 import { DragWindowManager } from './tabbing/DragWindowManager';
 import { Point } from './snapanddock/utils/PointUtils';
@@ -15,18 +15,12 @@ export type Target = SnapTarget|TabTarget;
 
 export enum eTargetType {
     TAB = 'TAB',
-    SNAP = 'SNAP'
+    SNAP = 'SNAP',
+    EJECT = 'EJECT'
 }
 
 export interface TargetBase {
     type: eTargetType;
-
-    /**
-     * The group that has been selected as the target candidate.
-     *
-     * This is not the group that the user is currently dragging, it is the group that has been selected as the target.
-     */
-    group: DesktopSnapGroup;
 
     /**
      * The window within the active group that was used to find this candidate.

--- a/src/provider/model/MouseTracker.ts
+++ b/src/provider/model/MouseTracker.ts
@@ -38,7 +38,7 @@ export class MouseTracker {
         this.knownPosition = position;
     }
 
-    private onTabDrop(window: DesktopWindow, position: Point){
+    private onTabDrop(){
         this.knownPosition = null;
     }
 

--- a/src/provider/model/MouseTracker.ts
+++ b/src/provider/model/MouseTracker.ts
@@ -39,7 +39,10 @@ export class MouseTracker {
     }
 
     private onTabDrop(){
-        this.knownPosition = null;
+        // Timeout because the position will be cleared once a tab drop has occurred.  In the event of an tab eject this information is needed at drop.
+        setTimeout(()=>{
+            this.knownPosition = null;
+        }, 500);
     }
 
     /**

--- a/src/provider/model/MouseTracker.ts
+++ b/src/provider/model/MouseTracker.ts
@@ -1,7 +1,8 @@
 import {Point, PointTopLeft} from 'hadouken-js-adapter/out/types/src/api/system/point';
 
+import {DragWindowManager} from '../tabbing/DragWindowManager';
+
 import {DesktopWindow, eTransformType, Mask, WindowState} from './DesktopWindow';
-import { DragWindowManager } from '../tabbing/DragWindowManager';
 
 /**
  * A helper to keep track of mouse position when a window is being dragged via user movement
@@ -34,13 +35,13 @@ export class MouseTracker {
         window.onCommit.remove(this.end, this);
     }
 
-    private onTabDrag(window: DesktopWindow, position: Point){
+    private onTabDrag(window: DesktopWindow, position: Point) {
         this.knownPosition = position;
     }
 
-    private onTabDrop(){
+    private onTabDrop() {
         // Timeout because the position will be cleared once a tab drop has occurred.  In the event of an tab eject this information is needed at drop.
-        setTimeout(()=>{
+        setTimeout(() => {
             this.knownPosition = null;
         }, 500);
     }
@@ -96,7 +97,7 @@ export class MouseTracker {
                 x: this.mouseOffset.x + (currentWindowState.center.x - currentWindowState.halfSize.x),
                 y: this.mouseOffset.y + (currentWindowState.center.y - currentWindowState.halfSize.y)
             };
-        } else if(this.knownPosition){
+        } else if (this.knownPosition) {
             return this.knownPosition;
         }
 

--- a/src/provider/snapanddock/Resolver.ts
+++ b/src/provider/snapanddock/Resolver.ts
@@ -49,6 +49,14 @@ export interface SnapTarget extends TargetBase {
      * Will be null if we don't want the window to resize as part of the snap.
      */
     halfSize: Point|null;
+
+
+    /**
+     * The group that has been selected as the target candidate.
+     *
+     * This is not the group that the user is currently dragging, it is the group that has been selected as the target.
+     */
+    group: DesktopSnapGroup;
 }
 
 /**

--- a/src/provider/tabbing/DragWindowManager.ts
+++ b/src/provider/tabbing/DragWindowManager.ts
@@ -1,11 +1,11 @@
 import {Window} from 'hadouken-js-adapter';
+import {Point} from 'hadouken-js-adapter/out/types/src/api/system/point';
+import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
 import {WindowIdentity} from '../../client/types';
-import { Signal2, Signal0 } from '../Signal';
-import { Point } from 'hadouken-js-adapter/out/types/src/api/system/point';
-import { _Window } from 'hadouken-js-adapter/out/types/src/api/window/window';
-import { DesktopWindow } from '../model/DesktopWindow';
-import { DesktopModel } from '../model/DesktopModel';
+import {DesktopModel} from '../model/DesktopModel';
+import {DesktopWindow} from '../model/DesktopWindow';
+import {Signal0, Signal2} from '../Signal';
 
 /**
  * Handles the Drag Window which appears when API drag and drop is initialized.
@@ -19,10 +19,10 @@ export class DragWindowManager {
 
     private _window!: Window;
 
-    private sourceWindow: DesktopWindow | null;
+    private sourceWindow: DesktopWindow|null;
     private model: DesktopModel;
 
-    constructor(model: DesktopModel){
+    constructor(model: DesktopModel) {
         this.model = model;
         this.sourceWindow = null;
     }
@@ -67,7 +67,7 @@ export class DragWindowManager {
     private async _createDragWindow(): Promise<void> {
         this._window = await fin.Window.create({
             name: 'TabbingDragWindow',
-            url: "about:blank",
+            url: 'about:blank',
             defaultHeight: 1,
             defaultWidth: 1,
             defaultLeft: 0,
@@ -84,7 +84,7 @@ export class DragWindowManager {
 
         const nativeWin = await this._window.getNativeWindow();
 
-        nativeWin.document.body.addEventListener("dragover", (ev: DragEvent)=>{
+        nativeWin.document.body.addEventListener('dragover', (ev: DragEvent) => {
             DragWindowManager.onDragOver.emit(this.sourceWindow!, {x: ev.screenX, y: ev.screenY});
             ev.preventDefault();
             ev.stopPropagation();
@@ -92,7 +92,7 @@ export class DragWindowManager {
             return true;
         });
 
-        nativeWin.document.body.addEventListener("drop", (ev: DragEvent)=>{
+        nativeWin.document.body.addEventListener('drop', (ev: DragEvent) => {
             DragWindowManager.onDragDrop.emit();
             ev.preventDefault();
             ev.stopPropagation();

--- a/src/provider/tabbing/DragWindowManager.ts
+++ b/src/provider/tabbing/DragWindowManager.ts
@@ -1,7 +1,7 @@
 import {Window} from 'hadouken-js-adapter';
 
 import {WindowIdentity} from '../../client/types';
-import { Signal2 } from '../Signal';
+import { Signal2, Signal0 } from '../Signal';
 import { Point } from 'hadouken-js-adapter/out/types/src/api/system/point';
 import { _Window } from 'hadouken-js-adapter/out/types/src/api/window/window';
 import { DesktopWindow } from '../model/DesktopWindow';
@@ -12,7 +12,7 @@ import { DesktopModel } from '../model/DesktopModel';
  */
 export class DragWindowManager {
     public static readonly onDragOver: Signal2<DesktopWindow, Point> = new Signal2();
-    public static readonly onDragDrop: Signal2<DesktopWindow, Point> = new Signal2();
+    public static readonly onDragDrop: Signal0 = new Signal0();
 
     // tslint:disable-next-line:no-any setTimout return Type is confused by VSC
     private _hideTimeout: any;
@@ -56,6 +56,7 @@ export class DragWindowManager {
      * Hides the drag window overlay.
      */
     public hideWindow(): void {
+        DragWindowManager.onDragDrop.emit();
         this._window.hide();
         clearTimeout(this._hideTimeout);
     }
@@ -76,7 +77,7 @@ export class DragWindowManager {
             opacity: 0.01,
             frame: false,
             waitForPageLoad: false,
-            alwaysOnTop: false,
+            alwaysOnTop: true,
             showTaskbarIcon: false,
             smallWindow: true
         });
@@ -92,7 +93,7 @@ export class DragWindowManager {
         });
 
         nativeWin.document.body.addEventListener("drop", (ev: DragEvent)=>{
-            DragWindowManager.onDragDrop.emit(this.sourceWindow!, {x: ev.screenX, y: ev.screenY});
+            DragWindowManager.onDragDrop.emit();
             ev.preventDefault();
             ev.stopPropagation();
             return true;

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -367,7 +367,7 @@ export class TabService {
          * Checks if our target is a snapped window (non tab);
          */
         const isTargetSnapped = targetWindow && targetWindow.getSnapGroup().length > 1 && !targetWindow.getTabGroup();
-        if (targetWindow && isOverWindowValid && !isActiveWindowTabbed && !isTargetSnapped) {
+        if (targetWindow && isOverWindowValid && !isTargetSnapped && (!isActiveWindowTabbed || !RectUtils.isPointInRect(activeGroup.center, activeGroup.halfSize, position!))) {
             const isTargetTabbed = targetWindow.getTabGroup();
 
             // Check if the target and active window have same tab config.

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -362,7 +362,7 @@ export class TabService {
      * Generates a valid tabbing target for a given active group in its current position.
      * @param {DesktopSnapGroup} activeGroup The current active group being moved by the user.
      */
-    public getTarget(activeWindow: Snappable): TabTarget|null {
+    public getTarget(activeWindow: Snappable): TabTarget|EjectTarget|null {
         const position: Point|null = this._model.getMouseTracker().getPosition();
 
         if(!position){
@@ -406,6 +406,13 @@ export class TabService {
                 dropArea: this.getWindowDropArea(targetWindow),
                 valid
             };
+        } else if(!isMouseInsideGroupBounds && !targetWindow){
+            return {
+                type: eTargetType.EJECT,
+                activeWindow,
+                position,
+                valid: true
+            }
         }
 
         return null;

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -20,6 +20,19 @@ export interface TabTarget extends TargetBase {
      * Represents the target window tabbing space;
      */
     dropArea: Rectangle;
+
+
+    /**
+     * The group that has been selected as the target candidate.
+     *
+     * This is not the group that the user is currently dragging, it is the group that has been selected as the target.
+     */
+    group: DesktopSnapGroup;
+}
+
+export interface EjectTarget extends TargetBase {
+    type: eTargetType.EJECT;
+    position: Point;
 }
 
 /**

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -49,7 +49,7 @@ export class TabService {
      */
     constructor(model: DesktopModel) {
         this._model = model;
-        this._dragWindowManager = new DragWindowManager();
+        this._dragWindowManager = new DragWindowManager(model);
         this._dragWindowManager.init();
 
         this.mApplicationConfigManager = new ApplicationConfigManager();
@@ -367,7 +367,6 @@ export class TabService {
          * Checks if our target is a snapped window (non tab);
          */
         const isTargetSnapped = targetWindow && targetWindow.getSnapGroup().length > 1 && !targetWindow.getTabGroup();
-
         if (targetWindow && isOverWindowValid && !isActiveWindowTabbed && !isTargetSnapped) {
             const isTargetTabbed = targetWindow.getTabGroup();
 


### PR DESCRIPTION
Part 2 of this story.  Dragging tabs around will now produce visual feedback.  Some internal changes regarding Tab/Eject targets are also included.