### PR TITLE
[SERVICE-302] Properly restore windows that were formerly a part of a tab group.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -571,7 +571,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "arr-union": {
@@ -1473,7 +1473,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -3092,6 +3092,7 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -3666,7 +3667,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3678,6 +3680,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3692,6 +3695,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3699,12 +3703,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3723,6 +3729,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3803,7 +3810,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3815,6 +3823,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3936,6 +3945,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4678,7 +4688,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
@@ -4779,7 +4789,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -5632,7 +5642,7 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "mimic-response": {
@@ -5656,7 +5666,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -5895,7 +5905,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -6536,7 +6546,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
     "progress": {
@@ -7103,7 +7113,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
         "is-equal-shallow": "^0.1.3"
@@ -7876,7 +7886,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
@@ -8295,7 +8305,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3092,7 +3092,6 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -3667,8 +3666,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3680,7 +3678,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3695,7 +3692,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3703,14 +3699,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3729,7 +3723,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3810,8 +3803,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3823,7 +3815,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3945,7 +3936,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -571,7 +571,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
@@ -1473,7 +1473,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -4678,7 +4678,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
       "dev": true
     },
     "inquirer": {
@@ -4779,7 +4779,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-builtin-module": {
@@ -5632,7 +5632,7 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
       "dev": true
     },
     "mimic-response": {
@@ -5656,7 +5656,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -5895,7 +5895,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -6536,7 +6536,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
       "dev": true
     },
     "progress": {
@@ -7103,7 +7103,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
         "is-equal-shallow": "^0.1.3"
@@ -7876,7 +7876,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
@@ -8295,7 +8295,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -10,7 +10,7 @@ import {WindowIdentity} from '../model/DesktopWindow';
 import {promiseMap} from '../snapanddock/utils/async';
 
 import {getGroup} from './group';
-import {addToWindowObject, inWindowObject, parseVersionString, wasCreatedFromManifest, wasCreatedProgrammatically, WindowObject, adjustSizeOfFormerlyTabbedWindows} from './utils';
+import {addToWindowObject, adjustSizeOfFormerlyTabbedWindows, inWindowObject, parseVersionString, wasCreatedFromManifest, wasCreatedProgrammatically, WindowObject} from './utils';
 
 // This value should be updated any time changes are made to the layout schema.
 // Major version indicates breaking changes.
@@ -116,13 +116,13 @@ export const getCurrentLayout = async(): Promise<Layout> => {
             const mainWindow: LayoutWindow = {...windowInfo.mainWindow, ...mainWindowLayoutData};
             const mainWinIdentity = {uuid, name: mainWindow.name};
             adjustSizeOfFormerlyTabbedWindows(mainWinIdentity, formerlyTabbedWindows, mainWindow);
-            
+
             // Filter for deregistered child windows
             windowInfo.childWindows = windowInfo.childWindows.filter((win: WindowDetail) => {
                 const isDeregistered = inWindowObject({uuid, name: win.name}, deregisteredWindows);
                 return isDeregistered ? false : true;
             });
-            
+
             // Grab the layout information for the child windows
             const childWindows: LayoutWindow[] = await promiseMap(windowInfo.childWindows, async (childWin: WindowDetail) => {
                 const {name} = childWin;
@@ -211,6 +211,6 @@ const getLayoutWindowData = async(ofWin: Window, tabbedWindows: WindowObject): P
 
     // If a window is tabbed (based on filtered tabGroups), tab it.
     const isTabbed = inWindowObject(ofWin.identity, tabbedWindows) ? true : false;
-    
+
     return {info, uuid, windowGroup: filteredWindowGroup, frame: applicationState.frame, state: options.state, isTabbed, isShowing: !applicationState.hidden};
 };

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -120,14 +120,14 @@ export const getCurrentLayout = async(): Promise<Layout> => {
             // Filter for deregistered child windows
             windowInfo.childWindows = windowInfo.childWindows.filter((win: WindowDetail) => {
                 const isDeregistered = inWindowObject({uuid, name: win.name}, deregisteredWindows);
-                return isDeregistered ? false : true;
+                return !isDeregistered;
             });
 
             // Grab the layout information for the child windows
             const childWindows: LayoutWindow[] = await promiseMap(windowInfo.childWindows, async (childWin: WindowDetail) => {
                 const {name} = childWin;
                 const childWinIdentity = {uuid, name};
-                const ofWin = await fin.Window.wrap(childWinIdentity);
+                const ofWin = fin.Window.wrapSync(childWinIdentity);
                 const windowLayoutData = await getLayoutWindowData(ofWin, tabbedWindows);
                 adjustSizeOfFormerlyTabbedWindows(childWinIdentity, formerlyTabbedWindows, childWin);
 

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -118,10 +118,7 @@ export const getCurrentLayout = async(): Promise<Layout> => {
             adjustSizeOfFormerlyTabbedWindows(mainWinIdentity, formerlyTabbedWindows, mainWindow);
 
             // Filter for deregistered child windows
-            windowInfo.childWindows = windowInfo.childWindows.filter((win: WindowDetail) => {
-                const isDeregistered = inWindowObject({uuid, name: win.name}, deregisteredWindows);
-                return !isDeregistered;
-            });
+            windowInfo.childWindows = windowInfo.childWindows.filter((win: WindowDetail) => !inWindowObject({uuid, name: win.name}, deregisteredWindows));
 
             // Grab the layout information for the child windows
             const childWindows: LayoutWindow[] = await promiseMap(windowInfo.childWindows, async (childWin: WindowDetail) => {

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -1,13 +1,14 @@
 import {Window} from 'hadouken-js-adapter';
 import {ApplicationInfo} from 'hadouken-js-adapter/out/types/src/api/application/application';
+import {WindowDetail} from 'hadouken-js-adapter/out/types/src/api/system/window';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 import {Identity} from 'hadouken-js-adapter/out/types/src/identity';
+
 import {LayoutApp, LayoutWindow} from '../../client/types';
 import {model, tabService} from '../main';
 import {DesktopSnapGroup} from '../model/DesktopSnapGroup';
 import {WindowIdentity} from '../model/DesktopWindow';
-import {WindowDetail} from 'hadouken-js-adapter/out/types/src/api/system/window';
-import { ApplicationConfigManager } from '../tabbing/components/ApplicationConfigManager';
+import {ApplicationConfigManager} from '../tabbing/components/ApplicationConfigManager';
 
 export interface SemVer {
     major: number;

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -247,10 +247,10 @@ export function adjustSizeOfFormerlyTabbedWindows(winIdentity: WindowIdentity, f
             const tabGroup = tabWindow.tabGroup;
             if (tabGroup) {
                 const tabStripHeight = tabGroup.config.height;
-        
+
                 layoutWindow.top = layoutWindow.top - tabStripHeight;
                 layoutWindow.height = layoutWindow.height + tabStripHeight;
-        
+
                 if (applicationState.frame === true) {
                     layoutWindow.height = layoutWindow.height + 7;
                     layoutWindow.left = layoutWindow.left - 7;

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -6,6 +6,7 @@ import {LayoutApp, LayoutWindow} from '../../client/types';
 import {model, tabService} from '../main';
 import {DesktopSnapGroup} from '../model/DesktopSnapGroup';
 import {WindowIdentity} from '../model/DesktopWindow';
+import {WindowDetail} from 'hadouken-js-adapter/out/types/src/api/system/window';
 
 export interface SemVer {
     major: number;
@@ -234,4 +235,20 @@ export function parseVersionString(versionString: string): SemVer {
     }
 
     return {major: Number.parseInt(match[1], 10), minor: Number.parseInt(match[2], 10), patch: Number.parseInt(match[3], 10)};
+}
+
+export function adjustSizeOfFormerlyTabbedWindows(winIdentity: WindowIdentity, formerlyTabbedWindows: WindowObject, layoutWindow: LayoutWindow|WindowDetail) {
+    if (inWindowObject(winIdentity, formerlyTabbedWindows)) {
+        const desktopWindow = model.getWindow(winIdentity);
+        const applicationState = desktopWindow!.applicationState;
+
+        layoutWindow.top = layoutWindow.top - 60;
+        layoutWindow.height = layoutWindow.height + 60;
+
+        if (applicationState.frame === true) {
+            layoutWindow.height = layoutWindow.height + 7;
+            layoutWindow.left = layoutWindow.left - 7;
+            layoutWindow.width = layoutWindow.width + 14;
+        }
+    }
 }

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -7,6 +7,7 @@ import {model, tabService} from '../main';
 import {DesktopSnapGroup} from '../model/DesktopSnapGroup';
 import {WindowIdentity} from '../model/DesktopWindow';
 import {WindowDetail} from 'hadouken-js-adapter/out/types/src/api/system/window';
+import { ApplicationConfigManager } from '../tabbing/components/ApplicationConfigManager';
 
 export interface SemVer {
     major: number;
@@ -239,11 +240,13 @@ export function parseVersionString(versionString: string): SemVer {
 
 export function adjustSizeOfFormerlyTabbedWindows(winIdentity: WindowIdentity, formerlyTabbedWindows: WindowObject, layoutWindow: LayoutWindow|WindowDetail) {
     if (inWindowObject(winIdentity, formerlyTabbedWindows)) {
-        const desktopWindow = model.getWindow(winIdentity);
-        const applicationState = desktopWindow!.applicationState;
+        const tabWindow = model.getWindow(winIdentity);
+        const applicationState = tabWindow!.applicationState;
+        const tabGroup = tabWindow!.tabGroup;
+        const tabStripHeight = tabGroup!.config.height;
 
-        layoutWindow.top = layoutWindow.top - 60;
-        layoutWindow.height = layoutWindow.height + 60;
+        layoutWindow.top = layoutWindow.top - tabStripHeight;
+        layoutWindow.height = layoutWindow.height + tabStripHeight;
 
         if (applicationState.frame === true) {
             layoutWindow.height = layoutWindow.height + 7;

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -242,17 +242,21 @@ export function parseVersionString(versionString: string): SemVer {
 export function adjustSizeOfFormerlyTabbedWindows(winIdentity: WindowIdentity, formerlyTabbedWindows: WindowObject, layoutWindow: LayoutWindow|WindowDetail) {
     if (inWindowObject(winIdentity, formerlyTabbedWindows)) {
         const tabWindow = model.getWindow(winIdentity);
-        const applicationState = tabWindow!.applicationState;
-        const tabGroup = tabWindow!.tabGroup;
-        const tabStripHeight = tabGroup!.config.height;
-
-        layoutWindow.top = layoutWindow.top - tabStripHeight;
-        layoutWindow.height = layoutWindow.height + tabStripHeight;
-
-        if (applicationState.frame === true) {
-            layoutWindow.height = layoutWindow.height + 7;
-            layoutWindow.left = layoutWindow.left - 7;
-            layoutWindow.width = layoutWindow.width + 14;
+        if (tabWindow) {
+            const applicationState = tabWindow.applicationState;
+            const tabGroup = tabWindow.tabGroup;
+            if (tabGroup) {
+                const tabStripHeight = tabGroup.config.height;
+        
+                layoutWindow.top = layoutWindow.top - tabStripHeight;
+                layoutWindow.height = layoutWindow.height + tabStripHeight;
+        
+                if (applicationState.frame === true) {
+                    layoutWindow.height = layoutWindow.height + 7;
+                    layoutWindow.left = layoutWindow.left - 7;
+                    layoutWindow.width = layoutWindow.width + 14;
+                }
+            }
         }
     }
 }

--- a/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
+++ b/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
@@ -5,10 +5,6 @@ import {createAppsArray} from '../utils/AppInitializer';
 import {AppContext, CreateAppData, createAppTest} from '../utils/createAppTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 import {assertWindowRestored, closeAllPreviews, createCloseAndRestoreLayout} from '../utils/workspacesUtils';
-import {TabSaveRestoreTestOptions} from './tabSaveAndRestore.test';
-
-const formerTabGroupTestOptionsArray: TabSaveRestoreTestOptions[] = [];
-
 
 const registeredProgrammaticApp = createAppsArray(1, 0);
 const deregisteredProgrammaticParentandChild =
@@ -22,14 +18,14 @@ const combinedManifestApps = registeredManifestApp.concat(deregisteredManifestPa
 
 const windowGrouping = [[0, 2]];
 
-formerTabGroupTestOptionsArray.push({apps: combinedProgrammaticApps, tabWindowGrouping: windowGrouping});
-formerTabGroupTestOptionsArray.push({apps: combinedManifestApps, tabWindowGrouping: windowGrouping});
-
 
 testParameterized<CreateAppData, AppContext>(
     (testOptions: CreateAppData): string =>
         `Tab SaveAndRestore - ${testOptions.apps[0].createType === 'manifest' ? 'Manifest' : 'Programmatic'} - Formerly tabbed window resize`,
-    formerTabGroupTestOptionsArray,
+    [
+        {apps: combinedProgrammaticApps, tabWindowGrouping: windowGrouping},
+        {apps: combinedManifestApps, tabWindowGrouping: windowGrouping}
+    ],
     createAppTest(async (t, applicationData: CreateAppData) => {
         if (applicationData.tabWindowGrouping) {
             const group = applicationData.tabWindowGrouping[0];

--- a/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
+++ b/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
@@ -31,27 +31,31 @@ testParameterized<CreateAppData, AppContext>(
         `Tab SaveAndRestore - ${testOptions.apps[0].createType === 'manifest' ? 'Manifest' : 'Programmatic'} - Formerly tabbed window resize`,
     formerTabGroupTestOptionsArray,
     createAppTest(async (t, applicationData: CreateAppData) => {
-        const group = applicationData.tabWindowGrouping![0];
-        const win1 = t.context.windows[group[0]];
-        const win2 = t.context.windows[group[1]];
-
-
-        await assertTabbed(win1, win2, t);
-        await assertGrouped(t, win1, win2);
-        const tabbedBounds = await win1.getBounds();
-
-        await createCloseAndRestoreLayout(t);
-        await delay(2000);
-
-        await assertWindowRestored(t, win1.identity.uuid, win1.identity.name!);
-
-        const untabbedBounds = await win1.getBounds();
-
-        if (untabbedBounds.top === tabbedBounds.top || untabbedBounds.height === tabbedBounds.height) {
-            t.fail(`Application ${win1.identity.uuid} was restored at: ${tabbedBounds.top} x ${tabbedBounds.left} instead of ${untabbedBounds.top} x ${
-                untabbedBounds.left}`);
+        if (applicationData.tabWindowGrouping) {
+            const group = applicationData.tabWindowGrouping[0];
+            const win1 = t.context.windows[group[0]];
+            const win2 = t.context.windows[group[1]];
+    
+    
+            await assertTabbed(win1, win2, t);
+            await assertGrouped(t, win1, win2);
+            const tabbedBounds = await win1.getBounds();
+    
+            await createCloseAndRestoreLayout(t);
+            await delay(2000);
+    
+            await assertWindowRestored(t, win1.identity.uuid, win1.identity.name!);
+    
+            const untabbedBounds = await win1.getBounds();
+    
+            if (untabbedBounds.top === tabbedBounds.top || untabbedBounds.height === tabbedBounds.height) {
+                t.fail(`Application ${win1.identity.uuid} was restored at: ${tabbedBounds.top} x ${tabbedBounds.left} instead of ${untabbedBounds.top} x ${
+                    untabbedBounds.left}`);
+            } else {
+                t.pass();
+            }
         } else {
-            t.pass();
+            t.fail('Improper test options passed in. Test options must include tabWindowGroupings in order to test');
         }
     }));
 

--- a/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
+++ b/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
@@ -22,28 +22,24 @@ const windowGrouping = [[0, 2]];
 testParameterized<CreateAppData, AppContext>(
     (testOptions: CreateAppData): string =>
         `Tab SaveAndRestore - ${testOptions.apps[0].createType === 'manifest' ? 'Manifest' : 'Programmatic'} - Formerly tabbed window resize`,
-    [
-        {apps: combinedProgrammaticApps, tabWindowGrouping: windowGrouping},
-        {apps: combinedManifestApps, tabWindowGrouping: windowGrouping}
-    ],
+    [{apps: combinedProgrammaticApps, tabWindowGrouping: windowGrouping}, {apps: combinedManifestApps, tabWindowGrouping: windowGrouping}],
     createAppTest(async (t, applicationData: CreateAppData) => {
         if (applicationData.tabWindowGrouping) {
             const group = applicationData.tabWindowGrouping[0];
             const win1 = t.context.windows[group[0]];
             const win2 = t.context.windows[group[1]];
-    
-    
+
             await assertTabbed(win1, win2, t);
             await assertGrouped(t, win1, win2);
             const tabbedBounds = await win1.getBounds();
-    
+
             await createCloseAndRestoreLayout(t);
             await delay(2000);
-    
+
             await assertWindowRestored(t, win1.identity.uuid, win1.identity.name!);
-    
+
             const untabbedBounds = await win1.getBounds();
-    
+
             if (untabbedBounds.top === tabbedBounds.top || untabbedBounds.height === tabbedBounds.height) {
                 t.fail(`Application ${win1.identity.uuid} was restored at: ${tabbedBounds.top} x ${tabbedBounds.left} instead of ${untabbedBounds.top} x ${
                     untabbedBounds.left}`);

--- a/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
+++ b/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
@@ -1,0 +1,59 @@
+import test from 'ava';
+import {assertGrouped, assertTabbed} from '../../provider/utils/assertions';
+import {delay} from '../../provider/utils/delay';
+import {createAppsArray} from '../utils/AppInitializer';
+import {AppContext, CreateAppData, createAppTest} from '../utils/createAppTest';
+import {testParameterized} from '../utils/parameterizedTestUtils';
+import {assertWindowRestored, closeAllPreviews, createCloseAndRestoreLayout} from '../utils/workspacesUtils';
+import {TabSaveRestoreTestOptions} from './tabSaveAndRestore.test';
+
+const formerTabGroupTestOptionsArray: TabSaveRestoreTestOptions[] = [];
+
+
+const registeredProgrammaticApp = createAppsArray(1, 0);
+const deregisteredProgrammaticParentandChild =
+    createAppsArray(1, 1, {manifest: false, url: 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=true'});
+const combinedProgrammaticApps = registeredProgrammaticApp.concat(deregisteredProgrammaticParentandChild);
+
+const registeredManifestApp = createAppsArray(1, 0, {manifest: true, url: 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=false'});
+const deregisteredManifestParentandChild =
+    createAppsArray(1, 1, {manifest: true, url: 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=true'});
+const combinedManifestApps = registeredManifestApp.concat(deregisteredManifestParentandChild);
+
+const windowGrouping = [[0, 2]];
+
+formerTabGroupTestOptionsArray.push({apps: combinedProgrammaticApps, tabWindowGrouping: windowGrouping});
+formerTabGroupTestOptionsArray.push({apps: combinedManifestApps, tabWindowGrouping: windowGrouping});
+
+
+testParameterized<CreateAppData, AppContext>(
+    (testOptions: CreateAppData): string =>
+        `Tab SaveAndRestore - ${testOptions.apps[0].createType === 'manifest' ? 'Manifest' : 'Programmatic'} - Formerly tabbed window resize`,
+    formerTabGroupTestOptionsArray,
+    createAppTest(async (t, applicationData: CreateAppData) => {
+        const group = applicationData.tabWindowGrouping![0];
+        const win1 = t.context.windows[group[0]];
+        const win2 = t.context.windows[group[1]];
+
+
+        await assertTabbed(win1, win2, t);
+        await assertGrouped(t, win1, win2);
+        const tabbedBounds = await win1.getBounds();
+
+        await createCloseAndRestoreLayout(t);
+        await delay(2000);
+
+        await assertWindowRestored(t, win1.identity.uuid, win1.identity.name!);
+
+        const untabbedBounds = await win1.getBounds();
+
+        if (untabbedBounds.top === tabbedBounds.top || untabbedBounds.height === tabbedBounds.height) {
+            t.fail(`Application ${win1.identity.uuid} was restored at: ${tabbedBounds.top} x ${tabbedBounds.left} instead of ${untabbedBounds.top} x ${
+                untabbedBounds.left}`);
+        } else {
+            t.pass();
+        }
+    }));
+
+
+test.afterEach.always(closeAllPreviews);


### PR DESCRIPTION
- Previously, if a window was a part of a tab group that was going to be disbanded (say, if it is tabbed to the child window of a deregistered App), that window would restore at a smaller size. 
- Now, windows restore at their proper size. 