### PR TITLE
[RUN-5010] Set no maxWidth/height to undefined instead of -1

### DIFF
--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -842,9 +842,9 @@ export class DesktopWindow implements DesktopEntity {
                         }
                     },
                     minWidth: resizeConstraints.x.minSize,
-                    maxWidth: resizeConstraints.x.maxSize === Number.MAX_SAFE_INTEGER ? undefined : resizeConstraints.x.maxSize,
+                    maxWidth: resizeConstraints.x.maxSize,
                     minHeight: resizeConstraints.y.minSize,
-                    maxHeight: resizeConstraints.y.maxSize === Number.MAX_SAFE_INTEGER ? undefined : resizeConstraints.y.maxSize,
+                    maxHeight: resizeConstraints.y.maxSize,
                 }));
             }
 

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -842,9 +842,9 @@ export class DesktopWindow implements DesktopEntity {
                         }
                     },
                     minWidth: resizeConstraints.x.minSize,
-                    maxWidth: resizeConstraints.x.maxSize === Number.MAX_SAFE_INTEGER ? -1 : resizeConstraints.x.maxSize,
+                    maxWidth: resizeConstraints.x.maxSize === Number.MAX_SAFE_INTEGER ? undefined : resizeConstraints.x.maxSize,
                     minHeight: resizeConstraints.y.minSize,
-                    maxHeight: resizeConstraints.y.maxSize === Number.MAX_SAFE_INTEGER ? -1 : resizeConstraints.y.maxSize,
+                    maxHeight: resizeConstraints.y.maxSize === Number.MAX_SAFE_INTEGER ? undefined : resizeConstraints.y.maxSize,
                 }));
             }
 


### PR DESCRIPTION
There is a core issue where having any maxWidth/maxHeight prevents maximization. The updateOptions call should be called with undefined instead. This should hold you over until a proper runtime fix is released.