### PR TITLE
[SERVICE-316] Windows sometimes flicker when switching tabs

### DIFF
--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -273,11 +273,11 @@ export class DesktopTabGroup implements DesktopEntity {
             await Promise.all([firstTab.sync(), this._window.sync()]);
             // Add the tabs one-at-a-time to avoid potential race conditions with constraints updates.
             for (const tab of tabs) {
-                await this.addTabInternal(tab, false);
+                await this.addTabInternal(tab, !!activeTabId && activeTabId === tab.identity);
             }
         });
 
-        if (activeTab !== firstTab) {
+        if (!activeTabId) {
             // Set the desired tab as active
             await this.switchTab(activeTab);
         } else {
@@ -410,6 +410,7 @@ export class DesktopTabGroup implements DesktopEntity {
      * @param {WindowIdentity} ID The ID of the tab to set as active.
      */
     public async switchTab(tab: DesktopWindow): Promise<void> {
+        console.error(tab.identity.name, "switchTab");
         if (tab && tab !== this._activeTab) {
             const prevTab: DesktopWindow = this._activeTab;
             const redrawRequired: boolean = prevTab && !RectUtils.isEqual(tab.currentState, this._activeTab.currentState);
@@ -539,8 +540,9 @@ export class DesktopTabGroup implements DesktopEntity {
             const payload: TabAddedPayload = {tabstripIdentity: this.identity, identity: tab.identity, properties: tabProps, index: this._tabs.indexOf(tab)};
 
             this.sendTabEvent(tab, 'tab-added', payload);
-            await tab.applyProperties({hidden: tab !== this._activeTab});
-            //await this._window.setAsForeground();
+            if(!setActive){
+                await tab.applyProperties({hidden: true});
+            }
         })();
         await addTabPromise;  // TODO: Need to add this to a pendingActions queue?
 

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -419,9 +419,10 @@ export class DesktopTabGroup implements DesktopEntity {
             const prevTab: DesktopWindow|null = this._activeTab;
 
             /**
-             * Focus the window if we are ejecting or removing from group.
+             * Focus the window in the tabstrip.  Should be falsy in cases of a window being ejected.
              */
-            const focus = this._activeTab && this._tabs.indexOf(this._activeTab) >= 0 || (!!this._activeTab && !this._activeTab.isReady);
+            const focus = this._activeTab && (this._tabs.indexOf(this._activeTab) >= 0 || !this._activeTab.isReady);
+
             this._activeTab = tab;
 
             await tab.applyProperties({hidden: false});
@@ -636,10 +637,7 @@ export class DesktopTabGroup implements DesktopEntity {
         }
 
         // Update the internal state of the tabGroup
-        this.currentState.resizeConstraints = {
-            x: {...result.x},
-            y: {...result.y}
-        };
+        this.currentState.resizeConstraints = {x: {...result.x}, y: {...result.y}};
         // Update the tabStrip constraints accordingly
         if (this._window.isReady) {
             await this._window.applyProperties({

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -269,7 +269,7 @@ export class DesktopTabGroup implements DesktopEntity {
         const activeTab: DesktopWindow = (activeTabId && this._model.getWindow(activeTabId)) || firstTab;
 
         await DesktopWindow.transaction(allWindows, async () => {
-            await this.addTabInternal(firstTab, true);
+            await this.addTabInternal(firstTab, false);
             await Promise.all([firstTab.sync(), this._window.sync()]);
             // Add the tabs one-at-a-time to avoid potential race conditions with constraints updates.
             for (const tab of tabs) {
@@ -525,7 +525,7 @@ export class DesktopTabGroup implements DesktopEntity {
             const halfSize: Point = {x: tabState.halfSize.x, y: tabState.halfSize.y - (this._config.height / 2)};
             await tab.applyProperties({center, halfSize, frame: false});
         } else {
-            const existingTabState: EntityState = this._activeTab.currentState;
+            const existingTabState: EntityState = this._activeTab && this._activeTab.currentState || this._tabs[0].currentState;
             const {center, halfSize} = existingTabState;
 
             // Align tab with existing tab

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -280,7 +280,7 @@ export class DesktopTabGroup implements DesktopEntity {
             await Promise.all([firstTab.sync(), this._window.sync()]);
             // Add the tabs one-at-a-time to avoid potential race conditions with constraints updates.
             for (const tab of tabs) {
-                await this.addTabInternal(tab, activeTab.identity === tab.identity);
+                await this.addTabInternal(tab, activeTab === tab);
             }
         });
 

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -540,7 +540,7 @@ export class DesktopTabGroup implements DesktopEntity {
 
             this.sendTabEvent(tab, 'tab-added', payload);
             await tab.applyProperties({hidden: tab !== this._activeTab});
-            await this._window.setAsForeground();
+            //await this._window.setAsForeground();
         })();
         await addTabPromise;  // TODO: Need to add this to a pendingActions queue?
 

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -528,19 +528,18 @@ export class DesktopTabGroup implements DesktopEntity {
         await tab.setTabGroup(this);
         tab.setSnapGroup(this._window.snapGroup);
 
-        const addTabPromise: Promise<void> = (async () => {
-            const payload: TabAddedPayload = {tabstripIdentity: this.identity, identity: tab.identity, properties: tabProps, index: this._tabs.indexOf(tab)};
 
-            this.sendTabEvent(tab, 'tab-added', payload);
-            if (!setActive) {
-                await tab.applyProperties({hidden: true});
-            }
-        })();
-        await addTabPromise;  // TODO: Need to add this to a pendingActions queue?
+        const payload: TabAddedPayload = {tabstripIdentity: this.identity, identity: tab.identity, properties: tabProps, index: this._tabs.indexOf(tab)};
+        this.sendTabEvent(tab, 'tab-added', payload);
+
+        if (!setActive) {
+            await tab.applyProperties({hidden: true});
+        }
 
         if (setActive) {
             await this.switchTab(tab);
         }
+
         await Promise.all([tab.sync(), this._window.sync()]);
 
         await this.updateGroupConstraints();

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -420,17 +420,18 @@ export class DesktopTabGroup implements DesktopEntity {
                 await prevTab.bringToFront();
                 await tab.applyProperties({hidden: false});
                 await new Promise<void>(r => setTimeout(r, 150));
-                await tab.bringToFront();
             } else {
                 // Show tab as quickly as possible
                 await tab.applyProperties({hidden: false});
-                await tab.bringToFront();
             }
+
+            await tab.setAsForeground();
+
             if (prevTab && prevTab.tabGroup === this) {
                 await prevTab.applyProperties({hidden: true});
             }
 
-            await Promise.all([this._window!.sync(), tab.sync()]).catch(e => console.error(e));
+            await Promise.all([this._window.sync(), tab.sync()]).catch(e => console.error(e));
             const payload: TabGroupEventPayload = {tabstripIdentity: this.identity, identity: tab.identity};
             this._window.sendMessage('tab-activated', payload);
         }
@@ -539,7 +540,7 @@ export class DesktopTabGroup implements DesktopEntity {
 
             this.sendTabEvent(tab, 'tab-added', payload);
             await tab.applyProperties({hidden: tab !== this._activeTab});
-            await this._window.bringToFront();
+            await this._window.setAsForeground();
         })();
         await addTabPromise;  // TODO: Need to add this to a pendingActions queue?
 

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -411,6 +411,10 @@ export class DesktopTabGroup implements DesktopEntity {
     public async switchTab(tab: DesktopWindow): Promise<void> {
         if (tab && tab !== this._activeTab) {
             const prevTab: DesktopWindow|null = this._activeTab;
+
+            /**
+             * Focus the window if we are ejecting or removing from group.
+             */
             const focus = this._activeTab && this._tabs.indexOf(this._activeTab) >= 0 || (!!this._activeTab && !this._activeTab.isReady);
             this._activeTab = tab;
 

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -582,12 +582,12 @@ export class DesktopWindow implements DesktopEntity {
     }
 
     public async bringToFront(): Promise<void> {
-        console.error(this.identity.name, "bringToFront");
+        console.error(this.identity.name, 'bringToFront');
         return this.addPendingActions('bringToFront ' + this._id, this._window.bringToFront());
     }
 
     public async setAsForeground(): Promise<void> {
-        console.error(this.identity.name, "setAsForeground");
+        console.error(this.identity.name, 'setAsForeground');
         return this.addPendingActions('setAsForeground ' + this._id, this._window.setAsForeground());
     }
 
@@ -975,7 +975,8 @@ export class DesktopWindow implements DesktopEntity {
     private async handleFocused(): Promise<void> {
         // If we're not maximized ourself, bring all snapped, non-maximized windows to the front
         if (!this.isMaximizedOrInMaximizedTab()) {
-            this._snapGroup.windows.filter(snapGroupWindow => snapGroupWindow !== this && !snapGroupWindow.isMaximizedOrInMaximizedTab() && !snapGroupWindow.currentState.hidden)
+            this._snapGroup.windows
+                .filter(snapGroupWindow => snapGroupWindow !== this && !snapGroupWindow.isMaximizedOrInMaximizedTab() && !snapGroupWindow.currentState.hidden)
                 .forEach(snapGroupWindow => snapGroupWindow.bringToFront());
         }
     }

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -582,10 +582,12 @@ export class DesktopWindow implements DesktopEntity {
     }
 
     public async bringToFront(): Promise<void> {
+        console.error(this.identity.name, "bringToFront");
         return this.addPendingActions('bringToFront ' + this._id, this._window.bringToFront());
     }
 
     public async setAsForeground(): Promise<void> {
+        console.error(this.identity.name, "setAsForeground");
         return this.addPendingActions('setAsForeground ' + this._id, this._window.setAsForeground());
     }
 
@@ -595,6 +597,7 @@ export class DesktopWindow implements DesktopEntity {
     }
 
     public async applyProperties(properties: Partial<EntityState>): Promise<void> {
+        console.error(this.identity.name, properties);
         this.updateState(properties, ActionOrigin.SERVICE);
     }
 
@@ -972,7 +975,7 @@ export class DesktopWindow implements DesktopEntity {
     private async handleFocused(): Promise<void> {
         // If we're not maximized ourself, bring all snapped, non-maximized windows to the front
         if (!this.isMaximizedOrInMaximizedTab()) {
-            this._snapGroup.windows.filter(snapGroupWindow => snapGroupWindow !== this && !snapGroupWindow.isMaximizedOrInMaximizedTab())
+            this._snapGroup.windows.filter(snapGroupWindow => snapGroupWindow !== this && !snapGroupWindow.isMaximizedOrInMaximizedTab() && !snapGroupWindow.currentState.hidden)
                 .forEach(snapGroupWindow => snapGroupWindow.bringToFront());
         }
     }

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -582,12 +582,10 @@ export class DesktopWindow implements DesktopEntity {
     }
 
     public async bringToFront(): Promise<void> {
-        console.error(this.identity.name, 'bringToFront');
         return this.addPendingActions('bringToFront ' + this._id, this._window.bringToFront());
     }
 
     public async setAsForeground(): Promise<void> {
-        console.error(this.identity.name, 'setAsForeground');
         return this.addPendingActions('setAsForeground ' + this._id, this._window.setAsForeground());
     }
 
@@ -597,7 +595,6 @@ export class DesktopWindow implements DesktopEntity {
     }
 
     public async applyProperties(properties: Partial<EntityState>): Promise<void> {
-        console.error(this.identity.name, properties);
         this.updateState(properties, ActionOrigin.SERVICE);
     }
 

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -585,6 +585,10 @@ export class DesktopWindow implements DesktopEntity {
         return this.addPendingActions('bringToFront ' + this._id, this._window.bringToFront());
     }
 
+    public async setAsForeground(): Promise<void> {
+        return this.addPendingActions('setAsForeground ' + this._id, this._window.setAsForeground());
+    }
+
     public async close(): Promise<void> {
         this._ready = false;
         return this.addPendingActions('close ' + this._id, this._window.close(true));

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -296,7 +296,7 @@ export class TabService {
             await existingTabGroup.removeTab(activeDesktopWindow, {center, halfSize});
         }
 
-        await activeDesktopWindow.bringToFront();
+        await activeDesktopWindow.setAsForeground();
     }
 
     /**

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -282,6 +282,7 @@ export class TabService {
             // If there is a window under our Point, and its not part of a tab group, and we are over a valid drop area
             if (existingTabGroup) {
                 await existingTabGroup.removeTab(activeDesktopWindow);
+                await activeDesktopWindow.setAsForeground();
             }
 
             // Create new tab group
@@ -294,9 +295,8 @@ export class TabService {
             const halfSize = {x: prevHalfSize.x, y: prevHalfSize.y + existingTabGroup.config.height / 2};
             const center = {x: target.position.x + halfSize.x, y: target.position.y + halfSize.y};
             await existingTabGroup.removeTab(activeDesktopWindow, {center, halfSize});
+            await activeDesktopWindow.setAsForeground();
         }
-
-        await activeDesktopWindow.setAsForeground();
     }
 
     /**

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -16,8 +16,8 @@ export interface SemVer {
 // TODO: Create Placeholder and PlaceholderStore classes?
 // This keeps track of how many placeholders we have open, so we know when we can start regrouping a layout.
 let numOfPlaceholders = 0;
-let functionToContinueRestorationWhenPlaceholdersClosed: (() => void) | undefined;
-let rejectTimeout: number | undefined;
+let functionToContinueRestorationWhenPlaceholdersClosed: (() => void)|undefined;
+let rejectTimeout: number|undefined;
 
 fin.System.addListener('window-closed', (win) => {
     if (win.name.startsWith('Placeholder-')) {


### PR DESCRIPTION
Reduces the amount of calls we are making when performing various tabbing operations.  

One outstanding flicker remains when breaking up a tab group (2 tabs only).  This is caused by windows receiving focus when being taken from a frameless to framed state.