### PR TITLE
[SERVICE-353] Strange window positioning if tabbed windows are shorter than the tabstrip

### DIFF
--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -437,9 +437,12 @@ export class TabService {
         const targetConstraints = target.currentState.resizeConstraints;
         const activeConstraints = active.currentState.resizeConstraints;
 
-        // Adjust target height for windows not currently in a tabGroup
+        // Adjust heights for windows not currently in a tabGroup
         if (!target.tabGroup) {
             targetSize.y -= this._config.query(target.scope).tabstrip.height;
+        }
+        if (!active.tabGroup) {
+            activeSize.y -= this._config.query(active.scope).tabstrip.height;
         }
 
         let result = true;

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -437,19 +437,28 @@ export class TabService {
         const targetConstraints = target.currentState.resizeConstraints;
         const activeConstraints = active.currentState.resizeConstraints;
 
+        // Adjust target height for windows not currently in a tabGroup
+        if (!target.tabGroup) {
+            targetSize.y -= this._config.query(target.scope).tabstrip.height;
+        }
+
         let result = true;
         // Active is able to be resized in direction where resize would be needed.
         result = result &&
             ((targetSize.x === activeSize.x || activeConstraints.x.resizableMin || activeConstraints.x.resizableMax) &&
              (targetSize.y === activeSize.y || activeConstraints.y.resizableMin || activeConstraints.y.resizableMax));
+        // Target is able to be resized in direction where resize would be needed.
+        result = result && (targetConstraints.y.resizableMin || targetConstraints.y.resizableMax);
         // Projected size after tabbing is within active's size constraints
         result = result &&
-            (targetSize.x > activeConstraints.x.minSize && targetSize.x < activeConstraints.x.maxSize && targetSize.y > activeConstraints.y.minSize &&
-             targetSize.y < activeConstraints.y.maxSize);
+            (targetSize.x >= activeConstraints.x.minSize && targetSize.x <= activeConstraints.x.maxSize && targetSize.y >= activeConstraints.y.minSize &&
+             targetSize.y <= activeConstraints.y.maxSize);
+        // Projected size after tabbing is within targets's size constraints
+        result = result && targetSize.y >= targetConstraints.y.minSize;
         // Union of both constraints would form a valid constraint
         result = result &&
-            (targetConstraints.x.maxSize > activeConstraints.x.minSize && targetConstraints.x.minSize < activeConstraints.x.maxSize &&
-             targetConstraints.y.maxSize > activeConstraints.y.minSize && targetConstraints.y.minSize < activeConstraints.y.maxSize);
+            (targetConstraints.x.maxSize >= activeConstraints.x.minSize && targetConstraints.x.minSize <= activeConstraints.x.maxSize &&
+             targetConstraints.y.maxSize >= activeConstraints.y.minSize && targetConstraints.y.minSize <= activeConstraints.y.maxSize);
 
         return result;
     }


### PR DESCRIPTION
I have updated the constraints compatibility check when tabbing to account for the fact that windows can shrink when tabbing. This will also prevent tabbing if windows are too small to reasonably be resized to accommodate the Tabstrip.

This PR is primarily a mitigation rather than a full solution. We should revisit down the road to see if we can move the window instead of resizing in these cases.
