### PR TITLE
[SERVICE-278] Prevent resizing of the top edge of a tabbed window

### DIFF
--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -633,7 +633,11 @@ export class DesktopTabGroup implements DesktopEntity {
             }
         }
 
-        this.currentState.resizeConstraints = result;
+        // Update the internal state of the tabGroup
+        this.currentState.resizeConstraints = {
+            x: {...result.x},
+            y: {...result.y}
+        };
         // Update the tabStrip constraints accordingly
         if (this._window.isReady) {
             await this._window.applyProperties({

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -634,9 +634,6 @@ export class DesktopTabGroup implements DesktopEntity {
         }
 
         this.currentState.resizeConstraints = result;
-
-        // Apply the new constraints to all windows
-        await Promise.all(this.tabs.map((tab: DesktopWindow) => tab.applyProperties({resizeConstraints: this.currentState.resizeConstraints})));
         // Update the tabStrip constraints accordingly
         if (this._window.isReady) {
             await this._window.applyProperties({
@@ -645,12 +642,16 @@ export class DesktopTabGroup implements DesktopEntity {
                     y: {
                         minSize: this._config.height,
                         maxSize: this._config.height,
-                        resizableMin: false,
+                        resizableMin: result.y.resizableMin,
                         resizableMax: false,
                     }
                 }
             });
         }
+
+        result.y.resizableMin = false;  // Cannot resize on the edge between tab and tabstrip (SERVICE-287)
+        // Apply the new constraints to all windows
+        await Promise.all(this.tabs.map((tab: DesktopWindow) => tab.applyProperties({resizeConstraints: result})));
     }
 
     // Will check that all of the tabs and the tabstrip are still in the correct relative positions, and if not

--- a/test/demo/tabbing/tabGroupResizeConstraints.test.ts
+++ b/test/demo/tabbing/tabGroupResizeConstraints.test.ts
@@ -154,7 +154,7 @@ function constraintsUnion(...windowConstraints: Constraints[]): Required<Constra
 
     // Check if the union of side constraints made the window non-resizable
     if (result.resizable) {
-        result.resizable = (Object.keys(result.resizeRegion.sides) as Side[]).every(key => result.resizeRegion.sides[key] !== false);
+        result.resizable = (Object.keys(result.resizeRegion.sides) as Side[]).some(key => result.resizeRegion.sides[key] !== false);
     }
 
     return result;


### PR DESCRIPTION
Changed some of the constraints propagation logic to restrict resizing on the internal edge of a tabgroup.