### PR TITLE
[SERVICE-305] Replace existing URL-based parameters with JSON config

### DIFF
--- a/src/provider/APIHandler.ts
+++ b/src/provider/APIHandler.ts
@@ -115,7 +115,7 @@ export class APIHandler {
 
     private async deregister(identity: WindowIdentity, id: ProviderIdentity): Promise<void> {
         try {
-            this._model.deregister(identity, {level: 'window', uuid: id.uuid, name: id.name!});
+            this._model.deregister(identity, {level: 'window', uuid: id.uuid, name: id.name || id.uuid});
         } catch (error) {
             console.error(error);
             throw new Error(`Unexpected error when deregistering: ${error}`);

--- a/src/provider/main.ts
+++ b/src/provider/main.ts
@@ -34,14 +34,6 @@ declare const window: Window&{
 
 fin.desktop.main(main);
 
-interface SupportedArguments {
-    disableTabbingOperations: boolean;
-    disableDockingOperations: boolean;
-}
-type Stringified<T> = {
-    [P in keyof T]?: string;
-};
-
 export async function main() {
     config = window.config = new Store(require('../../gen/provider/config/defaults.json'));
     loader = window.loader = new Loader(config, 'layouts');
@@ -55,35 +47,6 @@ export async function main() {
     // Need to ensure that `DesktopTabstripFactory` is created synchronously at service startup.
     // This ensures that it's watch listeners are active at the point where any application-specific tabstrips are configured.
     DesktopTabGroup.windowPool;  // tslint:disable-line:no-unused-expression
-
-
-    fin.InterApplicationBus.subscribe({uuid: '*'}, 'layoutsService:experimental:disableTabbing', (message: boolean, source: Identity) => {
-        tabService.disableTabbingOperations = message;
-    });
-    fin.InterApplicationBus.subscribe({uuid: '*'}, 'layoutsService:experimental:disableDocking', (message: boolean, source: Identity) => {
-        snapService.disableDockingOperations = message;
-    });
-
-    fin.Application.getCurrentSync().addListener('run-requested', (event: RunRequestedEvent<'application', 'run-requested'>) => {
-        processUserArgs(event.userAppConfigArgs);
-    });
-    fin.Window.getCurrentSync().getOptions().then((options: fin.WindowOptions) => {
-        //@ts-ignore userAppConfigArgs is returned by this function, but missing from types
-        processUserArgs(options.userAppConfigArgs);
-    });
-
-    function processUserArgs(args: Stringified<SupportedArguments>): void {
-        if (args) {
-            console.log('Using URL config:', args);
-
-            if (args.disableTabbingOperations) {
-                tabService.disableTabbingOperations = args.disableTabbingOperations === 'true';
-            }
-            if (args.disableDockingOperations) {
-                snapService.disableDockingOperations = args.disableDockingOperations === 'true';
-            }
-        }
-    }
 
     await win10Check;
     await apiHandler.register();

--- a/src/provider/model/DesktopEntity.ts
+++ b/src/provider/model/DesktopEntity.ts
@@ -1,9 +1,10 @@
 import {Point} from 'hadouken-js-adapter/out/types/src/api/system/point';
 
+import {Scope} from '../../../gen/provider/config/scope';
+
 import {DesktopSnapGroup} from './DesktopSnapGroup';
 import {DesktopTabGroup} from './DesktopTabGroup';
 import {EntityState, WindowIdentity} from './DesktopWindow';
-import { Scope } from '../../../gen/provider/config/scope';
 
 /**
  * Interface for anything that can be snapped - namely windows and tab sets. Represents any entity that should be

--- a/src/provider/model/DesktopEntity.ts
+++ b/src/provider/model/DesktopEntity.ts
@@ -3,6 +3,7 @@ import {Point} from 'hadouken-js-adapter/out/types/src/api/system/point';
 import {DesktopSnapGroup} from './DesktopSnapGroup';
 import {DesktopTabGroup} from './DesktopTabGroup';
 import {EntityState, WindowIdentity} from './DesktopWindow';
+import { Scope } from '../../../gen/provider/config/scope';
 
 /**
  * Interface for anything that can be snapped - namely windows and tab sets. Represents any entity that should be
@@ -24,10 +25,15 @@ export interface DesktopEntity {
     identity: WindowIdentity;
 
     /**
+     * As identity, but with an extra identifier that allows the config of this identity to be queried more easily.
+     */
+    scope: Scope;
+
+    /**
      * The current cached state of this entity.
      *
      * This is updated by adding listeners to the underlying window object(s). Due to the asynchronous nature of window
-     * operations, there is no guarentee that this state isn't stale, but this state is always updated as soon as is
+     * operations, there is no guarantee that this state isn't stale, but this state is always updated as soon as is
      * possible.
      */
     currentState: EntityState;

--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -284,7 +284,7 @@ export class DesktopModel {
         } else {
             // Find which existing windows match this rule
             const windowsToRemove: DesktopWindow[] = this._windows.filter((window: DesktopWindow) => {
-                const windowScope: Scope = {level: 'window', ...window.identity};
+                const windowScope: Scope = window.scope;
 
                 // First check that window matches rule, then also perform a query. There could be other higher-precedence rules that override `rule`.
                 // We check windowScope against the rule first to avoid querying the store unnecessarily - likely only a very small subset of windows will

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -11,6 +11,7 @@ import {DesktopModel} from './DesktopModel';
 import {DesktopSnapGroup} from './DesktopSnapGroup';
 import {DesktopTabstripFactory} from './DesktopTabstripFactory';
 import {DesktopWindow, EntityState, eTransformType, Mask, WindowMessages} from './DesktopWindow';
+import { Scope } from '../../../gen/provider/config/scope';
 
 /**
  * Handles functionality for the TabSet
@@ -139,6 +140,19 @@ export class DesktopTabGroup implements DesktopEntity {
      */
     public get tabs(): ReadonlyArray<DesktopWindow> {
         return this._tabs;
+    }
+
+    /**
+     * Scope isn't really strictly defined for a tab group...
+     * 
+     * Will assume that the tab group should follow the config rules for the active tab, in reality it should be some
+     * kind of union/intersection of all of the tab properties, similar to resizeConstraints, etc.
+     * 
+     * Config store doesn't currently support querying for a range of scopes, or "merging" config objects together.
+     */
+    public get scope(): Scope {
+        const activeWindow = this._activeTab || this._tabs[0] || this._window;
+        return activeWindow.scope;
     }
 
     public get isMaximized(): boolean {

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -1,5 +1,6 @@
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
+import {Scope} from '../../../gen/provider/config/scope';
 import {JoinTabGroupPayload, TabGroupEventPayload, TabPropertiesUpdatedPayload} from '../../client/tabbing';
 import {ApplicationUIConfig, TabProperties, WindowIdentity} from '../../client/types';
 import {Signal1} from '../Signal';
@@ -11,7 +12,6 @@ import {DesktopModel} from './DesktopModel';
 import {DesktopSnapGroup} from './DesktopSnapGroup';
 import {DesktopTabstripFactory} from './DesktopTabstripFactory';
 import {DesktopWindow, EntityState, eTransformType, Mask, WindowMessages} from './DesktopWindow';
-import { Scope } from '../../../gen/provider/config/scope';
 
 /**
  * Handles functionality for the TabSet
@@ -144,10 +144,10 @@ export class DesktopTabGroup implements DesktopEntity {
 
     /**
      * Scope isn't really strictly defined for a tab group...
-     * 
+     *
      * Will assume that the tab group should follow the config rules for the active tab, in reality it should be some
      * kind of union/intersection of all of the tab properties, similar to resizeConstraints, etc.
-     * 
+     *
      * Config store doesn't currently support querying for a range of scopes, or "merging" config objects together.
      */
     public get scope(): Scope {

--- a/src/provider/snapanddock/Resolver.ts
+++ b/src/provider/snapanddock/Resolver.ts
@@ -170,6 +170,6 @@ export class Resolver {
      * @param state State of the window object we are considering for snapping
      */
     private isSnappable(window: DesktopEntity, state: EntityState): boolean {
-        return !state.hidden && state.opacity > 0 && state.state === 'normal' && this._config.query({level: 'window', ...window.identity}).features.snap;
+        return !state.hidden && state.opacity > 0 && state.state === 'normal' && this._config.query(window.scope).features.snap;
     }
 }

--- a/src/provider/snapanddock/SnapService.ts
+++ b/src/provider/snapanddock/SnapService.ts
@@ -34,17 +34,14 @@ export interface SnapState {
 }
 
 export class SnapService {
-    /**
-     * Flag to disable / enable docking.
-     */
-    public disableDockingOperations = false;
-
     private _resolver: Resolver;
 
     private _model: DesktopModel;
+    private _config: ConfigStore;
 
     constructor(model: DesktopModel, config: ConfigStore) {
         this._model = model;
+        this._config = config;
         this._resolver = new Resolver(config);
 
         // Register global undock hotkey listener
@@ -152,7 +149,9 @@ export class SnapService {
             // Snap all windows in activeGroup to snapTarget.group
             snapTarget.activeWindow.applyOffset(snapTarget.offset, snapTarget.halfSize!);
 
-            if (!this.disableDockingOperations) {
+            const canDockActive: boolean = this._config.query(snapTarget.activeWindow.scope).features.dock;
+            const canDockTarget: boolean = snapTarget.targetGroup.windows.every(window => this._config.query(window.scope).features.dock);
+            if (canDockActive && canDockTarget) {
                 // Dock all windows in activeGroup to snapTarget.group
                 snapTarget.activeWindow.setSnapGroup(snapTarget.targetGroup);
 

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -1,6 +1,7 @@
 import {Point} from 'hadouken-js-adapter/out/types/src/api/system/point';
 
 import {ConfigurationObject, Tabstrip} from '../../../gen/provider/config/layouts-config';
+import {Scope} from '../../../gen/provider/config/scope';
 import {TabGroup, TabGroupDimensions, WindowIdentity} from '../../client/types';
 import {RequiredRecursive} from '../config/ConfigUtil';
 import {ConfigStore} from '../main';
@@ -12,8 +13,8 @@ import {DesktopTabstripFactory} from '../model/DesktopTabstripFactory';
 import {DesktopWindow, EntityState} from '../model/DesktopWindow';
 import {Rectangle, RectUtils} from '../snapanddock/utils/RectUtils';
 import {eTargetType, TargetBase} from '../WindowHandler';
+
 import {DragWindowManager} from './DragWindowManager';
-import { Scope } from '../../../gen/provider/config/scope';
 
 /**
  * TabTarget constructs an interface which represents an area on a window where a tab strip will be placed.
@@ -82,12 +83,14 @@ export class TabService {
             throw new Error('Must provide at least 2 Tab Identifiers');
         }
 
-        const tabs: DesktopWindow[] = tabIdentities.map((identity: WindowIdentity) => {
-            return this._model.getWindow(identity);
-        }).filter((tab: DesktopWindow|null): tab is DesktopWindow => {
-            // Also filter-out any tabbing-disabled windows
-            return tab !== null && this._config.query(tab.scope).features.tab;
-        });
+        const tabs: DesktopWindow[] = tabIdentities
+                                          .map((identity: WindowIdentity) => {
+                                              return this._model.getWindow(identity);
+                                          })
+                                          .filter((tab: DesktopWindow|null): tab is DesktopWindow => {
+                                              // Also filter-out any tabbing-disabled windows
+                                              return tab !== null && this._config.query(tab.scope).features.tab;
+                                          });
 
         if (tabs.length !== tabIdentities.length) {
             if (tabs.length < 2) {

--- a/test/provider/deregisterConfig.test.ts
+++ b/test/provider/deregisterConfig.test.ts
@@ -35,11 +35,6 @@ test.beforeEach(async (t: TestContext) => {
     t.context.windows = [];
 });
 test.afterEach.always(async (t: TestContext) => {
-    await executeJavascriptOnService(function(this: ProviderWindow) {
-        this.config.removeFromSource({level: 'window', uuid: 'testApp', name: 'testWindow'});
-        this.config.removeFromSource({level: 'window', uuid: 'testApp', name: 'testWindow1'});
-        this.config.removeFromSource({level: 'window', uuid: 'testApp', name: 'testWindow2'});
-    });
     await Promise.all(t.context.windows.map(win => win.close()));
 
     await teardown(t);

--- a/test/provider/deregisterWindow.test.ts
+++ b/test/provider/deregisterWindow.test.ts
@@ -18,18 +18,12 @@ let fin: Fin;
 test.before(async () => {
     fin = await getConnection();
 });
-test.afterEach.always(async () => {
-    // Need to explicitly remove de-register config from the store after each test completes
-    // Once SERVICE-291 is implemented, this will happen automatically when the window closes
-    await executeJavascriptOnService(function(this: ProviderWindow) {
-        this.config.removeFromSource({level: 'window', uuid: 'testApp', name: 'win1'});
-        this.config.removeFromSource({level: 'window', uuid: 'testApp', name: 'win2'});
-    });
-
+test.afterEach.always(async (t) => {
     await win1.close();
     await win2.close();
+
+    await teardown(t);
 });
-test.afterEach.always(teardown);
 
 test('normal deregister, snap with registered', async t => {
     win1 = await createChildWindow({

--- a/test/provider/dockingDisabled.test.ts
+++ b/test/provider/dockingDisabled.test.ts
@@ -1,6 +1,7 @@
 import {test} from 'ava';
 import {Window} from 'hadouken-js-adapter';
 
+import {Scope} from '../../gen/provider/config/scope';
 import {promiseMap} from '../../src/provider/snapanddock/utils/async';
 import {executeJavascriptOnService} from '../demo/utils/serviceUtils';
 import {teardown} from '../teardown';
@@ -10,7 +11,6 @@ import {getConnection} from './utils/connect';
 import {createChildWindow} from './utils/createChildWindow';
 import {dragSideToSide, dragWindowTo} from './utils/dragWindowTo';
 import {getBounds, NormalizedBounds} from './utils/getBounds';
-import { Scope } from '../../gen/provider/config/scope';
 
 let windows: Window[] = new Array<Window>(2);
 
@@ -69,18 +69,18 @@ test('docking enabled - normal behaviour expected', async t => {
 
 test('docking disabled - windows should snap but not dock', async t => {
     await toggleDocking(false);
-    
+
     let bounds: NormalizedBounds[];
-    
+
     await dragSideToSide(windows[1], 'left', windows[0], 'right', {x: 5, y: 10});
-    
+
     await assertNotGrouped(windows[0], t);
     await assertNotGrouped(windows[1], t);
     bounds = await promiseMap(windows, win => getBounds(win));
     t.is(bounds[0].right, bounds[1].left);
-    
+
     await dragWindowTo(windows[0], 400, 400);
-    
+
     await assertNotGrouped(windows[0], t);
     await assertNotGrouped(windows[1], t);
     bounds = await promiseMap(windows, win => getBounds(win));

--- a/test/provider/dockingDisabled.test.ts
+++ b/test/provider/dockingDisabled.test.ts
@@ -48,9 +48,6 @@ test.afterEach.always(async t => {
     }
     windows = new Array<Window>(2);
 
-    // Re-enable docking after each test as service state persists through whole run
-    await toggleDocking(true);
-
     await teardown(t);
 });
 

--- a/test/provider/dockingDisabled.test.ts
+++ b/test/provider/dockingDisabled.test.ts
@@ -7,7 +7,6 @@ import {executeJavascriptOnService} from '../demo/utils/serviceUtils';
 import {teardown} from '../teardown';
 
 import {assertGrouped, assertNotGrouped} from './utils/assertions';
-import {getConnection} from './utils/connect';
 import {createChildWindow} from './utils/createChildWindow';
 import {dragSideToSide, dragWindowTo} from './utils/dragWindowTo';
 import {getBounds, NormalizedBounds} from './utils/getBounds';
@@ -16,6 +15,7 @@ let windows: Window[] = new Array<Window>(2);
 
 const windowOptions = [
     {
+        name: 'dock-win1',
         autoShow: true,
         saveWindowState: false,
         defaultTop: 100,
@@ -26,6 +26,7 @@ const windowOptions = [
         frame: false
     },
     {
+        name: 'dock-win2',
         autoShow: true,
         saveWindowState: false,
         defaultTop: 300,
@@ -36,6 +37,7 @@ const windowOptions = [
         frame: false
     }
 ];
+const windowScopes: Scope[] = [{level: 'window', uuid: 'testApp', name: 'dock-win1'}, {level: 'window', uuid: 'testApp', name: 'dock-win2'}];
 
 test.beforeEach(async t => {
     for (let i = 0; i < 2; i++) {
@@ -88,8 +90,7 @@ test('docking disabled - windows should snap but not dock', async t => {
 });
 
 export async function toggleDocking(dockingEnabled: boolean): Promise<void> {
-    return executeJavascriptOnService(function(this: ProviderWindow, dockingEnabled) {
-        const scope: Scope = {level: 'application', uuid: 'testApp'};
-        this.config.add(scope, {features: {dock: dockingEnabled}});
-    }, dockingEnabled);
+    return executeJavascriptOnService(function(this: ProviderWindow, {windowScopes, dockingEnabled}) {
+        windowScopes.forEach(scope => this.config.add(scope, {features: {dock: dockingEnabled}}));
+    }, {windowScopes, dockingEnabled});
 }

--- a/test/teardown.ts
+++ b/test/teardown.ts
@@ -138,6 +138,9 @@ async function resetProviderState(t: TestContext): Promise<void> {
             if (rulesWithScope.length !== expectedCount) {
                 const configInfo = rulesWithScope.map(rule => JSON.stringify(rule)).join(SEPARATOR_LINE);
                 msgs.push(`Expected ${expectedCount} rules with scope ${scope}, got:${configInfo ? SEPARATOR_LINE + configInfo: " NONE"}`);
+
+                // Can't do a full clean-up without duplicating provider state here, but removing anything that was defined outside of the service (test windows, etc)
+                rules.set(scope, rulesWithScope.filter(config => config.source.level === 'service'));
             }
         });
         if (watches.length !== expectedWatcherCount) {


### PR DESCRIPTION
Removed the previous (temporary) service-wide flags with the config mechanism.

The services that had toggle-able features now apply these feature flags on a per-window basis, so these features can be disabled for specific windows/apps without affecting any unrelated windows.