### PR TITLE
[SERVICE-352] Fix: Strange preview window positioning when tabbing to a maximized window

### DIFF
--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -155,6 +155,21 @@ export class DesktopModel {
     }
 
     /**
+     * Returns the monitor rectangle which overlaps the most with the given rectangle
+     */
+    public getMonitorByRect(rect: Rectangle): Rectangle {
+        // As a useful heuristic, if the center of teh given rect is inside a monitor rect, that monitor will be the most overlapped.
+        const monitorWithCenter = this._monitors.find(mon => RectUtils.isPointInRect(mon.center, mon.halfSize, rect.center));
+        if (monitorWithCenter) {
+            return monitorWithCenter;
+        }
+        // Finds the monitor which has the largest overlapping area with the given rect
+        const mostOverlappedMonitor =
+            this._monitors.reduce((prev, current) => RectUtils.overlappingArea(prev, rect) > RectUtils.overlappingArea(current, rect) ? prev : current);
+        return RectUtils.clone(mostOverlappedMonitor);
+    }
+
+    /**
      * Re-registers the target window with the service, "white-listing" the window for use with the service for the
      * lifecycle of whichever window requested that the target be registered.
      *

--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -1,9 +1,10 @@
 import {Window} from 'hadouken-js-adapter';
 import {WindowEvent} from 'hadouken-js-adapter/out/types/src/api/events/base';
+import {MonitorEvent} from 'hadouken-js-adapter/out/types/src/api/events/system';
+import {MonitorInfo} from 'hadouken-js-adapter/out/types/src/api/system/monitor';
 import {WindowDetail, WindowInfo} from 'hadouken-js-adapter/out/types/src/api/system/window';
 
 import {ConfigurationObject, RegEx, Rule, Scope, WindowScope} from '../../../gen/provider/config/layouts-config';
-
 import {ConfigUtil, Masked} from '../config/ConfigUtil';
 import {ScopedConfig} from '../config/Store';
 import {MaskWatch} from '../config/Watch';
@@ -17,8 +18,6 @@ import {DesktopTabGroup} from './DesktopTabGroup';
 import {DesktopWindow, EntityState, WindowIdentity} from './DesktopWindow';
 import {MouseTracker} from './MouseTracker';
 import {ZIndexer} from './ZIndexer';
-import { MonitorEvent } from 'hadouken-js-adapter/out/types/src/api/events/system';
-import { MonitorInfo } from 'hadouken-js-adapter/out/types/src/api/system/monitor';
 
 type EnabledMask = {
     enabled: true
@@ -88,7 +87,7 @@ export class DesktopModel {
         });
 
         // Validate everything on monitor change, as groups may become disjointed
-        fin.System.addListener('monitor-info-changed', async (evt: MonitorEvent<"system", "monitor-info-changed">) => {
+        fin.System.addListener('monitor-info-changed', async (evt: MonitorEvent<'system', 'monitor-info-changed'>) => {
             this._monitors = [evt.primaryMonitor, ...evt.nonPrimaryMonitors].map(mon => RectUtils.convertToCenterHalfSize(mon.monitorRect));
 
             // Validate all tabgroups

--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -161,7 +161,7 @@ export class DesktopModel {
         // As a useful heuristic, if the center of the given rect is inside a monitor rect, that monitor will be the most overlapped.
         const monitorWithCenter = this._monitors.find(mon => RectUtils.isPointInRect(mon.center, mon.halfSize, rect.center));
         if (monitorWithCenter) {
-            return monitorWithCenter;
+            return RectUtils.clone(monitorWithCenter);
         }
         // Finds the monitor which has the largest overlapping area with the given rect
         const mostOverlappedMonitor =

--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -158,7 +158,7 @@ export class DesktopModel {
      * Returns the monitor rectangle which overlaps the most with the given rectangle
      */
     public getMonitorByRect(rect: Rectangle): Rectangle {
-        // As a useful heuristic, if the center of teh given rect is inside a monitor rect, that monitor will be the most overlapped.
+        // As a useful heuristic, if the center of the given rect is inside a monitor rect, that monitor will be the most overlapped.
         const monitorWithCenter = this._monitors.find(mon => RectUtils.isPointInRect(mon.center, mon.halfSize, rect.center));
         if (monitorWithCenter) {
             return monitorWithCenter;

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -213,11 +213,13 @@ export class DesktopTabGroup implements DesktopEntity {
 
             this._beforeMaximizeBounds = {center: {...center}, halfSize: {...halfSize}};
 
+            const currentMonitor = this._model.getMonitorByRect(this._groupState) || this._model.monitors[0];
+
             await this._window.applyProperties(
-                {center: {x: screen.availWidth / 2, y: this._config.height / 2}, halfSize: {x: screen.availWidth / 2, y: this._config.height / 2}});
+                {center: {x: currentMonitor.center.x, y: this._config.height / 2}, halfSize: {x: currentMonitor.halfSize.x, y: this._config.height / 2}});
             await this.activeTab.applyProperties({
-                center: {x: screen.availWidth / 2, y: (screen.availHeight + this._config.height) / 2},
-                halfSize: {x: screen.availWidth / 2, y: (screen.availHeight - this._config.height) / 2}
+                center: {x: currentMonitor.center.x, y: currentMonitor.center.y + this._config.height / 2},
+                halfSize: {x: currentMonitor.halfSize.x, y: currentMonitor.halfSize.y - this._config.height / 2}
             });
 
             this._isMaximized = true;

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -11,7 +11,7 @@ import {promiseMap} from '../snapanddock/utils/async';
 import {Debounced} from '../snapanddock/utils/Debounced';
 import {isWin10} from '../snapanddock/utils/platform';
 import {Point} from '../snapanddock/utils/PointUtils';
-import {Rectangle} from '../snapanddock/utils/RectUtils';
+import {Rectangle, RectUtils} from '../snapanddock/utils/RectUtils';
 
 import {DesktopEntity} from './DesktopEntity';
 import {DesktopModel} from './DesktopModel';
@@ -447,6 +447,11 @@ export class DesktopWindow implements DesktopEntity {
     }
 
     public get currentState(): EntityState {
+        // Special handling to return apparent bounds for maximized windows
+        if (this._currentState.state === 'maximized') {
+            const relevantMonitor = this._model.monitors.find(mon => RectUtils.isPointInRect(mon.center, mon.halfSize, this._currentState.center));
+            return {...this._currentState, ...relevantMonitor};
+        }
         return this._currentState;
     }
 

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -449,8 +449,8 @@ export class DesktopWindow implements DesktopEntity {
     public get currentState(): EntityState {
         // Special handling to return apparent bounds for maximized windows
         if (this._currentState.state === 'maximized') {
-            const relevantMonitor = this._model.monitors.find(mon => RectUtils.isPointInRect(mon.center, mon.halfSize, this._currentState.center));
-            return {...this._currentState, ...relevantMonitor};
+            const currentMonitor = this._model.getMonitorByRect(this._currentState);
+            return {...this._currentState, ...currentMonitor};
         }
         return this._currentState;
     }

--- a/src/provider/snapanddock/utils/RectUtils.ts
+++ b/src/provider/snapanddock/utils/RectUtils.ts
@@ -1,3 +1,5 @@
+import {Rect} from 'hadouken-js-adapter/out/types/src/api/system/monitor';
+
 import {Point, PointUtils} from './PointUtils';
 
 export class MeasureResult implements Point {
@@ -99,5 +101,16 @@ export class RectUtils {
 
     public static isEqual(rect1: Rectangle, rect2: Rectangle): boolean {
         return PointUtils.isEqual(rect1.center, rect2.center) && PointUtils.isEqual(rect1.halfSize, rect2.halfSize);
+    }
+    
+    /**
+     * Converts a rectangle from the {top,bottom,left,right} format used in the core to the {center, halfsize} format used in 
+     * the model.
+     */
+    public static convertToCenterHalfSize(rect: Rect): Rectangle {
+        return {
+            center: {x: rect.left + (rect.right - rect.left) / 2, y: rect.top + (rect.bottom - rect.top) / 2},
+            halfSize: {x: (rect.right - rect.left) / 2, y: (rect.bottom - rect.top) / 2}
+        };
     }
 }

--- a/src/provider/snapanddock/utils/RectUtils.ts
+++ b/src/provider/snapanddock/utils/RectUtils.ts
@@ -113,4 +113,14 @@ export class RectUtils {
             halfSize: {x: (rect.right - rect.left) / 2, y: (rect.bottom - rect.top) / 2}
         };
     }
+
+    public static overlappingArea(rect1: Rectangle, rect2: Rectangle): number {
+        const overlap = PointUtils.scale(this.distanceFromParts(rect1.center, rect1.halfSize, rect2.center, rect2.halfSize), -1);
+
+        return Math.max(0, overlap.x) * Math.max(0, overlap.y);
+    }
+
+    public static clone(rect: Rectangle): Rectangle {
+        return {center: PointUtils.clone(rect.center), halfSize: PointUtils.clone(rect.halfSize)};
+    }
 }

--- a/src/provider/snapanddock/utils/RectUtils.ts
+++ b/src/provider/snapanddock/utils/RectUtils.ts
@@ -102,9 +102,9 @@ export class RectUtils {
     public static isEqual(rect1: Rectangle, rect2: Rectangle): boolean {
         return PointUtils.isEqual(rect1.center, rect2.center) && PointUtils.isEqual(rect1.halfSize, rect2.halfSize);
     }
-    
+
     /**
-     * Converts a rectangle from the {top,bottom,left,right} format used in the core to the {center, halfsize} format used in 
+     * Converts a rectangle from the {top,bottom,left,right} format used in the core to the {center, halfsize} format used in
      * the model.
      */
     public static convertToCenterHalfSize(rect: Rect): Rectangle {

--- a/src/provider/snapanddock/utils/RectUtils.ts
+++ b/src/provider/snapanddock/utils/RectUtils.ts
@@ -109,7 +109,7 @@ export class RectUtils {
      */
     public static convertToCenterHalfSize(rect: Rect): Rectangle {
         return {
-            center: {x: rect.left + (rect.right - rect.left) / 2, y: rect.top + (rect.bottom - rect.top) / 2},
+            center: {x: (rect.right + rect.left) / 2, y: (rect.bottom + rect.top) / 2},
             halfSize: {x: (rect.right - rect.left) / 2, y: (rect.bottom - rect.top) / 2}
         };
     }

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -101,12 +101,15 @@ export class TabService {
             }
         }
 
+        // Used after formation to determine if group should be maximized
+        const previousState = tabs[0].currentState.state;
+
         const config: Tabstrip = this.getTabstripConfig(tabIdentities[0]);
         const snapGroup: DesktopSnapGroup = tabs[0].snapGroup;
         const tabGroup: DesktopTabGroup = new DesktopTabGroup(this._model, snapGroup, config);
         await tabGroup.addTabs(tabs, activeTab);
 
-        if (tabs[0].currentState.state === 'maximized') {
+        if (previousState === 'maximized') {
             tabGroup.maximize();
         }
     }

--- a/test/demo/tabbing/tabToMaximizedWindow.test.ts
+++ b/test/demo/tabbing/tabToMaximizedWindow.test.ts
@@ -16,7 +16,7 @@ interface TabToMaximizedWindowTestOptions extends CreateWindowData {
 }
 
 testParameterized(
-    `tab to maximized window`,
+    `Tab to maximized window`,
     [
         {frame: true, windowCount: 2, tabTo: 'actual'},
         {frame: true, windowCount: 2, tabTo: 'apparent'},

--- a/test/demo/tabbing/tabToMaximizedWindow.test.ts
+++ b/test/demo/tabbing/tabToMaximizedWindow.test.ts
@@ -1,0 +1,52 @@
+import {Rect} from 'hadouken-js-adapter/out/types/src/api/system/monitor';
+
+import {assertNotTabbed, assertTabbed} from '../../provider/utils/assertions';
+import {getConnection} from '../../provider/utils/connect';
+import {dragWindowTo} from '../../provider/utils/dragWindowTo';
+import {getBounds, getTabsetBounds, NormalizedBounds} from '../../provider/utils/getBounds';
+import {tabWindowsTogether} from '../../provider/utils/tabWindowsTogether';
+import {CreateWindowData, createWindowTest} from '../utils/createWindowTest';
+import {testParameterized} from '../utils/parameterizedTestUtils';
+import {getTabGroupState} from '../utils/tabServiceUtils';
+
+interface TabToMaximizedWindowTestOptions extends CreateWindowData {
+    windowCount: 2;
+    frame: boolean;
+    tabTo: 'apparent'|'actual';
+}
+
+testParameterized(
+    `tab to maximized window`,
+    [
+        {frame: true, windowCount: 2, tabTo: 'actual'},
+        {frame: true, windowCount: 2, tabTo: 'apparent'},
+        {frame: false, windowCount: 2, tabTo: 'actual'},
+        {frame: false, windowCount: 2, tabTo: 'apparent'},
+    ],
+    createWindowTest(async (t, options: TabToMaximizedWindowTestOptions) => {
+        const fin = await getConnection();
+        const {windows} = t.context;
+
+        await windows[1].maximize();
+
+        if (options.tabTo === 'apparent') {
+            const apparentBounds: Rect = (await fin.System.getMonitorInfo()).primaryMonitor.availableRect;
+            await dragWindowTo(windows[0], apparentBounds.left + 50, apparentBounds.top + 30);
+            // Windows should have tabbed
+            await assertTabbed(windows[0], windows[1], t);
+            // Make sure that the internal state of the tabGroup is correct
+            t.is(await getTabGroupState(windows[0].identity), 'maximized');
+            // TabGroup fills the whole screen
+            const groupBounds = await getTabsetBounds(windows[0]);
+            for (const side of Object.keys(apparentBounds) as (keyof Rect)[]) {
+                if (apparentBounds.hasOwnProperty(side)) {
+                    t.is(apparentBounds[side], groupBounds[side]);
+                }
+            }
+        } else {
+            const actualBounds: NormalizedBounds = await getBounds(windows[1]);
+            await tabWindowsTogether(windows[1], windows[0]);
+            // Windows should not have tabbed
+            await Promise.all(windows.map(win => assertNotTabbed(win, t)));
+        }
+    }));

--- a/test/demo/tabbing/tabToMaximizedWindow.test.ts
+++ b/test/demo/tabbing/tabToMaximizedWindow.test.ts
@@ -11,16 +11,16 @@ import {getTabGroupState} from '../utils/tabServiceUtils';
 
 interface TabToMaximizedWindowTestOptions extends CreateWindowData {
     windowCount: 2;
-    tabTo: 'apparent'|'actual';
+    tabTo: 'maximized'|'restored';
 }
 
 testParameterized(
     `Tab to maximized window`,
     [
-        {frame: true, windowCount: 2, tabTo: 'actual'},
-        {frame: true, windowCount: 2, tabTo: 'apparent'},
-        {frame: false, windowCount: 2, tabTo: 'actual'},
-        {frame: false, windowCount: 2, tabTo: 'apparent'},
+        {frame: true, windowCount: 2, tabTo: 'restored'},
+        {frame: true, windowCount: 2, tabTo: 'maximized'},
+        {frame: false, windowCount: 2, tabTo: 'restored'},
+        {frame: false, windowCount: 2, tabTo: 'maximized'},
     ],
     createWindowTest(async (t, options: TabToMaximizedWindowTestOptions) => {
         const fin = await getConnection();
@@ -28,22 +28,22 @@ testParameterized(
 
         await windows[1].maximize();
 
-        if (options.tabTo === 'apparent') {
-            const apparentBounds: Rect = (await fin.System.getMonitorInfo()).primaryMonitor.availableRect;
-            await dragWindowTo(windows[0], apparentBounds.left + 50, apparentBounds.top + 30);
+        if (options.tabTo === 'maximized') {
+            const maximizedBounds: Rect = (await fin.System.getMonitorInfo()).primaryMonitor.availableRect;
+            await dragWindowTo(windows[0], maximizedBounds.left + 50, maximizedBounds.top + 30);
             // Windows should have tabbed
             await assertTabbed(windows[0], windows[1], t);
             // Make sure that the internal state of the tabGroup is correct
             t.is(await getTabGroupState(windows[0].identity), 'maximized');
             // TabGroup fills the whole screen
             const groupBounds = await getTabsetBounds(windows[0]);
-            for (const side of Object.keys(apparentBounds) as (keyof Rect)[]) {
-                if (apparentBounds.hasOwnProperty(side)) {
-                    t.is(apparentBounds[side], groupBounds[side]);
+            for (const side of Object.keys(maximizedBounds) as (keyof Rect)[]) {
+                if (maximizedBounds.hasOwnProperty(side)) {
+                    t.is(maximizedBounds[side], groupBounds[side]);
                 }
             }
         } else {
-            const actualBounds: NormalizedBounds = await getBounds(windows[1]);
+            const restoredBounds: NormalizedBounds = await getBounds(windows[1]);
             await tabWindowsTogether(windows[1], windows[0]);
             // Windows should not have tabbed
             await Promise.all(windows.map(win => assertNotTabbed(win, t)));

--- a/test/demo/tabbing/tabToMaximizedWindow.test.ts
+++ b/test/demo/tabbing/tabToMaximizedWindow.test.ts
@@ -52,7 +52,7 @@ testParameterized(
 
 
 testParameterized(
-    `Cannot tab to window hidden by maximized window`, 
+    `Cannot tab to window hidden by maximized window`,
     [
         {frame: true, windowCount: 3},
         {frame: false, windowCount: 3},
@@ -72,6 +72,4 @@ testParameterized(
 
         // None of the windows should be tabbed
         await Promise.all(windows.map(win => assertNotTabbed(win, t)));
-
-    })
-)
+    }));

--- a/test/demo/tabbing/tabToMaximizedWindow.test.ts
+++ b/test/demo/tabbing/tabToMaximizedWindow.test.ts
@@ -11,7 +11,6 @@ import {getTabGroupState} from '../utils/tabServiceUtils';
 
 interface TabToMaximizedWindowTestOptions extends CreateWindowData {
     windowCount: 2;
-    frame: boolean;
     tabTo: 'apparent'|'actual';
 }
 
@@ -50,3 +49,29 @@ testParameterized(
             await Promise.all(windows.map(win => assertNotTabbed(win, t)));
         }
     }));
+
+
+testParameterized(
+    `Cannot tab to window hidden by maximized window`, 
+    [
+        {frame: true, windowCount: 3},
+        {frame: false, windowCount: 3},
+    ],
+    createWindowTest(async t => {
+        const {windows} = t.context;
+
+        await windows[2].moveBy(200, 200);
+        await windows[1].maximize();
+
+        // Stack the windows in z-order from top to bottom: 0 - 1 (maximized) - 2
+        await windows[2].setAsForeground();
+        await windows[1].setAsForeground();
+        await windows[0].setAsForeground();
+
+        await tabWindowsTogether(windows[2], windows[0]);
+
+        // None of the windows should be tabbed
+        await Promise.all(windows.map(win => assertNotTabbed(win, t)));
+
+    })
+)


### PR DESCRIPTION
Second run at this story.

- Added logic to the provider to store and track changes to the current monitor rectangles
- Changed `DesktopWindow.currentState` to return the apparent coordinates if a window is maximized (Note: only changed the public getter, the internal state is still the same).
- Also ended up fixing an issue where maximizing a tabGroup would always make it fill the monitor that the provider was on, regardless of the actual position of the tabGroup
- It is now not possible to tab to a window hidden underneath a maximized window. 
- Added a few new util functions to facilitate these changes

Known issues: 
- Currently, the tabstrip will still show the maximize icon when first tabbing to a maximized window. I have tested, and the model state is correct, it is just that the tabstrip is not aware of the change. I believe Bryan has a PR open which fixes this, so have left it for now.