### PR TITLE
[SERVICE-314] Undock tabGroups when maximising

### DIFF
--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -203,6 +203,11 @@ export class DesktopTabGroup implements DesktopEntity {
      */
     public async maximize(): Promise<void> {
         if (!this._isMaximized) {
+            // Before doing anything else we will undock the tabGroup (mitigation for SERVICE-314)
+            if (this.snapGroup.entities.length > 1) {
+                await this.setSnapGroup(new DesktopSnapGroup());
+            }
+
             const {center, halfSize} = this._activeTab.currentState;
             this._beforeMaximizeBounds = {center: {...center}, halfSize: {...halfSize}};
 

--- a/test/demo/tabbing/maximizeTabGroups.test.ts
+++ b/test/demo/tabbing/maximizeTabGroups.test.ts
@@ -1,0 +1,50 @@
+import { testParameterized } from "../utils/parameterizedTestUtils";
+import { createWindowTest, CreateWindowData } from "../utils/createWindowTest";
+import { layoutsClientPromise } from "../utils/serviceUtils";
+import { dragSideToSide } from "../../provider/utils/dragWindowTo";
+import { assertTabbed, assertGrouped, assertNotGrouped, assertNotMoved, assertNotGroupedTogether } from "../../provider/utils/assertions";
+import { getBounds } from "../../provider/utils/getBounds";
+
+interface MaximizeTabGroupsInstance extends CreateWindowData {
+    windowCount: 3 | 4;
+}
+
+
+testParameterized(`Docked tabGroups undock when maximized`, 
+    [
+        {windowCount: 3, frame: false},
+        {windowCount: 4, frame: false},
+    ],
+    createWindowTest(async (t, options: MaximizeTabGroupsInstance): Promise<void> => {
+        const {windows} = t.context;
+        const layoutsClient = await layoutsClientPromise;
+
+        await layoutsClient.tabbing.createTabGroup([windows[0].identity,windows[1].identity]);
+        await assertTabbed(windows[0], windows[1], t);
+        
+        // If 4 windows, the other two will be tabbed before snapping
+        if (options.windowCount > 3) {
+            await layoutsClient.tabbing.createTabGroup([windows[2].identity,windows[3].identity]);
+            await assertTabbed(windows[2], windows[3], t);
+        }
+        
+        await dragSideToSide(windows[2], 'left', windows[0], 'right');
+        await assertGrouped(t, ...windows);
+
+        const boundsBefore = await getBounds(windows[2]);
+        await layoutsClient.tabbing.maximizeTabGroup(windows[0].identity);
+        
+        await assertTabbed(windows[0], windows[1], t);
+        
+        // Snapped window has not moved/resized when tabgroup maximized.
+        const boundsAfter = await getBounds(windows[2]);
+        await assertNotMoved(boundsBefore, boundsAfter, t);
+        
+        if (options.windowCount > 3) {
+            await assertTabbed(windows[2], windows[3], t);
+            await assertNotGroupedTogether(t, windows[0], windows[2]);
+        } else {
+            await assertNotGrouped(windows[2], t);
+        }
+
+    }));

--- a/test/demo/tabbing/maximizeTabGroups.test.ts
+++ b/test/demo/tabbing/maximizeTabGroups.test.ts
@@ -1,50 +1,50 @@
-import { testParameterized } from "../utils/parameterizedTestUtils";
-import { createWindowTest, CreateWindowData } from "../utils/createWindowTest";
-import { layoutsClientPromise } from "../utils/serviceUtils";
-import { dragSideToSide } from "../../provider/utils/dragWindowTo";
-import { assertTabbed, assertGrouped, assertNotGrouped, assertNotMoved, assertNotGroupedTogether } from "../../provider/utils/assertions";
-import { getBounds } from "../../provider/utils/getBounds";
+import {assertGrouped, assertNotGrouped, assertNotGroupedTogether, assertNotMoved, assertTabbed} from '../../provider/utils/assertions';
+import {dragSideToSide} from '../../provider/utils/dragWindowTo';
+import {getBounds} from '../../provider/utils/getBounds';
+import {CreateWindowData, createWindowTest} from '../utils/createWindowTest';
+import {testParameterized} from '../utils/parameterizedTestUtils';
+import {layoutsClientPromise} from '../utils/serviceUtils';
 
 interface MaximizeTabGroupsInstance extends CreateWindowData {
-    windowCount: 3 | 4;
+    windowCount: 3|4;
 }
 
 
-testParameterized(`Docked tabGroups undock when maximized`, 
+testParameterized(
+    `Docked tabGroups undock when maximized`,
     [
         {windowCount: 3, frame: false},
         {windowCount: 4, frame: false},
     ],
-    createWindowTest(async (t, options: MaximizeTabGroupsInstance): Promise<void> => {
+    createWindowTest(async(t, options: MaximizeTabGroupsInstance): Promise<void> => {
         const {windows} = t.context;
         const layoutsClient = await layoutsClientPromise;
 
-        await layoutsClient.tabbing.createTabGroup([windows[0].identity,windows[1].identity]);
+        await layoutsClient.tabbing.createTabGroup([windows[0].identity, windows[1].identity]);
         await assertTabbed(windows[0], windows[1], t);
-        
+
         // If 4 windows, the other two will be tabbed before snapping
         if (options.windowCount > 3) {
-            await layoutsClient.tabbing.createTabGroup([windows[2].identity,windows[3].identity]);
+            await layoutsClient.tabbing.createTabGroup([windows[2].identity, windows[3].identity]);
             await assertTabbed(windows[2], windows[3], t);
         }
-        
+
         await dragSideToSide(windows[2], 'left', windows[0], 'right');
         await assertGrouped(t, ...windows);
 
         const boundsBefore = await getBounds(windows[2]);
         await layoutsClient.tabbing.maximizeTabGroup(windows[0].identity);
-        
+
         await assertTabbed(windows[0], windows[1], t);
-        
+
         // Snapped window has not moved/resized when tabgroup maximized.
         const boundsAfter = await getBounds(windows[2]);
         await assertNotMoved(boundsBefore, boundsAfter, t);
-        
+
         if (options.windowCount > 3) {
             await assertTabbed(windows[2], windows[3], t);
             await assertNotGroupedTogether(t, windows[0], windows[2]);
         } else {
             await assertNotGrouped(windows[2], t);
         }
-
     }));

--- a/test/provider/utils/assertions.ts
+++ b/test/provider/utils/assertions.ts
@@ -58,6 +58,38 @@ export async function assertNotGrouped(win: Window, t: TestContext) {
     t.is(snapGroup.length, 1);
 }
 
+export async function assertNotGroupedTogether(t: TestContext, win1: Window, win2: Window) {
+    const groups = await promiseMap([win1,win2], async win => win.getGroup());
+
+    // Quick pass if groups are of unequal length or of length 0
+    if (groups[0].length !== groups[1].length || groups[0].length === 0) {
+        t.pass();
+        return;
+    }
+
+    t.notDeepEqual(groups[0], groups[1], `Window ${win1.identity.uuid + '/' + win1.identity.name} in same native group as ${win2.identity.uuid + '/' + win2.identity.name}`);
+
+    const snapGroupIDs = await promiseMap([win1, win2], async win => getSnapGroupID(win.identity));
+    t.not(snapGroupIDs[0], snapGroupIDs[1],`Window ${win1.identity.uuid + '/' + win1.identity.name} in same snapGroup as ${win2.identity.uuid + '/' + win2.identity.name}`);
+}
+
+/**
+ * Assert that **none** of the given windows are part of the same snap group.
+ */
+export async function assertNoneGroupedTogether(t: TestContext, ...windows: Window[]) {
+    if (windows.length < 2) {
+        throw new Error('Too few windows passed to assertGrouped. Requires at least two windows');
+    }
+    // Get the native openfin groups for each window
+    const groups = await promiseMap(windows, async win => win.getGroup());
+    
+    for (let i = 0; i < windows.length; i++) {
+        for (let j = i + 1; j < windows.length; j++) {
+            assertNotGroupedTogether(t, windows[i], windows[j]);
+        }
+    }
+}
+
 export function assertMoved(bounds1: NormalizedBounds, bounds2: NormalizedBounds, t: TestContext) {
     t.notDeepEqual(bounds1, bounds2);
 }

--- a/test/provider/utils/assertions.ts
+++ b/test/provider/utils/assertions.ts
@@ -59,7 +59,7 @@ export async function assertNotGrouped(win: Window, t: TestContext) {
 }
 
 export async function assertNotGroupedTogether(t: TestContext, win1: Window, win2: Window) {
-    const groups = await promiseMap([win1,win2], async win => win.getGroup());
+    const groups = await promiseMap([win1, win2], async win => win.getGroup());
 
     // Quick pass if groups are of unequal length or of length 0
     if (groups[0].length !== groups[1].length || groups[0].length === 0) {
@@ -67,10 +67,16 @@ export async function assertNotGroupedTogether(t: TestContext, win1: Window, win
         return;
     }
 
-    t.notDeepEqual(groups[0], groups[1], `Window ${win1.identity.uuid + '/' + win1.identity.name} in same native group as ${win2.identity.uuid + '/' + win2.identity.name}`);
+    t.notDeepEqual(
+        groups[0],
+        groups[1],
+        `Window ${win1.identity.uuid + '/' + win1.identity.name} in same native group as ${win2.identity.uuid + '/' + win2.identity.name}`);
 
     const snapGroupIDs = await promiseMap([win1, win2], async win => getSnapGroupID(win.identity));
-    t.not(snapGroupIDs[0], snapGroupIDs[1],`Window ${win1.identity.uuid + '/' + win1.identity.name} in same snapGroup as ${win2.identity.uuid + '/' + win2.identity.name}`);
+    t.not(
+        snapGroupIDs[0],
+        snapGroupIDs[1],
+        `Window ${win1.identity.uuid + '/' + win1.identity.name} in same snapGroup as ${win2.identity.uuid + '/' + win2.identity.name}`);
 }
 
 /**

--- a/test/provider/utils/assertions.ts
+++ b/test/provider/utils/assertions.ts
@@ -80,9 +80,7 @@ export async function assertNoneGroupedTogether(t: TestContext, ...windows: Wind
     if (windows.length < 2) {
         throw new Error('Too few windows passed to assertGrouped. Requires at least two windows');
     }
-    // Get the native openfin groups for each window
-    const groups = await promiseMap(windows, async win => win.getGroup());
-    
+
     for (let i = 0; i < windows.length; i++) {
         for (let j = i + 1; j < windows.length; j++) {
             assertNotGroupedTogether(t, windows[i], windows[j]);


### PR DESCRIPTION
Fix/Mitigation for issue where maximising a snapped tabGroup could cause strange sizing/positioning of the snapped windows