### PR TITLE
[SERVICE-308] Validate desktop after monitor resolution change

### DIFF
--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -67,6 +67,15 @@ export class DesktopModel {
                 }
             });
         });
+
+        // Validate everything on monitor change, as groups may become disjointed
+        fin.System.addListener('monitor-info-changed', async () => {
+            // Validate all tabgroups
+            this.tabGroups.map(g => g.validate());
+
+            // Validate all snap groups
+            this.snapGroups.map(g => g.validate());
+        });
     }
 
     public get mouseTracker(): MouseTracker {

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -3,7 +3,8 @@ import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 import {JoinTabGroupPayload, TabGroupEventPayload, TabPropertiesUpdatedPayload} from '../../client/tabbing';
 import {ApplicationUIConfig, TabProperties, WindowIdentity} from '../../client/types';
 import {Signal1} from '../Signal';
-import {Point} from '../snapanddock/utils/PointUtils';
+import {Debounced} from '../snapanddock/utils/Debounced';
+import {Point, PointUtils} from '../snapanddock/utils/PointUtils';
 import {Rectangle, RectUtils} from '../snapanddock/utils/RectUtils';
 
 import {DesktopEntity} from './DesktopEntity';
@@ -55,6 +56,7 @@ export class DesktopTabGroup implements DesktopEntity {
 
     private _config: ApplicationUIConfig;
 
+    private _validateGroup: Debounced<() => void, DesktopTabGroup, []>;
 
     /**
      * Constructor for the TabGroup Class.
@@ -77,6 +79,8 @@ export class DesktopTabGroup implements DesktopEntity {
         this._config = config;
 
         this._isMaximized = false;
+
+        this._validateGroup = new Debounced(this.validateGroupInternal, this);
 
         DesktopTabGroup.onCreated.emit(this);
     }
@@ -430,6 +434,10 @@ export class DesktopTabGroup implements DesktopEntity {
         return Promise.all(promises).then(() => {});
     }
 
+    public validate(): void {
+        this._validateGroup.call();
+    }
+
     private updateBounds(): void {
         const activeTab = this.activeTab;
         if (!activeTab) {
@@ -587,5 +595,20 @@ export class DesktopTabGroup implements DesktopEntity {
             // Send event to tabstrip
             this._window.sendMessage(event, payload)
         ]);
+    }
+
+    // Will check that all of the tabs and the tabstrip are still in the correct relative positions, and if not
+    // moves them so that they are
+    private async validateGroupInternal() {
+        const tabStripOffset: Point<number> = PointUtils.difference(
+            this._window.currentState.center,
+            {x: this.currentState.center.x, y: this.currentState.center.y - this.currentState.halfSize.y + this.config.height / 2});
+
+        if (PointUtils.lengthSquared(tabStripOffset) > 0) {
+            console.log('TabGroup disjointed. Moving tabstrip back to group.', this.id);
+            await DesktopWindow.transaction([this._window], async (wins: DesktopWindow[]) => {
+                await wins[0].applyOffset(tabStripOffset);
+            });
+        }
     }
 }

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -5,6 +5,7 @@ import {SERVICE_IDENTITY} from '../../client/internal';
 import {apiHandler} from '../main';
 import {Signal1, Signal2} from '../Signal';
 import {promiseMap} from '../snapanddock/utils/async';
+import {Debounced} from '../snapanddock/utils/Debounced';
 import {isWin10} from '../snapanddock/utils/platform';
 import {Point} from '../snapanddock/utils/PointUtils';
 import {Rectangle} from '../snapanddock/utils/RectUtils';
@@ -109,9 +110,22 @@ enum ActionOrigin {
 
 type OpenFinWindowEventHandler = <K extends keyof fin.OpenFinWindowEventMap>(event: fin.OpenFinWindowEventMap[K]) => void;
 
+interface Transaction {
+    windows: DesktopWindow[];
+    remove: Debounced<() => void, typeof DesktopWindow, []>;
+}
+
 export class DesktopWindow implements DesktopEntity {
     public static readonly onCreated: Signal1<DesktopWindow> = new Signal1();
     public static readonly onDestroyed: Signal1<DesktopWindow> = new Signal1();
+
+    /**
+     * Tracks which windows are currently being manipulated as part of a transaction.
+     *
+     * This is used to identify and ignore group-changed events triggered by intermediate steps
+     * of the transaction which may lead to out-of-sync state and general instability.
+     */
+    public static activeTransactions: Transaction[] = [];
 
     public static async getWindowState(window: Window): Promise<EntityState> {
         return Promise.all([window.getOptions(), window.isShowing(), window.getBounds()])
@@ -170,12 +184,30 @@ export class DesktopWindow implements DesktopEntity {
      * @param transform Promisified transformation function. Will be applied after all the windows have been detached from their previous window groups.
      */
     public static async transaction(windows: DesktopWindow[], transform: (windows: DesktopWindow[]) => Promise<void>): Promise<void> {
+        // Create a transaction object and add it to the active transactions list.
+        // The 'remove' property looks a bit strange but effectively lets the object remove itself
+        // from the list when prompted.
+        const transaction: Transaction = {
+            windows,
+            remove: new Debounced(
+                () => {
+                    const indexToRemove = this.activeTransactions.indexOf(transaction);
+                    if (indexToRemove >= 0) {
+                        this.activeTransactions.splice(indexToRemove, 1);
+                    }
+                },
+                this)
+        };
+        this.activeTransactions.push(transaction);
         await Promise.all(windows.map(w => w.sync()));
         await Promise.all(windows.map(w => w.unsnap()));
         // await Promise.all(windows.map(w => w.sync()));
         await transform(windows);
         await Promise.all(windows.map(w => w.snap()));
         // await Promise.all(windows.map(w => w.sync()));
+        // We use the debounced here rather than removing it directly to allow time for
+        // all related events to be handled.
+        transaction.remove.call();
     }
 
     private static isWindow(window: Window|fin.WindowOptions): window is Window {
@@ -906,10 +938,22 @@ export class DesktopWindow implements DesktopEntity {
 
         await this.sync();
 
-        console.log('Received window group changed event: ', event);
-
         const targetWindow: DesktopWindow|null = this._model.getWindow({uuid: event.targetWindowAppUuid, name: event.targetWindowName});
         const targetGroup: DesktopSnapGroup|null = targetWindow ? targetWindow.snapGroup : null;
+
+        // Ignore events for windows currently under a transaction, and if the transaction is over postpone
+        // it's removal in case there are more events yet to be handled.
+        const relevantTransactions =
+            DesktopWindow.activeTransactions.filter((transaction: Transaction) => transaction.windows.some(w => !!targetWindow && w._id === targetWindow._id));
+        if (relevantTransactions.length > 0) {
+            console.log('Window currently in a transaction. Ignoring window group changed event: ', event);
+            relevantTransactions.forEach(t => {
+                t.remove.postpone();
+            });
+            return;
+        }
+
+        console.log('Received window group changed event: ', event);
 
         switch (event.reason) {
             case 'leave':


### PR DESCRIPTION
On `monitor-info-change` event we now globally validate all tab- and snapGroups.

SnapGroups are validated with the same logic as in other places: group is split into any remaining contiguous sets of windows.

For tabGroups, monitor resizes generally result in all state being correct with the exception of the tabstrip. When validating we check the relative position of the tabStrip to the group and move it back into position.


Note Re: testing - I discussed with Phil and we think that it would be unwise to automate screen resizing on the test slaves with the current setup. For the time being this will need to be tested manually.