### PR TITLE
[SERVICE-350] Prevent child windows from snapping to other windows during restoration

### DIFF
--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -326,7 +326,7 @@ export class DesktopTabGroup implements DesktopEntity {
             }
         });
 
-        if (!activeTabId) {
+        if (activeTabId) {
             // Set the desired tab as active
             await this.switchTab(activeTab);
         } else {

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -326,15 +326,7 @@ export class DesktopTabGroup implements DesktopEntity {
             }
         });
 
-        if (activeTabId) {
-            // Set the desired tab as active
-            await this.switchTab(activeTab);
-        } else {
-            // Need to re-send tab-activated event to ensure tab is active within tabstrip
-            // TODO: See if this can be avoided
-            const event: TabActivatedEvent = {tabstripIdentity: this.identity, identity: activeTab.identity, type: 'tab-activated'};
-            this._window.sendEvent(event);
-        }
+        await this.switchTab(activeTab);
     }
 
     public async swapTab(tabToRemove: DesktopWindow, tabToAdd: DesktopWindow): Promise<void> {

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -189,12 +189,16 @@ const createWorkspacePlaceholders = async(workspace: Workspace): Promise<void> =
             // Should de-tab here.
             const mainWindowModel = model.getWindow(app.mainWindow);
             await tabService.removeTab(app.mainWindow);
+
+            // Need to check its child windows here, if confirmed.
+            // Also calls removeTab and setSnapGroup on open child windows.
+            // These functions need to be in this order, otherwise child windows may re-attach (if removeTab is called on an application that it's tabbed to,
+            // leaving the child window as a remainingTab).
+            await childWindowPlaceholderCheckRunningApp(app, tabbedWindows, tabbedPlaceholdersToWindows, openWindows);
+
             if (mainWindowModel && mainWindowModel.snapGroup.length > 1) {
                 await mainWindowModel.setSnapGroup(new DesktopSnapGroup());
             }
-
-            // Need to check its child windows here, if confirmed.
-            await childWindowPlaceholderCheckRunningApp(app, tabbedWindows, tabbedPlaceholdersToWindows, openWindows);
         } else {
             if (inWindowObject(app.mainWindow, tabbedWindows)) {
                 await createTabbedPlaceholderAndRecord(app.mainWindow, tabbedPlaceholdersToWindows);


### PR DESCRIPTION
- Reverse ordering of parent and child `removeTab` calls. Before, all parent apps would `removeTab` before all children would. This timing would allow the children to attach to its neighbors on TabGroup disbanding. 
- Fix non-showing tabs on restore.
- Lint.