### PR TITLE
[SERVICE-313] Added "test teardown" util

### DIFF
--- a/res/test/provider.html
+++ b/res/test/provider.html
@@ -10,7 +10,7 @@
             channelProvider.register('execute-javascript', async (payload) => {
                 try {
                     result = await new Function("return " + payload.script)()(payload.data)
-                    return {success: true, result: JSON.stringify(result)};
+                    return {success: true, result};
                 } catch (e) {
                     // Deconstruct the error to be sent over the bus (NB: Error is not a JSON.stringify()-able type)
                     return {success: false, result: {message: e.message, stack: e.stack, name: e.name}};

--- a/res/test/provider.html
+++ b/res/test/provider.html
@@ -10,7 +10,7 @@
             channelProvider.register('execute-javascript', async (payload) => {
                 try {
                     result = await new Function("return " + payload.script)()(payload.data)
-                    return {success: true, result};
+                    return {success: true, result: JSON.stringify(result)};
                 } catch (e) {
                     // Deconstruct the error to be sent over the bus (NB: Error is not a JSON.stringify()-able type)
                     return {success: false, result: {message: e.message, stack: e.stack, name: e.name}};

--- a/res/test/testApp.js
+++ b/res/test/testApp.js
@@ -1,6 +1,6 @@
 const main = async () => {
-    fin.desktop.InterApplicationBus.Channel.connect('of-layouts-service-v1').then(client => {
-        client.send('deregister');
+    fin.InterApplicationBus.Channel.connect('of-layouts-service-v1').then(client => {
+        client.dispatch('deregister', fin.Window.me);
         client.register('savingLayout', () => {});
         client.register('restoreApp', (a) => a);
     });

--- a/src/provider/Preview.ts
+++ b/src/provider/Preview.ts
@@ -89,7 +89,7 @@ export class Preview {
     private createWindow(): PreviewWindow {
         const defaultHalfSize = {x: 160, y: 160};
         const options: fin.WindowOptions = {
-            name: 'previewWindow-',  // + Math.floor(Math.random() * 1000),
+            name: 'previewWindow',
             url: 'about:blank',
             defaultWidth: defaultHalfSize.x * 2,
             defaultHeight: defaultHalfSize.y * 2,

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -10,7 +10,6 @@ import {eTargetType, TargetBase} from '../WindowHandler';
 import {ApplicationConfigManager} from './components/ApplicationConfigManager';
 import {DragWindowManager} from './DragWindowManager';
 
-
 /**
  * TabTarget constructs an interface which represents an area on a window where a tab strip will be placed.
  */

--- a/test/demo/previewWindow.test.ts
+++ b/test/demo/previewWindow.test.ts
@@ -1,5 +1,6 @@
+import {test} from 'ava';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
-import * as robot from 'robotjs';
+import robot from 'robotjs';
 
 import {CreateWindowData, createWindowTest} from '../demo/utils/createWindowTest';
 import {testParameterized} from '../demo/utils/parameterizedTestUtils';
@@ -11,10 +12,13 @@ import {dragSideToSide} from '../provider/utils/dragWindowTo';
 import {getBounds} from '../provider/utils/getBounds';
 import {opposite, Side} from '../provider/utils/SideUtils';
 import {tabWindowsTogether} from '../provider/utils/tabWindowsTogether';
+import {teardown} from '../teardown';
 
 import {getTabstrip} from './utils/tabServiceUtils';
 import {tearoutToOtherTabstrip, tearoutToPoint} from './utils/tabstripUtils';
 
+
+test.afterEach.always(teardown);
 
 interface PreviewTestOptions extends CreateWindowData {
     side: Side;
@@ -33,7 +37,7 @@ testParameterized(
         const {windows} = t.context;
 
         const fin = await getConnection();
-        const previewWin: _Window = await fin.Window.wrap({name: 'previewWindow-', uuid: 'layouts-service'});
+        const previewWin: _Window = await fin.Window.wrap({name: 'previewWindow', uuid: 'layouts-service'});
         const windowBounds = await Promise.all([getBounds(windows[0]), getBounds(windows[1])]);
 
         await dragSideToSide(windows[1], opposite(side), windows[0], side, {x: 5, y: 5}, false);
@@ -67,7 +71,7 @@ testParameterized(
         const {windows} = t.context;
 
         const fin = await getConnection();
-        const previewWin: _Window = await fin.Window.wrap({name: 'previewWindow-', uuid: 'layouts-service'});
+        const previewWin: _Window = await fin.Window.wrap({name: 'previewWindow', uuid: 'layouts-service'});
         const windowBounds = await Promise.all([getBounds(windows[0]), getBounds(windows[1])]);
 
         await windows[1].resizeBy(
@@ -96,7 +100,7 @@ testParameterized(
         const {windows} = t.context;
 
         const fin = await getConnection();
-        const previewWin: _Window = await fin.Window.wrap({name: 'previewWindow-', uuid: 'layouts-service'});
+        const previewWin: _Window = await fin.Window.wrap({name: 'previewWindow', uuid: 'layouts-service'});
         const windowBounds = await Promise.all([getBounds(windows[0]), getBounds(windows[1])]);
 
         if (windowCount > 2) {
@@ -124,7 +128,7 @@ testParameterized(
         const {windows} = t.context;
 
         const fin = await getConnection();
-        const previewWin: _Window = await fin.Window.wrap({name: 'previewWindow-', uuid: 'layouts-service'});
+        const previewWin: _Window = await fin.Window.wrap({name: 'previewWindow', uuid: 'layouts-service'});
 
         await windows[0].moveTo(40, 40);
         if (windowCount > 3) await windows[3].moveTo(60, 60);

--- a/test/demo/snapanddock/advancedSnapAndDock.test.ts
+++ b/test/demo/snapanddock/advancedSnapAndDock.test.ts
@@ -1,9 +1,14 @@
+import {test} from 'ava';
+
 import {assertAllContiguous, assertGrouped, assertNoOverlap, assertNotGrouped} from '../../provider/utils/assertions';
 import {delay} from '../../provider/utils/delay';
 import {dragSideToSide} from '../../provider/utils/dragWindowTo';
 import {getBounds} from '../../provider/utils/getBounds';
+import {teardown} from '../../teardown';
 import {CreateWindowData, createWindowTest} from '../utils/createWindowTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
+
+test.afterEach.always(teardown);
 
 // Using testParameterized more for type safety than parameterization
 // since this just one very specific test

--- a/test/demo/snapanddock/basicSnapAndDock.test.ts
+++ b/test/demo/snapanddock/basicSnapAndDock.test.ts
@@ -1,14 +1,18 @@
+import {test} from 'ava';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
 import {assertAdjacent, assertGrouped, assertSquare} from '../../provider/utils/assertions';
 import {dragSideToSide, dragWindowTo} from '../../provider/utils/dragWindowTo';
 import {opposite, Side} from '../../provider/utils/SideUtils';
+import {teardown} from '../../teardown';
 import {CreateWindowData, createWindowTest, WindowContext} from '../utils/createWindowTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 
 interface TwoWindowTestOptions extends CreateWindowData {
     side: Side;
 }
+
+test.afterEach.always(teardown);
 
 testParameterized<TwoWindowTestOptions, WindowContext>(
     (testOptions: TwoWindowTestOptions): string => `Basic SnapAndDock - ${testOptions.windowCount} windows - ${testOptions.frame ? 'framed' : 'frameless'} - ${

--- a/test/demo/snapanddock/minimizeSnapGroup.test.ts
+++ b/test/demo/snapanddock/minimizeSnapGroup.test.ts
@@ -1,8 +1,10 @@
+import {test} from 'ava';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
 import {assertAllMinimizedOrHidden, assertAllNormalState, assertGrouped, assertTabbed} from '../../provider/utils/assertions';
 import {delay} from '../../provider/utils/delay';
 import {tabWindowsTogether} from '../../provider/utils/tabWindowsTogether';
+import {teardown} from '../../teardown';
 import {CreateWindowData, createWindowTest} from '../utils/createWindowTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 import {layoutsClientPromise} from '../utils/serviceUtils';
@@ -12,6 +14,8 @@ interface MinimizeTestOptions extends CreateWindowData {
     // Index of the window on which restore is invoked (group will be minimized from index 0)
     restoreIndex: number;
 }
+
+test.afterEach.always(teardown);
 
 testParameterized(
     (testOptions: MinimizeTestOptions) =>

--- a/test/demo/snapanddock/resizeOnSnap.test.ts
+++ b/test/demo/snapanddock/resizeOnSnap.test.ts
@@ -1,3 +1,4 @@
+import {test} from 'ava';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
 import {assertAdjacent, assertAllContiguous, assertGrouped, assertTabbed} from '../../provider/utils/assertions';
@@ -7,6 +8,7 @@ import {getBounds, getTabsetBounds} from '../../provider/utils/getBounds';
 import * as SideUtils from '../../provider/utils/SideUtils';
 import {Side} from '../../provider/utils/SideUtils';
 import {tabWindowsTogether} from '../../provider/utils/tabWindowsTogether';
+import {teardown} from '../../teardown';
 import {CreateWindowData, createWindowTest} from '../utils/createWindowTest';
 import {refreshWindowState} from '../utils/modelUtils';
 import {testParameterized} from '../utils/parameterizedTestUtils';
@@ -37,6 +39,8 @@ interface ResizeWithConstrainsOptions extends ResizeOnSnapOptions {
     shouldResize: boolean;
     windowCount: 2;
 }
+
+test.afterEach.always(teardown);
 
 // With window constraints
 testParameterized(

--- a/test/demo/snapanddock/resizeSnapGroup.test.ts
+++ b/test/demo/snapanddock/resizeSnapGroup.test.ts
@@ -1,7 +1,10 @@
+import {test} from 'ava';
 import robot from 'robotjs';
+
 import {assertAdjacent, assertGrouped, assertSquare} from '../../provider/utils/assertions';
 import {delay} from '../../provider/utils/delay';
 import {getBounds, NormalizedBounds} from '../../provider/utils/getBounds';
+import {teardown} from '../../teardown';
 import {CreateWindowData, createWindowTest} from '../utils/createWindowTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 
@@ -9,6 +12,8 @@ interface ResizeGroupOptions extends CreateWindowData {
     windowCount: 2|4;
     resizeType: ['inner'|'outer', 'vertical'|'horizontal'];
 }
+
+test.afterEach.always(teardown);
 
 testParameterized(
     (testOptions: ResizeGroupOptions): string =>

--- a/test/demo/snapanddock/snapTabGroups.test.ts
+++ b/test/demo/snapanddock/snapTabGroups.test.ts
@@ -1,4 +1,4 @@
-import test from 'ava';
+import {test} from 'ava';
 import Bounds from 'hadouken-js-adapter/out/types/src/api/window/bounds';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
@@ -7,6 +7,7 @@ import {delay} from '../../provider/utils/delay';
 import {dragSideToSide, dragWindowTo} from '../../provider/utils/dragWindowTo';
 import {opposite, Side, Sides} from '../../provider/utils/SideUtils';
 import {tabWindowsTogether} from '../../provider/utils/tabWindowsTogether';
+import {teardown} from '../../teardown';
 import {CreateWindowData, createWindowTest, WindowContext} from '../utils/createWindowTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 import {getTabstrip} from '../utils/tabServiceUtils';
@@ -15,6 +16,8 @@ import {switchTab, tearoutTab, tearoutToOtherTabstrip} from '../utils/tabstripUt
 interface SnapTabInstanceData {
     side: Side;
 }
+
+test.afterEach.always(teardown);
 
 /**
  * Performs the necessary test setup - tabs the windows into two tab groups, then snaps those groups together.

--- a/test/demo/snapanddock/validateGroup.test.ts
+++ b/test/demo/snapanddock/validateGroup.test.ts
@@ -1,8 +1,10 @@
+import {test} from 'ava';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
 import {assertAllContiguous, assertGrouped, assertNotGrouped} from '../../provider/utils/assertions';
 import {delay} from '../../provider/utils/delay';
 import {ArrangementsType, defaultArrangements} from '../../provider/utils/WindowInitializer';
+import {teardown} from '../../teardown';
 import {CreateWindowData, createWindowTest, WindowContext} from '../utils/createWindowTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 import {undockWindow} from '../utils/snapServiceUtils';
@@ -62,6 +64,8 @@ const customArrangements: ArrangementsType = Object.assign({}, defaultArrangemen
         ]
     }
 });
+
+test.afterEach.always(teardown);
 
 testParameterized<ValidateGroupOptions, WindowContext>(
     (testOptions: ValidateGroupOptions): string => `Validate Group - ${testOptions.frame ? 'framed' : 'frameless'} - ${testOptions.windowCount} window ${

--- a/test/demo/tabbing/createTabFromMultipleWindows.test.ts
+++ b/test/demo/tabbing/createTabFromMultipleWindows.test.ts
@@ -5,6 +5,7 @@ import {TabGroup} from '../../../src/client/types';
 import {DesktopTabGroup} from '../../../src/provider/model/DesktopTabGroup';
 import {getConnection} from '../../provider/utils/connect';
 import {getBounds, NormalizedBounds} from '../../provider/utils/getBounds';
+import {teardown} from '../../teardown';
 import {executeJavascriptOnService} from '../utils/serviceUtils';
 import {getId} from '../utils/tabServiceUtils';
 
@@ -20,6 +21,8 @@ test.afterEach.always(async () => {
     await win2.close();
     fin.InterApplicationBus.removeAllListeners();
 });
+
+test.afterEach.always(teardown);
 
 test('Create tab group from 2 windows', async (assert) => {
     // Arrange

--- a/test/demo/utils/serviceUtils.ts
+++ b/test/demo/utils/serviceUtils.ts
@@ -20,9 +20,9 @@ type RemoteExecResponse<R> = RemoteExecSuccess<R>|RemoteExecFailure;
 export async function executeJavascriptOnService<T, R>(func: ((data: T) => R | Promise<R>), data?: T): Promise<R> {
     const fin: Fin = await getConnection();
     return fin.InterApplicationBus.Channel.connect('layouts-provider-testing').then(async (channelClient: ChannelClient) => {
-        const response: RemoteExecResponse<R> = await channelClient.dispatch('execute-javascript', {script: func.toString(), data});
+        const response: RemoteExecResponse<string> = await channelClient.dispatch('execute-javascript', {script: func.toString(), data});
         if (response.success) {
-            return response.result;
+            return JSON.parse(response.result) as R;
         } else {
             // Reconstruct the error object from JSON
             const err = new Error();

--- a/test/demo/utils/serviceUtils.ts
+++ b/test/demo/utils/serviceUtils.ts
@@ -20,9 +20,9 @@ type RemoteExecResponse<R> = RemoteExecSuccess<R>|RemoteExecFailure;
 export async function executeJavascriptOnService<T, R>(func: ((data: T) => R | Promise<R>), data?: T): Promise<R> {
     const fin: Fin = await getConnection();
     return fin.InterApplicationBus.Channel.connect('layouts-provider-testing').then(async (channelClient: ChannelClient) => {
-        const response: RemoteExecResponse<string> = await channelClient.dispatch('execute-javascript', {script: func.toString(), data});
+        const response: RemoteExecResponse<R> = await channelClient.dispatch('execute-javascript', {script: func.toString(), data});
         if (response.success) {
-            return JSON.parse(response.result) as R;
+            return response.result;
         } else {
             // Reconstruct the error object from JSON
             const err = new Error();

--- a/test/demo/workspaces/basicSaveAndRestore.test.ts
+++ b/test/demo/workspaces/basicSaveAndRestore.test.ts
@@ -1,5 +1,6 @@
-import test from 'ava';
+import {test} from 'ava';
 
+import {teardown} from '../../teardown';
 import {AppInitializerParams} from '../utils/AppInitializer';
 import {AppContext, CreateAppData, createAppTest} from '../utils/createAppTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
@@ -24,6 +25,8 @@ numberOfApps.forEach(appNumber => {
         basicTestOptionsArray.push(manifestSaveAndRestoreTest);
     });
 });
+
+test.afterEach.always(teardown);
 
 testParameterized<CreateAppData, AppContext>(
     (testOptions: CreateAppData): string => `Basic SaveAndRestore - ${testOptions.apps[0].createType === 'manifest' ? 'Manifest' : 'Programmatic'} - ${

--- a/test/demo/workspaces/deregisteredBasicSaveAndRestore.test.ts
+++ b/test/demo/workspaces/deregisteredBasicSaveAndRestore.test.ts
@@ -1,6 +1,7 @@
-import test from 'ava';
+import {test} from 'ava';
 
 import {delay} from '../../provider/utils/delay';
+import {teardown} from '../../teardown';
 import {AppContext, CreateAppData, createAppTest} from '../utils/createAppTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 import {assertWindowNotRestored, closeAllPreviews, createBasicSaveAndRestoreTest, createCloseAndRestoreLayout} from '../utils/workspacesUtils';
@@ -23,6 +24,8 @@ numberOfApps.forEach(appNumber => {
         deregisteredTestOptionsArray.push(manifestDeregisteredTest);
     });
 });
+
+test.afterEach.always(teardown);
 
 testParameterized<CreateAppData, AppContext>(
     (testOptions: CreateAppData): string =>

--- a/test/demo/workspaces/schemaVersion.test.ts
+++ b/test/demo/workspaces/schemaVersion.test.ts
@@ -1,6 +1,8 @@
+import {test} from 'ava';
 import {MonitorInfo} from 'hadouken-js-adapter/out/types/src/api/system/monitor';
 
 import {Layout} from '../../../src/client/types';
+import {teardown} from '../../teardown';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 import {sendServiceMessage} from '../utils/serviceUtils';
 
@@ -8,6 +10,8 @@ interface SchemaVersionTestOptions {
     versionString: string|undefined;
     shouldError: boolean;
 }
+
+test.afterEach.always(teardown);
 
 testParameterized(
     (testOptions: SchemaVersionTestOptions) =>

--- a/test/demo/workspaces/snapSaveAndRestore.test.ts
+++ b/test/demo/workspaces/snapSaveAndRestore.test.ts
@@ -1,11 +1,13 @@
-import test from 'ava';
+import {test} from 'ava';
 
 import {assertAdjacent, assertGrouped} from '../../provider/utils/assertions';
 import {dragWindowTo} from '../../provider/utils/dragWindowTo';
+import {teardown} from '../../teardown';
 import {WindowGrouping} from '../utils/AppInitializer';
 import {AppContext, CreateAppData, createAppTest} from '../utils/createAppTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 import {closeAllPreviews, createCloseAndRestoreLayout, createSnapTests} from '../utils/workspacesUtils';
+
 import {BasicSaveRestoreTestOptions} from './basicSaveAndRestore.test';
 
 export interface SnapSaveRestoreTestOptions extends BasicSaveRestoreTestOptions {
@@ -36,6 +38,8 @@ appNumbers.forEach(appNumber => {
         }
     });
 });
+
+test.afterEach.always(teardown);
 
 testParameterized<CreateAppData, AppContext>(
     (testOptions: CreateAppData): string => `Snap SaveAndRestore - ${testOptions.apps[0].createType === 'manifest' ? 'Manifest' : 'Programmatic'} - ${

--- a/test/demo/workspaces/tabSaveAndRestore.test.ts
+++ b/test/demo/workspaces/tabSaveAndRestore.test.ts
@@ -1,10 +1,12 @@
-import test from 'ava';
+import {test} from 'ava';
 
 import {assertGrouped, assertTabbed} from '../../provider/utils/assertions';
+import {teardown} from '../../teardown';
 import {WindowGrouping} from '../utils/AppInitializer';
 import {AppContext, CreateAppData, createAppTest} from '../utils/createAppTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 import {closeAllPreviews, createCloseAndRestoreLayout, createTabTests} from '../utils/workspacesUtils';
+
 import {BasicSaveRestoreTestOptions} from './basicSaveAndRestore.test';
 
 export interface TabSaveRestoreTestOptions extends BasicSaveRestoreTestOptions {
@@ -35,6 +37,8 @@ appNumbers.forEach(appNumber => {
         }
     });
 });
+
+test.afterEach.always(teardown);
 
 testParameterized<CreateAppData, AppContext>(
     (testOptions: CreateAppData): string => `Tab SaveAndRestore - ${testOptions.apps[0].createType === 'manifest' ? 'Manifest' : 'Programmatic'} - ${

--- a/test/demo/workspaces/validateOnRestore.test.ts
+++ b/test/demo/workspaces/validateOnRestore.test.ts
@@ -1,8 +1,11 @@
+import {test} from 'ava';
+
 import {Layout} from '../../../src/client/types';
 import {assertAllContiguous, assertGrouped, assertNotGrouped} from '../../provider/utils/assertions';
 import {createChildWindow} from '../../provider/utils/createChildWindow';
 import {delay} from '../../provider/utils/delay';
 import {WindowInitializer} from '../../provider/utils/WindowInitializer';
+import {teardown} from '../../teardown';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 import {layoutsClientPromise} from '../utils/serviceUtils';
 import {assertWindowNotRestored, assertWindowRestored} from '../utils/workspacesUtils';
@@ -22,6 +25,8 @@ const childOptions = {
     url: 'http://localhost:1337/test/demo-window.html',
     frame: false
 };
+
+test.afterEach.always(teardown);
 
 testParameterized(
     'Validate Group on Restore',

--- a/test/provider/deregisterWindow.test.ts
+++ b/test/provider/deregisterWindow.test.ts
@@ -2,6 +2,7 @@ import {test} from 'ava';
 import {Fin, Window} from 'hadouken-js-adapter';
 import * as robot from 'robotjs';
 
+import {teardown} from '../teardown';
 import {getConnection} from './utils/connect';
 import {createChildWindow} from './utils/createChildWindow';
 import {dragWindowAndHover} from './utils/dragWindowAndHover';
@@ -19,6 +20,7 @@ test.afterEach.always(async () => {
     await win1.close();
     await win2.close();
 });
+test.afterEach.always(teardown);
 
 test('normal deregister, snap with registered', async t => {
     win1 = await createChildWindow({
@@ -209,7 +211,7 @@ test('deregister snapped window', async t => {
 
 test('no preview when deregistered - dragging registered', async t => {
     // Wrap the pre-spawned preview window
-    const previewWin = await getWindow({name: 'previewWindow-', uuid: 'layouts-service'});
+    const previewWin = await getWindow({name: 'previewWindow', uuid: 'layouts-service'});
 
     // Spawn two child windows (one of them deregistered)
     win1 = await createChildWindow({
@@ -246,7 +248,7 @@ test('no preview when deregistered - dragging registered', async t => {
 
 test('no preview when deregistered - dragging deregistered', async t => {
     // Wrap the pre-spawned preview window
-    const previewWin = await getWindow({name: 'previewWindow-', uuid: 'layouts-service'});
+    const previewWin = await getWindow({name: 'previewWindow', uuid: 'layouts-service'});
 
     // Spawn two child windows (one of them deregistered)
     win1 = await createChildWindow({

--- a/test/provider/dockingDisabled.test.ts
+++ b/test/provider/dockingDisabled.test.ts
@@ -2,6 +2,7 @@ import {test} from 'ava';
 import {Fin, Window} from 'hadouken-js-adapter';
 
 import {promiseMap} from '../../src/provider/snapanddock/utils/async';
+import {teardown} from '../teardown';
 
 import {assertGrouped, assertNotGrouped} from './utils/assertions';
 import {getConnection} from './utils/connect';
@@ -53,6 +54,7 @@ test.afterEach.always(async t => {
     // Re-enable docking after each test as service state persists through whole run
     await disableDocking(false);
 });
+test.afterEach.always(teardown);
 
 test('docking enabled - normal behaviour expected', async t => {
     let bounds: NormalizedBounds[];

--- a/test/provider/explodeGroup.test.ts
+++ b/test/provider/explodeGroup.test.ts
@@ -3,6 +3,7 @@ import {Fin, Window} from 'hadouken-js-adapter';
 
 import {WindowIdentity} from '../../src/client/types';
 import {explodeGroup} from '../demo/utils/snapServiceUtils';
+import {teardown} from '../teardown';
 
 import {getConnection} from './utils/connect';
 import {getBounds} from './utils/getBounds';
@@ -27,6 +28,7 @@ test.afterEach.always(async () => {
     }
     windows = new Array<Window>();
 });
+test.afterEach.always(teardown);
 
 async function assertExploded(t: GenericTestContext<AnyContext>) {
     // Check each window

--- a/test/provider/ignoreErrorWindows.test.ts
+++ b/test/provider/ignoreErrorWindows.test.ts
@@ -16,7 +16,13 @@ let crashApp: Application|undefined = undefined;
 test.before(async t => {
     fin = await getConnection();
 });
-test.afterEach.always(teardown);
+test.afterEach.always(async t => {
+    if (crashApp) {
+        crashApp.close(true);
+    }
+
+    await teardown(t);
+});
 
 test('Error windows are not registered with S&D or Tabbing', async t => {
     crashApp = await fin.Application.create(
@@ -78,12 +84,6 @@ test('Error windows are not included in generateLayout', async t => {
         t.false(isErrorInLayout(errorWindow.identity.uuid, layout), 'Error window found in generated layout');
 
         await errorWindow.close();
-    }
-});
-
-test.afterEach.always(async t => {
-    if (crashApp && await crashApp.isRunning()) {
-        crashApp.close(true);
     }
 });
 

--- a/test/provider/ignoreErrorWindows.test.ts
+++ b/test/provider/ignoreErrorWindows.test.ts
@@ -5,6 +5,7 @@ import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 import {Layout} from '../../src/client/types';
 import {sendServiceMessage} from '../demo/utils/serviceUtils';
 import {isWindowRegistered} from '../demo/utils/snapServiceUtils';
+import {teardown} from '../teardown';
 
 import {getConnection} from './utils/connect';
 import {delay} from './utils/delay';
@@ -15,6 +16,7 @@ let crashApp: Application|undefined = undefined;
 test.before(async t => {
     fin = await getConnection();
 });
+test.afterEach.always(teardown);
 
 test('Error windows are not registered with S&D or Tabbing', async t => {
     crashApp = await fin.Application.create(

--- a/test/provider/nativeGroupListeners.test.ts
+++ b/test/provider/nativeGroupListeners.test.ts
@@ -3,6 +3,7 @@ import {Fin, Window} from 'hadouken-js-adapter';
 
 import {WindowIdentity} from '../../src/client/types';
 import {undockWindow} from '../demo/utils/snapServiceUtils';
+import {teardown} from '../teardown';
 
 import {assertGrouped, assertMoved, assertNotGrouped, assertNotMoved} from './utils/assertions';
 import {getConnection} from './utils/connect';
@@ -72,6 +73,7 @@ test.afterEach.always(async () => {
     win1 = win2 = {} as Window;
     windows = new Array<Window>();
 });
+test.afterEach.always(teardown);
 
 /* ====== Utils ====== */
 

--- a/test/provider/tabOnDragOver.test.ts
+++ b/test/provider/tabOnDragOver.test.ts
@@ -2,6 +2,8 @@ import {test} from 'ava';
 import {Fin, Window} from 'hadouken-js-adapter';
 import * as robot from 'robotjs';
 
+import {teardown} from '../teardown';
+
 import {assertNotTabbed, assertTabbed} from './utils/assertions';
 import {getConnection} from './utils/connect';
 import {createChildWindow} from './utils/createChildWindow';
@@ -54,6 +56,7 @@ test.afterEach.always(async () => {
 
     wins = [];
 });
+test.afterEach.always(teardown);
 
 test('Drag window over window - should create tabgroup', async t => {
     // Drag wins[0] over wins[1] to make a tabset (in valid drop region)

--- a/test/provider/undock.test.ts
+++ b/test/provider/undock.test.ts
@@ -4,6 +4,7 @@ import {Fin, Window} from 'hadouken-js-adapter';
 import {WindowIdentity} from '../../src/client/types';
 import {UNDOCK_MOVE_DISTANCE} from '../../src/provider/snapanddock/Config';
 import {undockWindow} from '../demo/utils/snapServiceUtils';
+import {teardown} from '../teardown';
 
 import {assertNotGrouped} from './utils/assertions';
 import {getConnection} from './utils/connect';
@@ -39,6 +40,7 @@ test.afterEach.always(async () => {
     }
     windows = new Array<Window>();
 });
+test.afterEach.always(teardown);
 
 
 async function initWindows(t: TestContext, num: number, side?: Side) {

--- a/test/provider/updateTabProperties.test.ts
+++ b/test/provider/updateTabProperties.test.ts
@@ -5,6 +5,7 @@ import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 import {WindowIdentity} from '../../src/provider/model/DesktopWindow';
 import {executeJavascriptOnService} from '../demo/utils/serviceUtils';
 import {updateTabProperties} from '../demo/utils/tabServiceUtils';
+import {teardown} from '../teardown';
 
 import {getConnection} from './utils/connect';
 import {tabWindowsTogether} from './utils/tabWindowsTogether';
@@ -31,6 +32,7 @@ test.afterEach.always(async () => {
 
     wins = [];
 });
+test.afterEach.always(teardown);
 
 test('Update Tab Properties - property changes reflected in service', async t => {
     // Drag wins[0] over wins[1] to make a tabset (in valid drop region)

--- a/test/provider/userBoundsChanging.test.ts
+++ b/test/provider/userBoundsChanging.test.ts
@@ -1,10 +1,11 @@
 import {AnyContext, GenericTestContext, test} from 'ava';
 import {Fin, Window} from 'hadouken-js-adapter';
 
+import {teardown} from '../teardown';
+
 import {getConnection} from './utils/connect';
 import {createChildWindow} from './utils/createChildWindow';
 import {delay} from './utils/delay';
-
 import {getBounds} from './utils/getBounds';
 
 let fin: Fin;
@@ -51,6 +52,7 @@ test.afterEach.always(async () => {
 
     wins = [];
 });
+test.afterEach.always(teardown);
 
 test('Animate Basic Snap, top - should not snap', async t => {
     const win2Bounds = await getBounds(wins[1]);

--- a/test/runner.js
+++ b/test/runner.js
@@ -137,27 +137,24 @@ async function serve() {
 
         // Add route to dynamically generate app manifests
         app.use('/create-manifest', (req, res) => {
-            const { uuid, url, defaultTop } = req.query;
+            const {uuid, url, defaultTop} = req.query;
 
-            res.contentType('application/json')
-            res.json({
-                "devtools_port": 9090,
-                "runtime": {
-                    "arguments": "--v=1 --enable-crash-reporting",
-                    "version": "9.61.37.46"
-                },
-                "services": [{ "name": "layouts", "manifestUrl": "http://localhost:1337/test/provider.json" }],
-                "startup_app": {
-                    "uuid": uuid || 'save-restore-test-app-' + Math.random().toString(36).substring(2),                    
-                    "url": url || 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=false',
-                    "autoShow": true,
-                    "saveWindowState": false,
-                    "defaultTop": defaultTop ? JSON.parse(defaultTop): 100,
-                    "defaultLeft": 100,
-                    "defaultHeight": 225,
-                    "defaultWidth": 225
-                }
-            });
+            // Create manifest (based upon demo app manifest)
+            const manifest = require('../res/demo/app.json');
+            manifest.startup_app = {
+                uuid: uuid || 'save-restore-test-app-' + Math.random().toString(36).substring(2),
+                url: url || 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=false',
+                defaultTop: defaultTop ? JSON.parse(defaultTop): 100,
+                defaultLeft: 100,
+                defaultHeight: 225,
+                defaultWidth: 225
+            };
+            delete manifest.shortcut;
+            delete manifest.services;
+
+            // Send response
+            res.contentType('application/json');
+            res.json(manifest);
         });
         
         console.log("Starting test server...");

--- a/test/runner.js
+++ b/test/runner.js
@@ -140,17 +140,20 @@ async function serve() {
             const {uuid, url, defaultTop} = req.query;
 
             // Create manifest (based upon demo app manifest)
-            const manifest = require('../res/demo/app.json');
-            manifest.startup_app = {
-                uuid: uuid || 'save-restore-test-app-' + Math.random().toString(36).substring(2),
-                url: url || 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=false',
-                defaultTop: defaultTop ? JSON.parse(defaultTop): 100,
-                defaultLeft: 100,
-                defaultHeight: 225,
-                defaultWidth: 225
+            const {shortcut, services, ...baseManifest} = require('../res/demo/app.json');
+            const manifest = {
+                ...baseManifest,
+                startup_app: {
+                    uuid: uuid || 'save-restore-test-app-' + Math.random().toString(36).substring(2),
+                    url: url || 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=false',
+                    autoShow: true,
+                    saveWindowState: false,
+                    defaultTop: defaultTop ? JSON.parse(defaultTop): 100,
+                    defaultLeft: 100,
+                    defaultHeight: 225,
+                    defaultWidth: 225
+                }
             };
-            delete manifest.shortcut;
-            delete manifest.services;
 
             // Send response
             res.contentType('application/json');

--- a/test/teardown.ts
+++ b/test/teardown.ts
@@ -1,0 +1,130 @@
+import {TestContext} from 'ava';
+import {Window} from 'hadouken-js-adapter';
+
+import {getConnection} from './provider/utils/connect';
+import {executeJavascriptOnService} from './demo/utils/serviceUtils';
+import {WindowInfo, WindowDetail} from 'hadouken-js-adapter/out/types/src/api/system/window';
+import {delay} from './provider/utils/delay';
+
+/**
+ * Util function to completely reset the desktop in-between test runs.
+ * 
+ * This should be added as a `test.afterEach.always` hook in EVERY ava test file.
+ * 
+ * Any left-over state will cause the previous test to fail, but this state will be clean-ed-up so that it does not
+ * impact the next test to run.
+ * 
+ * @param t Test context
+ */
+export async function teardown(t: TestContext): Promise<void> {
+    const fin = await getConnection();
+
+    await closeAllWindows(t);
+    await resetProviderState(t);
+    
+    fin.InterApplicationBus.removeAllListeners();
+    
+    const msg = await executeJavascriptOnService(function(this: ProviderWindow) {
+        const m = this.model;
+        const lengths = [m.windows.length, Object.keys(m['_windowLookup']).length, m.snapGroups.length, m.tabGroups.length];
+
+        if (lengths.some(l => l > 0)) {
+            return `${lengths.join(" ")}\n${m.windows.map(w => w.id).join(', ')}\n${m.snapGroups.map(g => `${g.id}${g.entities.map(w => w.id).join(',')}`).join(', ')}\n${m.tabGroups.map(g => `${g.id}${g.tabs.map(w => w.id).join(',')}`).join(', ')}`;
+        } else {
+            return null;
+        }
+    });
+    if (msg) {
+        console.log(msg);
+    }
+}
+
+async function closeAllWindows(t: TestContext): Promise<void> {
+    const fin = await getConnection();
+
+    // Fetch all open windows
+    const windowInfo: WindowInfo[] = await fin.System.getAllWindows();
+    const windows: Window[] = windowInfo.reduce<Window[]>((windows: Window[], info: WindowInfo) => {
+        windows.push(fin.Window.wrapSync({uuid: info.uuid, name: info.mainWindow.name}));
+        info.childWindows.forEach((child: WindowDetail) => {
+            windows.push(fin.Window.wrapSync({uuid: info.uuid, name: child.name}));
+        });
+
+        return windows;
+    }, []);
+
+    // Look for any windows that should no longer exist
+    const windowIsVisible: boolean[] = await Promise.all(windows.map(w => w.isShowing()));
+    const invalidWindows: Window[] = windows.filter((window: Window, index: number) => {
+        const {uuid, name} = window.identity;
+
+        if (uuid === 'testApp') {
+            // Main window persists, but close any child windows
+            return name !== uuid;
+        } else if(uuid === 'layouts-service') {
+            if (name === uuid || name === 'previewWindow') {
+                // Main window and preview window persist
+                return false;
+            } else if (name!.startsWith('TABSET-')) {
+                // Allow pooled tabstrips to persist, but destroy any broken/left-over tabstrips
+                // Will assume that any invisible tabstrips are pooled
+                return windowIsVisible[index];
+            } else {
+                // Any other service windows (S&R placeholders, etc) should get cleaned-up
+                return false;
+            }
+        } else {
+            // All other applications should get cleaned-up
+            return true;
+        }
+    });
+
+    if (invalidWindows.length > 0) {
+        await Promise.all(invalidWindows.map((window: Window) => window.close(true)));
+        t.fail(`${invalidWindows.length} window(s) left over after test: ${invalidWindows.map(w => `${w.identity.uuid}/${w.identity.name}`).join(", ")}`);
+    }
+}
+
+async function resetProviderState(t: TestContext): Promise<void> {
+    const msg: string|null = await executeJavascriptOnService(function(this: ProviderWindow): string|null {
+        const SEPARATOR_LIST = ', ';
+        const SEPARATOR_LINE = '\n    ';
+
+        const {windows, snapGroups, tabGroups} = this.model;
+        const msgs: string[] = [];
+
+        if (windows.length > 0) {
+            msgs.push(`Provider still had ${windows.length} windows registered: ${windows.map(w => w.id).join(SEPARATOR_LIST)}`);
+            this.model['_windows'].length = 0;
+            this.model['_windowLookup'] = {};
+        }
+        if (snapGroups.length > 0) {
+            const groupInfo = snapGroups.map((s, i) => `${i+1}: ${s.id} (${s.entities.map(e => e.id).join(SEPARATOR_LIST)})`).join(SEPARATOR_LINE);
+            
+            msgs.push(`Provider still had ${snapGroups.length} snapGroups registered:${SEPARATOR_LINE}${groupInfo}`);
+            this.model['_snapGroups'].length = 0;
+        }
+        if (tabGroups.length > 0) {
+            const groupInfo = tabGroups.map((t, i) => `${i+1}: ${t.id} (${t.tabs.map(w => w.id).join(SEPARATOR_LIST)})`).join(SEPARATOR_LINE);
+
+            msgs.push(`Provider still had ${tabGroups.length} tabGroups registered:${SEPARATOR_LINE}${groupInfo}`);
+            this.model['_tabGroups'].length = 0;
+        }
+
+        if (msgs.length > 1) {
+            return `${msgs.length} issues detected in provider state:${SEPARATOR_LINE}${msgs.join(SEPARATOR_LINE)}`;
+        } else if (msgs.length === 1) {
+            return msgs[0];
+        } else {
+            return null;
+        }
+    });
+
+    if (msg) {
+        // Fail test
+        t.fail(msg);
+
+        // Wait for clean-up to complete
+        await delay(5000);
+    }
+}


### PR DESCRIPTION
Added an 'afterEach' hook to run after each integration test. The hook will ensure that the desktop state has been completely reset before the next test starts.

If there is any left-over state (such as a window being open that shouldn't be), then the util will repair the issue to get the test runner back into it's default state, and then fail the previous test with a description of the problem.

There is one exception to the "fail" rule - due to a known issue where closing multiple tabs simultaneously may not destroy the tabstrip window, any remaining tabstrip windows will not cause the previous test to fail. The util will still clean-up the left-over tabstrip window(s). The root cause of this issue will be investigated in a future story.