### PR TITLE
[N/A] Update testbed applications to work properly with workspaces

### DIFF
--- a/src/demo/spawn.ts
+++ b/src/demo/spawn.ts
@@ -25,6 +25,11 @@ export interface WindowData {
     id?: string;
 
     /**
+     * If restoring an application, the name is passed back to the `createWindow` function to properly restore the child windows and close out placeholders.
+     */
+    name?: string;
+
+    /**
      * URL of the window. Defaults to the testbed app.
      */
     url?: string;
@@ -188,7 +193,7 @@ async function createApplication(options: Omit<AppData, 'parent'>): Promise<Appl
 }
 
 async function createChildWindow(data: Omit<WindowData, 'parent'>): Promise<_Window> {
-    const name: string = data.id || `Win-${Math.random().toString().substr(2, 4)}`;
+    const name: string = data.id || data.name || `Win-${Math.random().toString().substr(2, 4)}`;
     const url = getUrl(data);
     const size = getWindowSize(data);
 

--- a/src/demo/testbed/WorkspacesUI.ts
+++ b/src/demo/testbed/WorkspacesUI.ts
@@ -1,8 +1,10 @@
-import {workspaces} from '../../client/main';
-import {createWindow} from '../spawn';
-import {EventsUI} from './EventsUI';
-import {WorkspaceWindow, WorkspaceApp} from '../../client/types';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
+
+import {workspaces} from '../../client/main';
+import {WorkspaceApp, WorkspaceWindow} from '../../client/types';
+import {createWindow} from '../spawn';
+
+import {EventsUI} from './EventsUI';
 
 export class WorkspacesUI {
     private _log: EventsUI;
@@ -26,7 +28,6 @@ export class WorkspacesUI {
         const ofApp = fin.Application.getCurrentSync();
         const openWindows = await ofApp.getChildWindows();
         const openAndPosition = layoutApp.childWindows.map(async (win: WorkspaceWindow, index: number) => {
-            console.log("win.name", win.name);
             if (!openWindows.some((w: _Window) => w.identity.name === win.name)) {
                 await createWindow(win);
             } else {

--- a/src/demo/testbed/WorkspacesUI.ts
+++ b/src/demo/testbed/WorkspacesUI.ts
@@ -1,0 +1,75 @@
+import {workspaces} from '../../client/main';
+import {createWindow} from '../spawn';
+import {EventsUI} from './EventsUI';
+import {WorkspaceWindow, WorkspaceApp} from '../../client/types';
+import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
+
+export class WorkspacesUI {
+    private _log: EventsUI;
+
+    constructor(log: EventsUI) {
+        // Allow layouts service to save and restore this application
+        workspaces.setGenerateHandler(() => {
+            return {test: true};
+        });
+        workspaces.setRestoreHandler(this.onAppRes);
+        workspaces.ready();
+
+        workspaces.addEventListener('workspace-restored', (e: Event) => {
+            log.addEvent(e);
+        });
+        this._log = log;
+    }
+
+    private async onAppRes(layoutApp: WorkspaceApp): Promise<WorkspaceApp> {
+        console.log('Apprestore called:', layoutApp);
+        const ofApp = fin.Application.getCurrentSync();
+        const openWindows = await ofApp.getChildWindows();
+        const openAndPosition = layoutApp.childWindows.map(async (win: WorkspaceWindow, index: number) => {
+            console.log("win.name", win.name);
+            if (!openWindows.some((w: _Window) => w.identity.name === win.name)) {
+                await createWindow(win);
+            } else {
+                await this.positionWindow(win);
+            }
+        });
+        await Promise.all(openAndPosition);
+        return layoutApp;
+    }
+
+    // Positions a window when it is restored.
+    // Also given to the client to use.
+    private async positionWindow(win: WorkspaceWindow) {
+        try {
+            const {isShowing, isTabbed} = win;
+
+            const ofWin = await fin.Window.wrap(win);
+            await ofWin.setBounds(win);
+
+            if (isTabbed) {
+                await ofWin.show();
+                return;
+            }
+
+            await ofWin.leaveGroup();
+
+            if (!isShowing) {
+                await ofWin.hide();
+                return;
+            }
+
+            if (win.state === 'normal') {
+                // Need to both restore and show because the restore function doesn't emit a `shown` or `show-requested` event
+                await ofWin.restore();
+                await ofWin.show();
+            } else if (win.state === 'minimized') {
+                await ofWin.minimize();
+            } else if (win.state === 'maximized') {
+                await ofWin.maximize();
+            }
+
+        } catch (e) {
+            console.error('position window error', e);
+        }
+    }
+}

--- a/src/demo/testbed/index.ts
+++ b/src/demo/testbed/index.ts
@@ -6,6 +6,7 @@ import {SnapAndDockUI} from './SnapAndDockUI';
 import {TabbingUI} from './TabbingUI';
 import {Elements, View} from './View';
 import {WindowsUI} from './WindowsUI';
+import {WorkspacesUI} from './WorkspacesUI';
 
 /**
  * Dictionary of user-facing strings
@@ -37,9 +38,10 @@ view.ready.then((elements: Elements) => {
     const tabbingUI: TabbingUI = new TabbingUI(elements, eventsUI);
     const registrationUI: RegistrationUI = new RegistrationUI(elements, eventsUI);
     const windowUI: WindowsUI = new WindowsUI(elements);
+    const workspacesUI: WorkspacesUI = new WorkspacesUI(eventsUI);
 
     // Make objects accessible from the debugger
-    Object.assign(window, {view, eventsUI, snapAndDockUI, tabbingUI, registrationUI, windowUI});
+    Object.assign(window, {view, eventsUI, snapAndDockUI, tabbingUI, registrationUI, windowUI, workspacesUI});
 
     // Listen for requests to spawn child windows/applications
     addSpawnListeners();

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -138,8 +138,21 @@ export const createTabPlaceholder = async (win: WorkspaceWindow) => {
 
 // Check to see if an application was created programmatically.
 export const wasCreatedProgrammatically = (app: ApplicationInfo|WorkspaceApp) => {
-    const initialOptions = app.initialOptions as {uuid: string, url: string};
-    return app && app.initialOptions && initialOptions.uuid && initialOptions.url;
+    const initialOptions = app.initialOptions as fin.ApplicationOptions;
+    if (app && initialOptions && initialOptions.uuid) {
+        if (initialOptions.url) {
+            return true;
+        }
+
+        if (initialOptions.mainWindowOptions) {
+            return !!initialOptions.mainWindowOptions.url;
+        }
+
+        return false;
+        
+    } else {
+        return false;
+    }
 };
 
 // Type here should be ApplicationInfo from the js-adapter (needs to be updated)

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -149,7 +149,7 @@ export const wasCreatedProgrammatically = (app: ApplicationInfo|WorkspaceApp) =>
         }
 
         return false;
-        
+
     } else {
         return false;
     }


### PR DESCRIPTION
- Changed `wasCreatedProgrammatically` logic. (Could use some help with making sure this works properly. It broke on the `Create Programmatically` apps.)
 - Added `workspacesUI` class to properly register/respond to workspaces calls. 
- Updated `createChildWindow` in `spawn` to take name from workspace (for proper restoration. Need to restore a window at the same name in order for the placeholder to disappear). 