### PR TITLE
[SERVICE-323] Restoring maximized state now works regardless of whether app was running or not

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -40,6 +40,11 @@ export interface RegEx {
     invert?: boolean;
 }
 
+/**
+ * Window state, corresponds to `WindowOptions.state`
+ */
+export type WindowState = 'normal'|'minimized'|'maximized';
+
 
 /* Tabbing */
 
@@ -201,7 +206,7 @@ export interface WorkspaceWindow extends Bounds, WindowIdentity {
     /**
      * Window state, corresponds to `WindowOptions.state`
      */
-    state: 'normal'|'minimized'|'maximized';
+    state: WindowState;
 
     /**
      * If the window is framed or frameless, corresponds to `WindowOptions.frame`
@@ -268,6 +273,11 @@ export interface TabGroupInfo {
      * Object containing the tabstrip configuration
      */
     config: ApplicationUIConfig|'default';
+
+    /**
+     * The state the TabGroup and contained windows are mimicing
+     */
+    state: WindowState;
 }
 
 /**

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -2,7 +2,7 @@ import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
 import {Scope} from '../../../gen/provider/config/scope';
 
-import {ApplicationUIConfig, TabAddedPayload, TabGroupEventPayload, TabProperties, WindowIdentity} from '../../client/types';
+import {ApplicationUIConfig, TabAddedPayload, TabGroupEventPayload, TabProperties, WindowIdentity, WindowState} from '../../client/types';
 import {WindowMessages} from '../APIMessages';
 import {tabService} from '../main';
 import {Signal1} from '../Signal';
@@ -155,8 +155,12 @@ export class DesktopTabGroup implements DesktopEntity {
         return activeWindow.scope;
     }
 
-    public get isMaximized(): boolean {
-        return this._isMaximized;
+    /**
+     * Returns the window state this tab group is currently mimicing. Note this may not match the internal underlying state
+     * as 'maximized' tabs are not truely maximized as far as Windows is concerned
+     */
+    public get state(): WindowState {
+        return this._window.currentState.state === 'minimized' ? 'minimized' : this._isMaximized ? 'maximized' : 'normal';
     }
 
     public applyOverride<K extends keyof EntityState>(property: K, value: EntityState[K]): Promise<void> {

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -3,6 +3,7 @@ import {Identity, Window} from 'hadouken-js-adapter';
 
 import {WindowScope} from '../../../gen/provider/config/scope';
 import {SERVICE_IDENTITY} from '../../client/internal';
+import {WindowState} from '../../client/types';
 import {WindowMessages} from '../APIMessages';
 import {apiHandler} from '../main';
 import {Aggregators, Signal1, Signal2} from '../Signal';
@@ -16,7 +17,6 @@ import {DesktopEntity} from './DesktopEntity';
 import {DesktopModel} from './DesktopModel';
 import {DesktopSnapGroup} from './DesktopSnapGroup';
 import {DesktopTabGroup} from './DesktopTabGroup';
-import { WindowState } from '../../client/types';
 
 export interface EntityState extends Rectangle {
     center: Point;

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -16,6 +16,7 @@ import {DesktopEntity} from './DesktopEntity';
 import {DesktopModel} from './DesktopModel';
 import {DesktopSnapGroup} from './DesktopSnapGroup';
 import {DesktopTabGroup} from './DesktopTabGroup';
+import { WindowState } from '../../client/types';
 
 export interface EntityState extends Rectangle {
     center: Point;
@@ -23,7 +24,7 @@ export interface EntityState extends Rectangle {
 
     frame: boolean;
     hidden: boolean;
-    state: 'normal'|'minimized'|'maximized';
+    state: WindowState;
 
     icon: string;
     title: string;

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1036,7 +1036,7 @@ export class DesktopWindow implements DesktopEntity {
     private isMaximizedOrInMaximizedTab(): boolean {
         if (this._currentState.state === 'maximized') {
             return true;
-        } else if (this._tabGroup !== null && this._tabGroup.isMaximized) {
+        } else if (this._tabGroup !== null && this._tabGroup.state === 'maximized') {
             return true;
         } else {
             return false;

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -208,6 +208,12 @@ export class TabService {
                 await tabGroup.addTabs(tabs, groupDef.groupInfo.active);
                 await tabGroup.window.sync();
 
+                if (tabGroup.state === 'maximized') {
+                    await tabGroup.maximize();
+                } else if (tabGroup.state === 'minimized') {
+                    await tabGroup.minimize();
+                }
+
                 tabGroups.push(tabGroup);
             } else {
                 console.error('Not enough valid tab identifiers within tab blob to form a tab group', groupDef.tabs);

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -1,6 +1,6 @@
 import {Tabstrip} from '../../../gen/provider/config/layouts-config';
 import {Scope} from '../../../gen/provider/config/scope';
-import {TabPropertiesUpdatedPayload} from '../../client/types';
+import {TabPropertiesUpdatedPayload, WindowState} from '../../client/types';
 import {TabGroup, TabGroupDimensions, TabProperties, WindowIdentity} from '../../client/types';
 import {ConfigStore} from '../main';
 import {DesktopEntity} from '../model/DesktopEntity';
@@ -165,7 +165,8 @@ export class TabService {
                     width: groupRect.halfSize.x * 2,
                     appHeight: appRect.halfSize.y * 2
                 },
-                config
+                config,
+                state: group.state
             };
 
             return {tabs, groupInfo};

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -5,7 +5,7 @@ import {WindowInfo as WindowInfo_Window} from 'hadouken-js-adapter/out/types/src
 import {Identity} from 'hadouken-js-adapter/out/types/src/identity';
 
 import {WorkspaceAPI} from '../../client/internal';
-import {CustomData, TabGroup, Workspace, WorkspaceApp, WorkspaceWindow} from '../../client/types';
+import {CustomData, TabGroup, Workspace, WorkspaceApp, WorkspaceWindow, WindowState} from '../../client/types';
 import {LegacyAPI} from '../APIMessages';
 import {apiHandler, model, tabService} from '../main';
 import {WindowIdentity} from '../model/DesktopWindow';
@@ -25,7 +25,7 @@ export const SCHEMA_MAJOR_VERSION = parseVersionString(LAYOUTS_SCHEMA_VERSION).m
 interface WorkspaceWindowData {
     uuid: string;
     isShowing: boolean;
-    state: 'normal'|'minimized'|'maximized';
+    state: WindowState;
     frame: boolean;
     info: WindowInfo_Window;
     windowGroup: Identity[];

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -5,7 +5,7 @@ import {WindowInfo as WindowInfo_Window} from 'hadouken-js-adapter/out/types/src
 import {Identity} from 'hadouken-js-adapter/out/types/src/identity';
 
 import {WorkspaceAPI} from '../../client/internal';
-import {CustomData, TabGroup, Workspace, WorkspaceApp, WorkspaceWindow, WindowState} from '../../client/types';
+import {CustomData, TabGroup, WindowState, Workspace, WorkspaceApp, WorkspaceWindow} from '../../client/types';
 import {LegacyAPI} from '../APIMessages';
 import {apiHandler, model, tabService} from '../main';
 import {WindowIdentity} from '../model/DesktopWindow';

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -214,8 +214,7 @@ export const restoreWorkspace = async(payload: Workspace, identity: Identity): P
                 if (ofAppNotRunning) {
                     await ofAppNotRunning.run().catch(console.log);
                     const ofWindowNotRunning = await ofAppNotRunning.getWindow();
-                    await ofWindowNotRunning.setBounds(app.mainWindow);
-                    await ofWindowNotRunning.showAt(app.mainWindow.left, app.mainWindow.top);
+                    await positionWindow(app.mainWindow);
                 }
                 // SHOULD WE RETURN DEFAULT RESPONSE HERE?!?
                 return defaultResponse;

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -24,8 +24,6 @@ export const positionWindow = async (win: WorkspaceWindow) => {
         }
         await ofWin.leaveGroup();
 
-
-        // COMMENTED OUT FOR DEMO
         if (win.state === 'normal') {
             await ofWin.restore();
         } else if (win.state === 'minimized') {

--- a/test/demo/tabbing/createTabFromMultipleWindows.test.ts
+++ b/test/demo/tabbing/createTabFromMultipleWindows.test.ts
@@ -39,7 +39,8 @@ test('Create tab group from 2 windows', async (assert) => {
         groupInfo: {
             config: {url: 'http://localhost:1337/provider/tabbing/tabstrip/tabstrip.html', height: 60},
             active: {uuid: win2.identity.uuid, name: win2.identity.name!},
-            dimensions: {x: 100, y: 100, width: preWin2Bounds.width, appHeight: preWin2Bounds.height}
+            dimensions: {x: 100, y: 100, width: preWin2Bounds.width, appHeight: preWin2Bounds.height},
+            state: 'normal'
         },
         tabs: [
             {uuid: app1.identity.uuid, name: win1.identity.name!},


### PR DESCRIPTION
The previous fix for SERVICE-323 only worked for currently running apps, as different codepaths were used for restoring the state of windows depending on if it was running or not.

The positionWindow method is now used for both the case where we're restoring an app that is already running, and when it needed to be started

This PR now also saves and restores state of the tab group itself, which causes a schema change that we want in before 1.0