### PR TITLE
[SERVICE-348][SERVICE-367] Block maximize actions on tabgroups that contain a window with maximizable: false or maxWidth/maxHeight constraints

### DIFF
--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -207,7 +207,7 @@ export class DesktopTabGroup implements DesktopEntity {
             // This all looks a bit messy, but is basically just determining which windows are preventing the maximize and including them in the error message.
             const nonMaximizableWindows: string[] = this._tabs.filter(tab => !tab.applicationState.maximizable).map(tab => tab.id);
             if (nonMaximizableWindows.length > 0) {
-                throw new Error(`Unable to maximize tabGroup: The following tas are not resizable: [${nonMaximizableWindows.join(', ')}]`);
+                throw new Error(`Unable to maximize tabGroup: The following tabs are not resizable: [${nonMaximizableWindows.join(', ')}]`);
             }
             const sizeConstrainedWindows = this._tabs
                                                .filter(

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -107,7 +107,7 @@ export class TabService {
         await tabGroup.addTabs(tabs, activeTab);
 
         if (tabs[0].currentState.state === 'maximized') {
-            tabGroup.maximize();
+            tabGroup.maximize().catch(console.warn);
         }
     }
 
@@ -209,7 +209,7 @@ export class TabService {
 
                 // TODO: Change to look at groupDef.groupInfo.state
                 if (tabGroup.state === 'maximized') {
-                    await tabGroup.maximize();
+                    tabGroup.maximize().catch(console.warn);
                 } else if (tabGroup.state === 'minimized') {
                     await tabGroup.minimize();
                 }

--- a/test/demo/tabbing/tabGroupResizeConstraints.test.ts
+++ b/test/demo/tabbing/tabGroupResizeConstraints.test.ts
@@ -10,7 +10,7 @@ import {CreateWindowData, createWindowTest} from '../utils/createWindowTest';
 import {refreshWindowState} from '../utils/modelUtils';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 import {layoutsClientPromise} from '../utils/serviceUtils';
-import { getTabGroupState } from '../utils/tabServiceUtils';
+import {getTabGroupState} from '../utils/tabServiceUtils';
 
 interface TabConstraintsOptions extends CreateWindowData {
     windowConstraints: Constraints[];

--- a/test/demo/tabbing/tabGroupResizeConstraints.test.ts
+++ b/test/demo/tabbing/tabGroupResizeConstraints.test.ts
@@ -1,7 +1,7 @@
 import {test, TestContext} from 'ava';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
-import {assertAllTabbed, assertNotTabbed} from '../../provider/utils/assertions';
+import {assertAllTabbed, assertNotTabbed, assertTabbed} from '../../provider/utils/assertions';
 import {delay} from '../../provider/utils/delay';
 import {Side, sideArray} from '../../provider/utils/SideUtils';
 import {tabWindowsTogether} from '../../provider/utils/tabWindowsTogether';
@@ -10,6 +10,7 @@ import {CreateWindowData, createWindowTest} from '../utils/createWindowTest';
 import {refreshWindowState} from '../utils/modelUtils';
 import {testParameterized} from '../utils/parameterizedTestUtils';
 import {layoutsClientPromise} from '../utils/serviceUtils';
+import { getTabGroupState } from '../utils/tabServiceUtils';
 
 interface TabConstraintsOptions extends CreateWindowData {
     windowConstraints: Constraints[];
@@ -112,6 +113,31 @@ const defaultConstraints: Required<Constraints> = {
         }
     }
 };
+
+testParameterized(
+    `Cannot maximize tabset when tab has maxWidth/Height`,
+    [
+        {frame: true, windowCount: 2, windowConstraints: [{}, {}]},
+        {frame: true, windowCount: 2, windowConstraints: [{}, {maxHeight: 500}]},
+        {frame: true, windowCount: 2, windowConstraints: [{}, {maxWidth: 500}]},
+    ],
+    createWindowTest(async (t, options: TabConstraintsOptions) => {
+        const {tabbing} = await layoutsClientPromise;
+        const windows = t.context.windows;
+
+        await Promise.all(windows.map((win, index) => win.updateOptions(options.windowConstraints[index])));
+        await Promise.all(windows.map((win) => refreshWindowState(win.identity)));
+
+        await tabWindowsTogether(windows[0], windows[1]);
+        await assertTabbed(windows[0], windows[1], t);
+
+        if (options.windowConstraints[1].maxHeight || options.windowConstraints[1].maxWidth) {
+            await t.throws(tabbing.maximizeTabGroup(windows[0].identity));
+        } else {
+            await t.notThrows(tabbing.maximizeTabGroup(windows[0].identity));
+            t.is(await getTabGroupState(windows[0].identity), 'maximized');
+        }
+    }));
 
 function assertConstraintsMatch(expected: Constraints, actual: Constraints, t: TestContext): void {
     for (const key of Object.keys(defaultConstraints) as (keyof Constraints)[]) {

--- a/test/demo/utils/tabServiceUtils.ts
+++ b/test/demo/utils/tabServiceUtils.ts
@@ -2,7 +2,7 @@ import {Identity} from 'hadouken-js-adapter';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
 import {SERVICE_IDENTITY, TabAPI, UpdateTabPropertiesPayload} from '../../../src/client/internal';
-import {TabProperties, WindowIdentity} from '../../../src/client/types';
+import {TabProperties, WindowIdentity, WindowState} from '../../../src/client/types';
 import {DesktopTabGroup} from '../../../src/provider/model/DesktopTabGroup';
 import {DesktopWindow} from '../../../src/provider/model/DesktopWindow';
 import {getConnection} from '../../provider/utils/connect';
@@ -120,4 +120,24 @@ export async function getActiveTab(identity: Identity): Promise<Identity> {
  */
 export async function updateTabProperties(identity: Identity, properties: Partial<TabProperties>) {
     await sendServiceMessage<UpdateTabPropertiesPayload, void>(TabAPI.UPDATETABPROPERTIES, {window: identity, properties});
+}
+
+export async function getTabGroupState(identity: Identity): Promise<WindowState> {
+    return executeJavascriptOnService<WindowIdentity, WindowState>(function(this: ProviderWindow, identity: WindowIdentity): WindowState {
+        const desktopWindow = this.model.getWindow(identity);
+
+        if (desktopWindow) {
+            const tabGroup = desktopWindow.tabGroup;
+
+            if (tabGroup) {
+                return tabGroup.state;
+
+            } else {
+                throw new Error(`Error when determining tabGroup state: window ${desktopWindow.id} is not in a tab group`);
+            }
+
+        } else {
+            throw new Error(`Attempted to get the tabGroup of non-existent or deregistered window: ${identity.uuid}/${identity.name}`);
+        }
+    }, identity as WindowIdentity);
 }


### PR DESCRIPTION
- TabGroups will check their maximizability before maximising and throw an error if false.
- `updateGroupConstraints` will now also update the maximizability of the tabGroup.
- TabGroup maximizability is determined by the union of all windows' maximizability and whether they have any maximum height/width constraints.