### PR TITLE
[SERVICE-324] Restoring certain layout configurations twice causes runtime errors

### DIFF
--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -639,10 +639,7 @@ export class DesktopTabGroup implements DesktopEntity {
         }
 
         // Update the internal state of the tabGroup
-        this.currentState.resizeConstraints = {
-            x: {...result.x},
-            y: {...result.y}
-        };
+        this.currentState.resizeConstraints = {x: {...result.x}, y: {...result.y}};
         // Update the tabStrip constraints accordingly
         if (this._window.isReady) {
             await this._window.applyProperties({

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -691,7 +691,7 @@ export class DesktopWindow implements DesktopEntity {
                     if (this._ready && group === this._snapGroup) {
                         // It's possible that "other" has closed in the inervening time between registration of this pending
                         // action and its execution. If that is the case, we will roll over to the next window in the group
-                        // until we find one that is groupable. If there are no groupable windows left in the group we will 
+                        // until we find one that is groupable. If there are no groupable windows left in the group we will
                         // log a warning and not proceed with the snap.
                         let target: DesktopWindow|undefined;
                         if (other.isReady) {


### PR DESCRIPTION
Added some better failure handling to the low-level window grouping logic to prevent calling mergeGroups on windows which no longer exist.