### PR TITLE
[SERVICE-352] Prevent tabbing to maximized, un-tabbed windows

### DIFF
--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -425,7 +425,7 @@ export class DesktopWindow implements DesktopEntity {
 
     public get isActive(): boolean {
         const state: EntityState = this._currentState;
-        return !state.hidden && state.opacity > 0 && state.state !== 'minimized';
+        return !state.hidden && state.opacity > 0 && state.state === 'normal';
     }
 
     /**


### PR DESCRIPTION
Changed `DesktopWindow.isActive` to also exclude maximized windows.

NOTE: This will lead to a known issue where it is possible to snap/tab to windows behind the maximized window.  After some discussions, that is preferable to tabbing/snapping to the maximized window's original position, and as the effort to resolve would be fairly substantial, it is being left to post-1.0.