### PR TITLE
[SERVICE-336] Clicking restore in the middle of another restore breaks restoration

### DIFF
--- a/src/provider/APIHandler.ts
+++ b/src/provider/APIHandler.ts
@@ -13,7 +13,7 @@ import {DesktopWindow, WindowIdentity} from './model/DesktopWindow';
 import {SnapService} from './snapanddock/SnapService';
 import {TabService} from './tabbing/TabService';
 import {generateWorkspace} from './workspaces/create';
-import {getAppToRestore, restoreApplication, restoreWorkspace} from './workspaces/restore';
+import {appReadyForRestore, restoreWorkspace} from './workspaces/restore';
 
 
 /**
@@ -150,13 +150,7 @@ export class APIHandler {
     }
 
     private appReady(payload: void, identity: Identity): void {
-        const {uuid} = identity;
-        const appToRestore = getAppToRestore(uuid);
-
-        if (appToRestore) {
-            const {layoutApp, resolve} = appToRestore;
-            restoreApplication(layoutApp, resolve);
-        }
+        appReadyForRestore(identity.uuid);
     }
 
     private setTabstrip(payload: {config: ApplicationUIConfig, id: Identity}) {

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -639,10 +639,7 @@ export class DesktopTabGroup implements DesktopEntity {
         }
 
         // Update the internal state of the tabGroup
-        this.currentState.resizeConstraints = {
-            x: {...result.x},
-            y: {...result.y}
-        };
+        this.currentState.resizeConstraints = {x: {...result.x}, y: {...result.y}};
         // Update the tabStrip constraints accordingly
         if (this._window.isReady) {
             await this._window.applyProperties({

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -60,7 +60,7 @@ export const restoreWorkspace = async(payload: Workspace, identity: Identity): P
 
     await createAllPlaceholders(layout);
 
-    const apps = await promiseMap(layout.apps, async(app: WorkspaceApp): Promise<WorkspaceApp> => await restoreApp(app, startupApps));
+    const apps = await promiseMap(layout.apps, app => restoreApp(app, startupApps));
 
     // Wait for all apps to startup
     const startupResponses = await Promise.all(startupApps);

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -299,13 +299,13 @@ const restoreApp = async(app: WorkspaceApp, startupApps: Promise<WorkspaceApp>[]
 };
 
 const clientRestoreAppWithTimeout = async(app: WorkspaceApp, mayBeLegacyApp: boolean): Promise<WorkspaceApp> => {
-    const {uuid} = app;
+    const identity = {uuid: app.uuid, name: app.uuid};
 
     const defaultResponse = {...app, childWindows: []};
 
-    const sendToClientPromises = [apiHandler.sendToClient<WorkspaceApp, WorkspaceApp|false>({uuid, name: uuid}, WorkspaceAPI.RESTORE_HANDLER, app)];
+    const sendToClientPromises = [apiHandler.sendToClient<WorkspaceApp, WorkspaceApp|false>(identity, WorkspaceAPI.RESTORE_HANDLER, app)];
     if (mayBeLegacyApp) {
-        sendToClientPromises.push(apiHandler.sendToClient<WorkspaceApp, WorkspaceApp|false>({uuid, name: uuid}, LegacyAPI.RESTORE_HANDLER, app));
+        sendToClientPromises.push(apiHandler.sendToClient<WorkspaceApp, WorkspaceApp|false>(identity, LegacyAPI.RESTORE_HANDLER, app));
     }
 
     const responsePromise = Promise.race(sendToClientPromises).then((response: WorkspaceApp|false|undefined) => response ? response : defaultResponse);

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -13,8 +13,13 @@ import {SCHEMA_MAJOR_VERSION} from './create';
 import {regroupWorkspace} from './group';
 import {addToWindowObject, childWindowPlaceholderCheck, childWindowPlaceholderCheckRunningApp, createNormalPlaceholder, createTabbedPlaceholderAndRecord, inWindowObject, parseVersionString, positionWindow, SemVer, TabbedPlaceholders, wasCreatedProgrammatically, WindowObject} from './utils';
 
-const GLOBAL_RESTORE_TIMEOUT = 120000;
+// Duration in milliseconds that the entire Workspace restore may take, before we allow another restore to start
+const GLOBAL_EXCLUSIVITY_TIMEOUT = 120000;
+
+// Duration in milliseconds that we give a client app to startup when restoring a Workspace
 const CLIENT_STARTUP_TIMEOUT = 60000;
+
+// Duration in milliseconds that we give a client app to restore itself when restoring a Workspace
 const CLIENT_RESTORE_TIMEOUT = 60000;
 
 const appsCurrentlyStarting = new Map();
@@ -148,7 +153,7 @@ const startRestoreBlockerTimeout = (): void => {
                 appsToRestore.clear();
                 appsCurrentlyRestoring.clear();
             }
-        }, GLOBAL_RESTORE_TIMEOUT);
+        }, GLOBAL_EXCLUSIVITY_TIMEOUT);
     })();
 };
 

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -46,7 +46,7 @@ export const appReadyForRestore = async(uuid: string): Promise<void> => {
     }
 };
 
-export const restoreWorkspace = async(payload: Workspace, identity: Identity): Promise<Workspace> => {
+export const restoreWorkspace = async(payload: Workspace): Promise<Workspace> => {
     if (restoreExclusivityToken !== null) {
         throw new Error('Attempting to restore while restore in progress');
     }

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -259,7 +259,7 @@ const restoreApp = async(app: WorkspaceApp, startupApps: Promise<WorkspaceApp>[]
                 return defaultResponse;
             }
         } else {
-            let ofAppNotRunning: undefined|Application;
+            let ofAppNotRunning: Application|undefined;
             console.log('App is not running:', app);
 
             // App is not running - setup communication to fire once app is started

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -47,6 +47,8 @@ export const appReadyForRestore = async(uuid: string): Promise<void> => {
 };
 
 export const restoreWorkspace = async(payload: Workspace): Promise<Workspace> => {
+    console.log('Restoring workspace:', payload);
+
     if (restoreExclusivityToken !== null) {
         throw new Error('Attempting to restore while restore in progress');
     }
@@ -274,7 +276,7 @@ const restoreApp = async(app: WorkspaceApp, startupApps: Promise<WorkspaceApp>[]
 
             if (ofAppNotRunning) {
                 await ofAppNotRunning.run().catch(console.log);
-                await model.expect({name, uuid});
+                await model.expect({uuid, name: uuid});
                 await positionWindow(app.mainWindow);
             }
             // SHOULD WE RETURN DEFAULT RESPONSE HERE?!?

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -13,7 +13,7 @@ import {SCHEMA_MAJOR_VERSION} from './create';
 import {regroupWorkspace} from './group';
 import {addToWindowObject, childWindowPlaceholderCheck, childWindowPlaceholderCheckRunningApp, createNormalPlaceholder, createTabbedPlaceholderAndRecord, inWindowObject, parseVersionString, positionWindow, SemVer, TabbedPlaceholders, wasCreatedProgrammatically, WindowObject} from './utils';
 
-const GLOBAL_RESTORE_TIMEOUT = 10000;
+const GLOBAL_RESTORE_TIMEOUT = 120000;
 const CLIENT_STARTUP_TIMEOUT = 60000;
 const CLIENT_RESTORE_TIMEOUT = 60000;
 

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -13,8 +13,8 @@ import {SCHEMA_MAJOR_VERSION} from './create';
 import {regroupWorkspace} from './group';
 import {addToWindowObject, childWindowPlaceholderCheck, childWindowPlaceholderCheckRunningApp, createNormalPlaceholder, createTabbedPlaceholderAndRecord, inWindowObject, parseVersionString, positionWindow, SemVer, TabbedPlaceholders, wasCreatedProgrammatically, WindowObject} from './utils';
 
-const STARTUP_TIMEOUT = 60000;
-const RESTORE_TIMEOUT = 60000;
+const CLIENT_STARTUP_TIMEOUT = 60000;
+const CLIENT_RESTORE_TIMEOUT = 60000;
 
 const appsCurrentlyStarting = new Map();
 const appsToRestore = new Map();
@@ -86,7 +86,7 @@ const setAppToRestoreWithTimeout = (layoutApp: WorkspaceApp, resolve: Function):
 
             resolve(defaultResponse);
         }
-    }, STARTUP_TIMEOUT);
+    }, CLIENT_STARTUP_TIMEOUT);
 };
 
 const getAppToRestore = (uuid: string): AppToRestore => {
@@ -292,7 +292,7 @@ const clientRestoreAppWithTimeout = async(app: WorkspaceApp): Promise<WorkspaceA
 
     const responsePromise = sendToClientPromise.then((response: WorkspaceApp|false|undefined) => response ? response : defaultResponse);
 
-    const timeoutPromise = new Promise<WorkspaceApp>((response) => setTimeout(() => response(defaultResponse), RESTORE_TIMEOUT));
+    const timeoutPromise = new Promise<WorkspaceApp>((response) => setTimeout(() => response(defaultResponse), CLIENT_RESTORE_TIMEOUT));
 
     return Promise.race([responsePromise, timeoutPromise]);
 };

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -52,7 +52,7 @@ export const restoreWorkspace = async(payload: Workspace, identity: Identity): P
     const layout = payload;
     const startupApps: Promise<WorkspaceApp>[] = [];
 
-    createAllPlaceholders(layout);
+    await createAllPlaceholders(layout);
 
     const apps = await promiseMap(layout.apps, async(app: WorkspaceApp): Promise<WorkspaceApp> => await restoreApp(app, startupApps));
 

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -238,8 +238,11 @@ const restoreApplication = async(layoutApp: WorkspaceApp, resolve: Function): Pr
         if (appsToRestore.has(uuid) && !appsCurrentlyRestoring.has(uuid)) {
             // Instruct app to restore its child windows
             appsCurrentlyRestoring.set(uuid, true);
-            const responseAppLayout: WorkspaceApp|false|undefined =
-                await apiHandler.sendToClient<WorkspaceApp, WorkspaceApp|false>({uuid, name}, WorkspaceAPI.RESTORE_HANDLER, layoutApp);
+
+            const responseAppLayout: WorkspaceApp|false|undefined = await Promise.race([
+                apiHandler.sendToClient<WorkspaceApp, WorkspaceApp|false>({uuid, name}, WorkspaceAPI.RESTORE_HANDLER, layoutApp),
+                apiHandler.sendToClient<WorkspaceApp, WorkspaceApp|false>({uuid, name}, LegacyAPI.RESTORE_HANDLER, layoutApp)
+            ]);
 
             // Flag app as restored
             appsCurrentlyRestoring.delete(uuid);

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -238,7 +238,8 @@ const restoreApplication = async(layoutApp: WorkspaceApp, resolve: Function): Pr
         if (appsToRestore.has(uuid) && !appsCurrentlyRestoring.has(uuid)) {
             // Instruct app to restore its child windows
             appsCurrentlyRestoring.set(uuid, true);
-            const responseAppLayout: WorkspaceApp|false = await apiHandler.channel.dispatch({uuid, name}, WorkspaceAPI.RESTORE_HANDLER, layoutApp);
+            const responseAppLayout: WorkspaceApp|false|undefined =
+                await apiHandler.sendToClient<WorkspaceApp, WorkspaceApp|false>({uuid, name}, WorkspaceAPI.RESTORE_HANDLER, layoutApp);
 
             // Flag app as restored
             appsCurrentlyRestoring.delete(uuid);

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -34,10 +34,10 @@ interface AppToRestore {
 
 export const appReadyForRestore = async(uuid: string): Promise<void> => {
     const appToRestore = appsToRestoreWhenReady.get(uuid)!;
-    
+
     if (appToRestore) {
         const {workspaceApp, resolve} = appToRestore;
-        
+
         appsToRestoreWhenReady.delete(uuid);
 
         requestClientRestoreApp(workspaceApp, resolve);
@@ -64,7 +64,7 @@ export const restoreWorkspace = async(payload: Workspace): Promise<Workspace> =>
 
     // Wait for all apps to startup
     const startupResponses: WorkspaceApp[] = await Promise.all(startupApps);
-    
+
     // Wait for all child windows to appear. Continue and Warn if placeholders aren't closed in 60 seconds.
     try {
         await waitUntilAllPlaceholdersClosed();
@@ -100,10 +100,10 @@ const requestClientRestoreApp = async(workspaceApp: WorkspaceApp, resolve: Funct
     const {uuid} = workspaceApp;
     const appConnection = apiHandler.isClientConnection({uuid, name: uuid});
     if (appConnection) {
-            // Instruct app to restore its child windows
-            const appworkspaceAppResult = await clientRestoreAppWithTimeout(workspaceApp, false);
+        // Instruct app to restore its child windows
+        const appworkspaceAppResult = await clientRestoreAppWithTimeout(workspaceApp, false);
 
-            resolve(appworkspaceAppResult);
+        resolve(appworkspaceAppResult);
     }
 };
 
@@ -305,7 +305,7 @@ const clientRestoreAppWithTimeout = async(app: WorkspaceApp, mayBeLegacyApp: boo
 
 const setAppToClientRestoreWithTimeout = (workspaceApp: WorkspaceApp, resolve: Function): void => {
     const {uuid} = workspaceApp;
-    const save = {workspaceApp: workspaceApp, resolve};
+    const save = {workspaceApp, resolve};
 
     const defaultResponse = {...workspaceApp, childWindows: []};
 
@@ -313,7 +313,6 @@ const setAppToClientRestoreWithTimeout = (workspaceApp: WorkspaceApp, resolve: F
 
     setTimeout(() => {
         if (appsToRestoreWhenReady.delete(uuid)) {
-
             resolve(defaultResponse);
         }
     }, CLIENT_STARTUP_TIMEOUT);

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -58,7 +58,7 @@ export const restoreWorkspace = async(payload: Workspace): Promise<Workspace> =>
     const workspace = payload;
     const startupApps: Promise<WorkspaceApp>[] = [];
 
-    await createAllPlaceholders(workspace);
+    await createWorkspacePlaceholders(workspace);
 
     const apps: WorkspaceApp[] = await promiseMap(workspace.apps, app => restoreApp(app, startupApps));
 
@@ -165,7 +165,7 @@ const startExclusivityTimeout = (): void => {
     })();
 };
 
-const createAllPlaceholders = async(workspace: Workspace): Promise<void> => {
+const createWorkspacePlaceholders = async(workspace: Workspace): Promise<void> => {
     const tabbedWindows: WindowObject = {};
     const openWindows: WindowObject = {};
     const tabbedPlaceholdersToWindows: TabbedPlaceholders = {};
@@ -191,7 +191,7 @@ const createAllPlaceholders = async(workspace: Workspace): Promise<void> => {
     // Check if we need to make tabbed vs. normal placeholders for both main windows and child windows.
     // Push those placeholder windows into tabbedPlaceholdersToWindows object
     // If an app is running, we need to check which of its child windows are open.
-    async function createAllPlaceholders(app: WorkspaceApp) {
+    async function createWorkspaceAppPlaceholders(app: WorkspaceApp) {
         const ofApp = fin.Application.wrapSync(app);
         const isRunning = await ofApp.isRunning();
         if (isRunning) {
@@ -216,7 +216,7 @@ const createAllPlaceholders = async(workspace: Workspace): Promise<void> => {
     }
 
     // Kick off placeholder creation for all apps.
-    await promiseMap(workspace.apps, createAllPlaceholders);
+    await promiseMap(workspace.apps, createWorkspaceAppPlaceholders);
 
     // Edit the tabGroups object with the placeholder window names/uuids, so we can create a Tab Group with a combination of open applications and placeholder
     // windows.

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -16,8 +16,8 @@ export interface SemVer {
 // TODO: Create Placeholder and PlaceholderStore classes?
 // This keeps track of how many placeholders we have open, so we know when we can start regrouping a layout.
 let numOfPlaceholders = 0;
-let functionToContinueRestorationWhenPlaceholdersClosed: (() => void) | undefined;
-let rejectTimeout: number | undefined;
+let functionToContinueRestorationWhenPlaceholdersClosed: (() => void)|undefined;
+let rejectTimeout: number|undefined;
 
 fin.System.addListener('window-closed', (win) => {
     if (win.name.startsWith('Placeholder-')) {


### PR DESCRIPTION
This still needs full testing, but would appreciate eyes on this.

There's four real parts to this

1. At the start and end of the restoreWorkspace method, mark and unmark that a restore is in progress, and if the restoreWorkspace  method is called again during a restore, throw an exception

2. Add a timeout when waiting for a  WorkspaceAPI.RESTORE_HANDLER call to the client app via sendToClient to return

3. Add a timeout when waiting for a client app to notify the provider that it is ready to restore

These 3 together /should/ be enough to ensure that we don't start a restore when we are already mid-restore but will also never block restores permanently due to a misbehaving client app. However, for caution, we also have:

4. A global timeout on the marker that restore is running, so that we definitely never permanently block restores

As part of this PR, I've also split up the restoreWorkspace to make it more manageable