### PR TITLE
[SERVICE-317] Tab tearout will only work on one monitor at a time.

### DIFF
--- a/src/provider/tabbing/DragWindowManager.ts
+++ b/src/provider/tabbing/DragWindowManager.ts
@@ -1,4 +1,5 @@
 import {Window} from 'hadouken-js-adapter';
+import {DipRect, MonitorInfo} from 'hadouken-js-adapter/out/types/src/api/system/monitor';
 import {Point} from 'hadouken-js-adapter/out/types/src/api/system/point';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
@@ -6,7 +7,6 @@ import {WindowIdentity} from '../../client/types';
 import {DesktopModel} from '../model/DesktopModel';
 import {DesktopWindow} from '../model/DesktopWindow';
 import {Signal0, Signal2} from '../Signal';
-import { MonitorInfo, DipRect } from 'hadouken-js-adapter/out/types/src/api/system/monitor';
 
 /**
  * Handles the Drag Window which appears when API drag and drop is initialized.
@@ -105,7 +105,7 @@ export class DragWindowManager {
                     defaultTop: 0,
                     saveWindowState: false,
                     autoShow: true,
-                    opacity: 0.6,
+                    opacity: 0.01,
                     frame: false,
                     waitForPageLoad: false,
                     alwaysOnTop: true,
@@ -139,20 +139,22 @@ export class DragWindowManager {
             ev.stopPropagation();
             return true;
         });
-
-        
     }
 
     /**
      * Updates the in memory virtual screen bounds and positions the drag window accordingly.
-     * 
+     *
      * This should only be called on initalization and on 'monitor info changed' events.
      */
     private async setWindowBounds() {
         const monitorInfo: MonitorInfo = await fin.System.getMonitorInfo();
         this._virtualScreen = monitorInfo.virtualScreen;
 
-        this._window.setBounds(this._virtualScreen.left, this._virtualScreen.top, Math.abs(this._virtualScreen.left - this._virtualScreen.right),Math.abs(this._virtualScreen.top - this._virtualScreen.bottom));
+        this._window.setBounds(
+            this._virtualScreen.left,
+            this._virtualScreen.top,
+            Math.abs(this._virtualScreen.left - this._virtualScreen.right),
+            Math.abs(this._virtualScreen.top - this._virtualScreen.bottom));
         this._window.hide();
     }
 }

--- a/test/demo/tabbing/dragWindow.test.ts
+++ b/test/demo/tabbing/dragWindow.test.ts
@@ -1,0 +1,48 @@
+import {test} from 'ava';
+import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
+import robot from 'robotjs';
+
+import {CreateWindowData, createWindowTest} from '../../demo/utils/createWindowTest';
+import {testParameterized} from '../../demo/utils/parameterizedTestUtils';
+import {getConnection} from '../../provider/utils/connect';
+import {getBounds} from '../../provider/utils/getBounds';
+import {tabWindowsTogether} from '../../provider/utils/tabWindowsTogether';
+import {teardown} from '../../teardown';
+import {getTabstrip} from '../utils/tabServiceUtils';
+import {tearoutToPoint} from '../utils/tabstripUtils';
+
+
+test.afterEach.always(teardown);
+
+testParameterized(
+    (testOptions: CreateWindowData): string => `Drag Overlay Correct Size`,
+    [{frame: true, windowCount: 2}],
+    createWindowTest(async (t, testOptions: CreateWindowData) => {
+        const {windowCount} = testOptions;
+        const {windows} = t.context;
+
+        const fin = await getConnection();
+        const dragWindow: _Window = await fin.Window.wrap({name: 'TabbingDragWindow', uuid: 'layouts-service'});
+
+        await tabWindowsTogether(windows[0], windows[1]);
+
+        const bounds = await getBounds(windows[0]);
+        await tearoutToPoint(await getTabstrip(windows[0].identity), 1, {x: bounds.right! + 50, y: bounds.bottom! + 50}, true);
+
+        const dragWindowBounds = await getBounds(dragWindow);
+        const {virtualScreen} = await fin.System.getMonitorInfo();
+
+        robot.mouseToggle('up');
+
+        await windows[0].close();
+        await windows[1].close();
+
+        t.deepEqual(
+            {
+                left: virtualScreen.left,
+                top: virtualScreen.top,
+                width: Math.abs(virtualScreen.left - virtualScreen.right),
+                height: Math.abs(virtualScreen.top - virtualScreen.bottom)
+            },
+            {left: dragWindowBounds.left, top: dragWindowBounds.top, width: dragWindowBounds.width, height: dragWindowBounds.height});
+    }, {defaultCentered: true, defaultWidth: 250, defaultHeight: 150}));


### PR DESCRIPTION
Allows for the drag window to cover any monitor enabling multimonitor tabbing.  