### PR TITLE
[N/A] Fix previewWindow test break

### DIFF
--- a/test/demo/previewWindow.test.ts
+++ b/test/demo/previewWindow.test.ts
@@ -37,7 +37,7 @@ testParameterized(
         const {windows} = t.context;
 
         const fin = await getConnection();
-        const previewWin: _Window = await fin.Window.wrap({name: 'previewWindow', uuid: 'layouts-service'});
+        const previewWin: _Window = await fin.Window.wrap({name: 'successPreview', uuid: 'layouts-service'});
         const windowBounds = await Promise.all([getBounds(windows[0]), getBounds(windows[1])]);
 
         await dragSideToSide(windows[1], opposite(side), windows[0], side, {x: 5, y: 5}, false);
@@ -71,7 +71,7 @@ testParameterized(
         const {windows} = t.context;
 
         const fin = await getConnection();
-        const previewWin: _Window = await fin.Window.wrap({name: 'previewWindow', uuid: 'layouts-service'});
+        const previewWin: _Window = await fin.Window.wrap({name: 'successPreview', uuid: 'layouts-service'});
         const windowBounds = await Promise.all([getBounds(windows[0]), getBounds(windows[1])]);
 
         await windows[1].resizeBy(
@@ -100,7 +100,7 @@ testParameterized(
         const {windows} = t.context;
 
         const fin = await getConnection();
-        const previewWin: _Window = await fin.Window.wrap({name: 'previewWindow', uuid: 'layouts-service'});
+        const previewWin: _Window = await fin.Window.wrap({name: 'successPreview', uuid: 'layouts-service'});
         const windowBounds = await Promise.all([getBounds(windows[0]), getBounds(windows[1])]);
 
         if (windowCount > 2) {
@@ -128,7 +128,7 @@ testParameterized(
         const {windows} = t.context;
 
         const fin = await getConnection();
-        const previewWin: _Window = await fin.Window.wrap({name: 'previewWindow', uuid: 'layouts-service'});
+        const previewWin: _Window = await fin.Window.wrap({name: 'successPreview', uuid: 'layouts-service'});
 
         await windows[0].moveTo(40, 40);
         if (windowCount > 3) await windows[3].moveTo(60, 60);

--- a/test/provider/deregisterWindow.test.ts
+++ b/test/provider/deregisterWindow.test.ts
@@ -211,7 +211,7 @@ test('deregister snapped window', async t => {
 
 test('no preview when deregistered - dragging registered', async t => {
     // Wrap the pre-spawned preview window
-    const previewWin = await getWindow({name: 'previewWindow', uuid: 'layouts-service'});
+    const previewWin = await getWindow({name: 'successPreview', uuid: 'layouts-service'});
 
     // Spawn two child windows (one of them deregistered)
     win1 = await createChildWindow({
@@ -248,7 +248,7 @@ test('no preview when deregistered - dragging registered', async t => {
 
 test('no preview when deregistered - dragging deregistered', async t => {
     // Wrap the pre-spawned preview window
-    const previewWin = await getWindow({name: 'previewWindow', uuid: 'layouts-service'});
+    const previewWin = await getWindow({name: 'successPreview', uuid: 'layouts-service'});
 
     // Spawn two child windows (one of them deregistered)
     win1 = await createChildWindow({

--- a/test/teardown.ts
+++ b/test/teardown.ts
@@ -65,7 +65,7 @@ async function closeAllWindows(t: TestContext): Promise<void> {
             // Main window persists, but close any child windows
             return name !== uuid;
         } else if(uuid === 'layouts-service') {
-            if (name === uuid || name === 'successPreview' || name == 'failurePreview') {
+            if (name === uuid || name === 'successPreview' || name === 'failurePreview') {
                 // Main window and preview windows persist
                 return false;
             } else if (name!.startsWith('TABSET-')) {

--- a/test/teardown.ts
+++ b/test/teardown.ts
@@ -65,7 +65,7 @@ async function closeAllWindows(t: TestContext): Promise<void> {
             // Main window persists, but close any child windows
             return name !== uuid;
         } else if(uuid === 'layouts-service') {
-            if (name === uuid || name === 'previewWindow') {
+            if (name === uuid || name === 'successPreview' || name == 'failurePreview') {
                 // Main window and preview window persist
                 return false;
             } else if (name!.startsWith('TABSET-')) {

--- a/test/teardown.ts
+++ b/test/teardown.ts
@@ -66,7 +66,7 @@ async function closeAllWindows(t: TestContext): Promise<void> {
             return name !== uuid;
         } else if(uuid === 'layouts-service') {
             if (name === uuid || name === 'successPreview' || name == 'failurePreview') {
-                // Main window and preview window persist
+                // Main window and preview windows persist
                 return false;
             } else if (name!.startsWith('TABSET-')) {
                 // Allow pooled tabstrips to persist, but destroy any broken/left-over tabstrips


### PR DESCRIPTION
This fixes tests that broke due to reliance on the preview window having a particular name, which changed with SERVICE-287