### PR TITLE
[SERVICE-323] generateLayout has incorrect state for maximized windows

### DIFF
--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -209,7 +209,6 @@ const getWorkspaceWindowData = async(ofWin: Window, tabbedWindows: WindowObject)
         }
     });
 
-    const options = await ofWin.getOptions();
     const desktopWindow = model.getWindow(identity);
     if (desktopWindow === null) {
         throw Error(`No desktop window for window. Name: ${identity.name}, UUID: ${identity.uuid}`);
@@ -219,5 +218,7 @@ const getWorkspaceWindowData = async(ofWin: Window, tabbedWindows: WindowObject)
     // If a window is tabbed (based on filtered tabGroups), tab it.
     const isTabbed = inWindowObject(ofWin.identity, tabbedWindows) ? true : false;
 
-    return {info, uuid, windowGroup: filteredWindowGroup, frame: applicationState.frame, state: options.state, isTabbed, isShowing: !applicationState.hidden};
+    const state = desktopWindow.currentState.state;
+
+    return {info, uuid, windowGroup: filteredWindowGroup, frame: applicationState.frame, state, isTabbed, isShowing: !applicationState.hidden};
 };


### PR DESCRIPTION
Issue fixed by using the state from the DesktopWindow rather than the lower-level Window, which does not appear to give the correct result for state.

Restoring windows to the correct state appears to 'just work' now