### PR TITLE
[SERVICE-287] Prevent flicker on snap/tab previews when switching between valid/invalid targets

### DIFF
--- a/src/provider/Preview.ts
+++ b/src/provider/Preview.ts
@@ -1,6 +1,4 @@
-import {DesktopSnapGroup} from './model/DesktopSnapGroup';
 import {SnapTarget} from './snapanddock/Resolver';
-import {Point, PointUtils} from './snapanddock/utils/PointUtils';
 import {Rectangle} from './snapanddock/utils/RectUtils';
 import {TabTarget} from './tabbing/TabService';
 import {eTargetType, Target} from './WindowHandler';

--- a/src/provider/Preview.ts
+++ b/src/provider/Preview.ts
@@ -87,7 +87,7 @@ export class Preview {
     private positionPreview(previewWindow: fin.OpenFinWindow, target: PreviewableTarget) {
         const previewRect = this.generatePreviewRect(target);
 
-        previewWindow!.setBounds(
+        previewWindow.setBounds(
             previewRect.center.x - previewRect.halfSize.x,
             previewRect.center.y - previewRect.halfSize.y,
             previewRect.halfSize.x * 2,

--- a/src/provider/Preview.ts
+++ b/src/provider/Preview.ts
@@ -6,7 +6,6 @@ import {TabTarget} from './tabbing/TabService';
 import {eTargetType, Target} from './WindowHandler';
 
 const PREVIEW_SUCCESS = '#3D4059';
-const PREVIEW_SUCCESS_RESIZE = PREVIEW_SUCCESS;
 const PREVIEW_FAILURE = `repeating-linear-gradient(45deg, #3D4059, #3D4059 .25em, #C24629 0, #C24629 .5em)`;
 
 interface PreviewWindow {
@@ -63,11 +62,7 @@ export class Preview {
         this.positionPreview(target);
 
         if (target.valid) {
-            if (PointUtils.isEqual(this.activeWindowPreview.halfSize, groupHalfSize)) {
-                this.activeWindowPreview.nativeWindow!.document.body.style.background = PREVIEW_SUCCESS;
-            } else {
-                this.activeWindowPreview.nativeWindow!.document.body.style.background = PREVIEW_SUCCESS_RESIZE;
-            }
+            this.activeWindowPreview.nativeWindow!.document.body.style.background = PREVIEW_SUCCESS;
         } else {
             this.activeWindowPreview.nativeWindow!.document.body.style.background = PREVIEW_FAILURE;
         }

--- a/src/provider/Preview.ts
+++ b/src/provider/Preview.ts
@@ -22,7 +22,7 @@ export class Preview {
     constructor() {
         this._activeWindowPreview = null;
 
-        this._successPreviewWindow = this.createWindow('previewSuccess', SUCCESS_PREVIEW_BACKGROUND_CSS);
+        this._successPreviewWindow = this.createWindow('successPreview', SUCCESS_PREVIEW_BACKGROUND_CSS);
         this._failurePreviewWindow = this.createWindow('failurePreview', FAILURE_PREVIEW_BACKGROUND_CSS);
     }
 


### PR DESCRIPTION
This changes the internals of Preview to use two separate windows for success and failure, rather than changing CSS, which seems to take a frame to update, causing the flicker.

This also removes leftover debugging functionality, and incomplete/unused support for pooling windows, which has been found to be unnecessary