### PR TITLE
[SERVICE-299] Publish a version of the client that can be imported directly from the browser

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,7 @@ pipeline {
                 sh "aws s3 cp ./res/provider ${S3_LOC}/ --recursive"
                 sh "aws s3 cp ./dist/provider ${S3_LOC}/ --recursive"
                 sh "aws s3 cp ./dist/docs ${S3_LOC}/docs/ --recursive"
+                sh "aws s3 cp ./dist/client/openfin-layouts.js ${S3_LOC}/"
                 sh "aws s3 cp ./dist/provider/app.json ${STAGING_JSON}"
                 withCredentials([string(credentialsId: "NPM_TOKEN_WRITE", variable: 'NPM_TOKEN')]) {
                     sh "echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > $WORKSPACE/.npmrc"
@@ -61,6 +62,7 @@ pipeline {
                 sh "aws s3 cp ./res/provider ${S3_LOC}/ --recursive"
                 sh "aws s3 cp ./dist/provider ${S3_LOC}/ --recursive"
                 sh "aws s3 cp ./dist/docs ${S3_LOC}/docs/ --recursive"
+                sh "aws s3 cp ./dist/client/openfin-layouts.js ${S3_LOC}/"
                 sh "aws s3 cp ./dist/provider/app.json ${PROD_JSON}"
                 withCredentials([string(credentialsId: "NPM_TOKEN_WRITE", variable: 'NPM_TOKEN')]) {
                     sh "echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > $WORKSPACE/.npmrc"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ npm install openfin-layouts
 
 The client library is also available as a resource which can be included via `<script>` tag:
 ```
-<script src="https://cdn.openfin/services/openfin/layouts/<VERSION>/openfin-layouts.js"></script>
+   <script src="https://cdn.openfin/services/openfin/layouts/<VERSION>/openfin-layouts.js"></script>
+```
+This will expose the global variable `OpenFinLayouts` with the API methods documented in the link below.  Example:
+```
+   OpenFinLayouts.undockWindow();
 ```
 
 The client module exports a set of functions - [API docs available](https://urls.openfin.co/layouts/docs).

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Optionally you can add a URL for specifying a custom location or a specific vers
 npm install openfin-layouts
 ```
 
+The client library is also available as a resource which can be included via `<script>` tag:
+```
+<script src="https://cdn.openfin/services/openfin/layouts/<VERSION>/openfin-layouts.js"></script>
+```
+
 The client module exports a set of functions - [API docs available](https://urls.openfin.co/layouts/docs).
 
 

--- a/res/demo/LayoutsUI.html
+++ b/res/demo/LayoutsUI.html
@@ -26,7 +26,7 @@
         <button onclick="LayoutsUI.createAppFromManifest3()">Create App3 From Manifest</button>
         <button onclick="LayoutsUI.createAppProgrammatically4()">Create App4 Programmatically</button>
         <button onclick="LayoutsUI.createAppProgrammatically5()">Create App5 Programmatically</button>
-        <button onclick="LayoutsUI.createSimpleWindow('libScriptIncluded')">Library Src Included</button>
+        <button onclick="LayoutsUI.createSimpleWindow('libScriptIncluded')">Client Lib Included</button>
         <button onclick="LayoutsUI.createSnapWindows()">Create Snap Windows</button>
         <button onclick="LayoutsUI.killAllWindows()">Close All Windows</button>
     </div>

--- a/res/demo/LayoutsUI.html
+++ b/res/demo/LayoutsUI.html
@@ -26,15 +26,16 @@
         <button onclick="LayoutsUI.createAppFromManifest3()">Create App3 From Manifest</button>
         <button onclick="LayoutsUI.createAppProgrammatically4()">Create App4 Programmatically</button>
         <button onclick="LayoutsUI.createAppProgrammatically5()">Create App5 Programmatically</button>
+        <button onclick="LayoutsUI.createSimpleWindow('libScriptIncluded')">Library Src Included</button>
         <button onclick="LayoutsUI.createSnapWindows()">Create Snap Windows</button>
         <button onclick="LayoutsUI.killAllWindows()">Close All Windows</button>
     </div>
     <h3>Tabbed Windows</h3>
     <div>
-        <button onclick="LayoutsUI.createTabbedWindow('default')">Default Tabstrip</button>
-        <button onclick="LayoutsUI.createTabbedWindow('tabapp1')">Custom Tabstrip 1</button>
-        <button onclick="LayoutsUI.createTabbedWindow('tabapp2')">Custom Tabstrip 2</button>
-        <button onclick="LayoutsUI.createTabbedWindow('disableFrame')">'disableFrame' Window</button>
+        <button onclick="LayoutsUI.createSimpleWindow('tabbing/default')">Default Tabstrip</button>
+        <button onclick="LayoutsUI.createSimpleWindow('tabbing/tabapp1')">Custom Tabstrip 1</button>
+        <button onclick="LayoutsUI.createSimpleWindow('tabbing/tabapp2')">Custom Tabstrip 2</button>
+        <button onclick="LayoutsUI.createSimpleWindow('tabbing/disableFrame')">'disableFrame' Window</button>
     </div>
     <div>
         <textArea id='showLayout'></textArea>

--- a/res/demo/libScriptIncluded.html
+++ b/res/demo/libScriptIncluded.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Openfin Layouts Included</title>
+    <script src="http://localhost:1337/client/openfin-layouts.js"></script>
+</head>
+<body>
+    <script>
+        const randomColor = () => {
+            return '#' + ((1 << 24) * Math.random() | 0).toString(16);
+        };
+
+        document.addEventListener('DOMContentLoaded', () => {
+            document.body.style.backgroundColor = randomColor();
+        });
+    </script>
+    
+    <p>Openfin Layouts Library is included via script tag in this window.  Accessible with global var OpenfinLayouts</p>
+</body>
+</html>

--- a/src/demo/LayoutsUI.ts
+++ b/src/demo/LayoutsUI.ts
@@ -145,11 +145,11 @@ export function createSnapWindows(): void {
     });
 }
 
-export function createTabbedWindow(page: string) {
+export function createSimpleWindow(page: string) {
     const uuid = `App${numTabbedWindows}`;
     const app = new fin.desktop.Application(
         {
-            url: `http://localhost:1337/demo/tabbing/${page}.html`,
+            url: `http://localhost:1337/demo/${page}.html`,
             uuid,
             name: uuid,
             mainWindowOptions: {defaultWidth: 400, defaultHeight: 300, saveWindowState: false, autoShow: true, defaultCentered: true}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,8 +19,11 @@ const outputDir = path.resolve(__dirname, './dist');
  *  - plugins {...object[]}
  *      Optional list of plugins to add to the config object
  *      Defaults to empty list
+ *  - outputFilename {string}
+ *      Allows a custom output file name to be used instead of the default [name]-bundle.js
  */
 function createConfig(outPath, entryPoint, options, ...plugins) {
+    console.log(process.env);
     const config = {
         entry: entryPoint,
         optimization: {
@@ -28,7 +31,7 @@ function createConfig(outPath, entryPoint, options, ...plugins) {
         },
         output: {
             path: outPath,
-            filename: '[name]-bundle.js'
+            filename: `${options && options.outputFilename || '[name]-bundle'}.js`
         },
         resolve: {
             extensions: ['.ts', '.tsx', '.js']
@@ -91,6 +94,7 @@ const versionPlugin = new webpack.DefinePlugin({PACKAGE_VERSION: `'${version}'`}
 
 module.exports = [
     createConfig(`${outputDir}/client`, './src/client/main.ts', {minify: false, isLibrary: true, libraryName: 'OpenFinLayouts'}, versionPlugin),
+    createConfig(`${outputDir}/client`, './src/client/main.ts', {minify: true, isLibrary: true, libraryName: 'OpenFinLayouts', outputFilename: "openfin-layouts"}, versionPlugin),
     createConfig(`${outputDir}/provider`, {
         main: './src/provider/main.ts',
         tabStrip: './src/provider/tabbing/tabstrip/main.ts'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,6 @@ const outputDir = path.resolve(__dirname, './dist');
  *      Allows a custom output file name to be used instead of the default [name]-bundle.js
  */
 function createConfig(outPath, entryPoint, options, ...plugins) {
-    console.log(process.env);
     const config = {
         entry: entryPoint,
         optimization: {


### PR DESCRIPTION
**Do Not Merge Yet**  Pending API changes

Creates a minified client library which can be included via `script` tag.  The location will be on the CDN as `https://cdn.openfin.co/services/openfin/layouts/<VERSION>/openfin-layouts.js`.  Once included, the library will be accessible via global var `OpenFinLayouts`.  This can be tested in the demo app using 'Client Lib Included' button.

