### PR TITLE
[SERVICE-334] Prevent embedding of absolute URL's to default tabstrips within saved workspaces	

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -271,6 +271,11 @@ export interface TabGroupInfo {
      * Object containing the saved bounds of the tabset
      */
     dimensions: TabGroupDimensions;
+
+    /**
+     * Indicates whether this tabstrip is using the default configuration or specifies a custom configuration
+     */
+    defaultConfig: boolean;
 }
 
 /**

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -255,14 +255,6 @@ export interface TabGroup {
  */
 export interface TabGroupInfo {
     /**
-     * Tabstrip URL.
-     *
-     * This will either be the URL of the default tabstrip that is built-in to the service, or the URL set by the
-     * application via {@link setTabClient}.
-     */
-    url: string;
-
-    /**
      * The identity of the currently active tab. Will be one of the identities within {@link TabGroup.tabs}.
      */
     active: WindowIdentity;
@@ -273,9 +265,9 @@ export interface TabGroupInfo {
     dimensions: TabGroupDimensions;
 
     /**
-     * Indicates whether this tabstrip is using the default configuration or specifies a custom configuration
+     * Object containing the tabstrip configuration
      */
-    defaultConfig: boolean;
+    config: ApplicationUIConfig|'default';
 }
 
 /**
@@ -300,16 +292,9 @@ export interface TabGroupDimensions {
     width: number;
 
     /**
-     * The pixel height of the tabstrip window.
-     *
-     * The total height of the entire tabset is this plus {@link TabGroupDimensions.appHeight}.
-     */
-    tabGroupHeight: number;
-
-    /**
      * The pixel height of the application windows within this tabset.
      *
-     * The total height of the entire tabset is this plus {@link TabGroupDimensions.tabGroupHeight}.
+     * The total height of the entire tabset is this plus {@link TabGroupInfo.config.height}.
      */
     appHeight: number;
 }

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -161,8 +161,7 @@ export class TabService {
 
             const appRect: Rectangle = group.activeTab.currentState;
             const groupRect: Rectangle = group.window.currentState;
-            const config: ApplicationUIConfig|'default' =
-                (group.config === ApplicationConfigManager.DEFAULT_CONFIG) ? 'default' : group.config;
+            const config: ApplicationUIConfig|'default' = (group.config === ApplicationConfigManager.DEFAULT_CONFIG) ? 'default' : group.config;
 
             const groupInfo = {
                 active: group.activeTab.identity,

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -193,8 +193,7 @@ export class TabService {
 
             if (tabs.length >= 2) {
                 // Create a tabstrip window in the correct position
-                const tabstripOptions: ApplicationUIConfig =
-                    groupDef.groupInfo.config === 'default' ? ApplicationConfigManager.DEFAULT_CONFIG : groupDef.groupInfo.config;
+                const tabstripOptions: ApplicationUIConfig = ApplicationConfigManager.convertToApplicationUIConfig(groupDef.groupInfo.config);
 
                 // Each tab group will be a stand-alone snap group
                 const snapGroup: DesktopSnapGroup = new DesktopSnapGroup();

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -170,7 +170,8 @@ export class TabService {
                     width: groupRect.halfSize.x * 2,
                     tabGroupHeight: groupRect.halfSize.y * 2,
                     appHeight: appRect.halfSize.y * 2
-                }
+                },
+                defaultConfig: group.config === ApplicationConfigManager.DEFAULT_CONFIG
             };
 
             return {tabs, groupInfo};
@@ -192,7 +193,9 @@ export class TabService {
 
             if (tabs.length >= 2) {
                 // Create a tabstrip window in the correct position
-                const tabstripOptions: ApplicationUIConfig = {url: groupDef.groupInfo.url, height: dimensions.tabGroupHeight};
+                const tabstripOptions: ApplicationUIConfig = groupDef.groupInfo.defaultConfig ?
+                    ApplicationConfigManager.DEFAULT_CONFIG :
+                    {url: groupDef.groupInfo.url, height: dimensions.tabGroupHeight};
 
                 // Each tab group will be a stand-alone snap group
                 const snapGroup: DesktopSnapGroup = new DesktopSnapGroup();

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -161,17 +161,18 @@ export class TabService {
 
             const appRect: Rectangle = group.activeTab.currentState;
             const groupRect: Rectangle = group.window.currentState;
+            const config: ApplicationUIConfig|'default' =
+                (group.config === ApplicationConfigManager.DEFAULT_CONFIG) ? 'default' : group.config;
+
             const groupInfo = {
-                url: group.config.url,
                 active: group.activeTab.identity,
                 dimensions: {
                     x: groupRect.center.x - groupRect.halfSize.x,
                     y: groupRect.center.y - groupRect.halfSize.y,
                     width: groupRect.halfSize.x * 2,
-                    tabGroupHeight: groupRect.halfSize.y * 2,
                     appHeight: appRect.halfSize.y * 2
                 },
-                defaultConfig: group.config === ApplicationConfigManager.DEFAULT_CONFIG
+                config
             };
 
             return {tabs, groupInfo};
@@ -193,9 +194,8 @@ export class TabService {
 
             if (tabs.length >= 2) {
                 // Create a tabstrip window in the correct position
-                const tabstripOptions: ApplicationUIConfig = groupDef.groupInfo.defaultConfig ?
-                    ApplicationConfigManager.DEFAULT_CONFIG :
-                    {url: groupDef.groupInfo.url, height: dimensions.tabGroupHeight};
+                const tabstripOptions: ApplicationUIConfig =
+                    groupDef.groupInfo.config === 'default' ? ApplicationConfigManager.DEFAULT_CONFIG : groupDef.groupInfo.config as ApplicationUIConfig;
 
                 // Each tab group will be a stand-alone snap group
                 const snapGroup: DesktopSnapGroup = new DesktopSnapGroup();
@@ -203,7 +203,7 @@ export class TabService {
 
                 // Position first tab to cover entire tab area - both tabstrip and app bounds
                 // The positions of tabstrip and subsequent tabs will all be based on this
-                const combinedHeight: number = dimensions.tabGroupHeight + dimensions.appHeight;
+                const combinedHeight: number = tabstripOptions.height + dimensions.appHeight;
                 const appBounds: Rectangle = {
                     center: {x: dimensions.x + (dimensions.width / 2), y: dimensions.y + (combinedHeight / 2)},
                     halfSize: {x: dimensions.width / 2, y: combinedHeight / 2}

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -195,7 +195,7 @@ export class TabService {
             if (tabs.length >= 2) {
                 // Create a tabstrip window in the correct position
                 const tabstripOptions: ApplicationUIConfig =
-                    groupDef.groupInfo.config === 'default' ? ApplicationConfigManager.DEFAULT_CONFIG : groupDef.groupInfo.config as ApplicationUIConfig;
+                    groupDef.groupInfo.config === 'default' ? ApplicationConfigManager.DEFAULT_CONFIG : groupDef.groupInfo.config;
 
                 // Each tab group will be a stand-alone snap group
                 const snapGroup: DesktopSnapGroup = new DesktopSnapGroup();

--- a/src/provider/tabbing/components/ApplicationConfigManager.ts
+++ b/src/provider/tabbing/components/ApplicationConfigManager.ts
@@ -24,6 +24,14 @@ export class ApplicationConfigManager {
      */
     public static onApplicationConfigCreated: Signal2<string, ApplicationUIConfig> = new Signal2();
 
+
+    /**
+     * Utility method for converting a ApplicationUIConfig|'default' to a ApplicationUIConfig
+     */
+    public static convertToApplicationUIConfig(config: ApplicationUIConfig|'default'): ApplicationUIConfig {
+        return config === 'default' ? ApplicationConfigManager.DEFAULT_CONFIG : config;
+    }
+
     /**
      * @private
      * Container for all application configurations

--- a/test/demo/tabbing/createTabFromMultipleWindows.test.ts
+++ b/test/demo/tabbing/createTabFromMultipleWindows.test.ts
@@ -1,8 +1,8 @@
 import {test} from 'ava';
 import {Application, Fin, Window} from 'hadouken-js-adapter';
 
-import {TabGroup} from '../../../src/client/types';
 import {DesktopTabGroup} from '../../../src/provider/model/DesktopTabGroup';
+import {ApplicationConfigManager} from '../../../src/provider/tabbing/components/ApplicationConfigManager';
 import {getConnection} from '../../provider/utils/connect';
 import {getBounds, NormalizedBounds} from '../../provider/utils/getBounds';
 import {teardown} from '../../teardown';
@@ -37,9 +37,9 @@ test('Create tab group from 2 windows', async (assert) => {
 
     const tabGroups: TabGroup[] = [{
         groupInfo: {
-            url: 'http://localhost:1337/provider/tabbing/tabstrip/tabstrip.html',
+            config: ApplicationConfigManager.DEFAULT_CONFIG,
             active: {uuid: win2.identity.uuid, name: win2.identity.name!},
-            dimensions: {x: 100, y: 100, width: preWin2Bounds.width, tabGroupHeight: 60, appHeight: preWin2Bounds.height}
+            dimensions: {x: 100, y: 100, width: preWin2Bounds.width, appHeight: preWin2Bounds.height}
         },
         tabs: [
             {uuid: app1.identity.uuid, name: win1.identity.name!},
@@ -79,7 +79,8 @@ test('Create tab group from 2 windows', async (assert) => {
     assert.is(win2Bounds.right, win1Bounds.right);
     assert.is(win2Bounds.top, win1Bounds.top);
     assert.is(win2Bounds.width, win1Bounds.width);
-    assert.is(win2Bounds.top, (tabGroups[0].groupInfo.dimensions.y + tabGroups[0].groupInfo.dimensions.tabGroupHeight));
+    assert.is(
+        win2Bounds.top, (tabGroups[0].groupInfo.dimensions.y + ApplicationConfigManager.convertToApplicationUIConfig(tabGroups[0].groupInfo.config).height));
     assert.is(win2Bounds.left, tabGroups[0].groupInfo.dimensions.x);
 
 


### PR DESCRIPTION
We now store either the string "default", or the URL and tabstrip height if using a custom tabstrip.

Note that we now reuse ApplicationUIConfig in TabGroupInfo. We also have removed URL from TabGroupInfo  and tabGroupHeight in TabGroupDimensions as these are in ApplicationUIConfig