### PR TITLE
[SERVICE-360] Possible to disjoint tabs from tabstrips with quick mouse movements during addTab

### DIFF
--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -593,11 +593,29 @@ export class DesktopTabGroup implements DesktopEntity {
             const halfSize: Point = {x: tabState.halfSize.x, y: tabState.halfSize.y - (this._config.height / 2)};
             await tab.applyProperties({center, halfSize, frame: false});
         } else {
+            // Delay to allow other async operations to jump ahead in the queue. Specifically, any pending boundsChanging events
+            // should be processed before continuing.
+            await new Promise(res => setTimeout(res, 10));
+            // If the target window/group is in the process of being moved, we delay the rest of the operation until we receive
+            // a bounds changed and update the currentState. This should serve as a fix/mitigation for SERVICE-360.
+            if (this._window.moveInProgress) {
+                console.log('a');
+                await new Promise(async res => {
+                    const slot = this._window.onCommit.add(async (win, type) => {
+                        console.log('b');
+                        slot.remove();
+                        res();
+                    });
+                    console.log('c');
+                });
+            }
             const existingTabState: EntityState = this._activeTab && this._activeTab.currentState || this._tabs[0].currentState;
             const {center, halfSize} = existingTabState;
-
+            
             // Align tab with existing tab
+            console.log('d');
             await tab.applyProperties({center, halfSize, frame: false});
+            
         }
 
         await tab.setTabGroup(this);

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -602,23 +602,19 @@ export class DesktopTabGroup implements DesktopEntity {
             // If the target window/group is in the process of being moved, we delay the rest of the operation until we receive
             // a bounds changed and update the currentState. This should serve as a fix/mitigation for SERVICE-360.
             if (this._window.moveInProgress) {
-                console.log('a');
                 await new Promise(async res => {
                     const slot = this._window.onCommit.add(async (win, type) => {
-                        console.log('b');
                         slot.remove();
                         res();
                     });
-                    console.log('c');
                 });
             }
             const existingTabState: EntityState = this._activeTab && this._activeTab.currentState || this._tabs[0].currentState;
             const {center, halfSize} = existingTabState;
-            
+
             // Align tab with existing tab
             console.log('d');
             await tab.applyProperties({center, halfSize, frame: false});
-            
         }
 
         await tab.setTabGroup(this);

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -613,7 +613,6 @@ export class DesktopTabGroup implements DesktopEntity {
             const {center, halfSize} = existingTabState;
 
             // Align tab with existing tab
-            console.log('d');
             await tab.applyProperties({center, halfSize, frame: false});
         }
 

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -261,30 +261,30 @@ export class DesktopWindow implements DesktopEntity {
      */
     public readonly onTeardown: Signal1<DesktopWindow, Promise<void>, Promise<void>> = new Signal1(Aggregators.AWAIT_VOID);
 
-    
+
     private _model: DesktopModel;
     private _identity: WindowIdentity;
     private _scope: WindowScope;
     private _id: string;  // Created from window uuid and name
-    
+
     private _window: Window;
-    
+
     /**
      * Cached state. Reflects the current state of the *actual* window object - basically, what you would get if you called any of the OpenFin API functions on
      * the window object.
      */
     private _currentState: EntityState;
-    
+
     /**
      * What the application "thinks" the state of this window is. This is the state of the window, excluding any changes made to the window by the service.
      */
     private _applicationState: EntityState;
-    
+
     /**
      * Lists all the modifications made to the window by the service. This is effectively a 'diff' between currentState and applicationState.
      */
     private _modifiedState: Partial<EntityState>;
-    
+
     /**
      * A subset of modifiedState - changes made to the window on a very short-term basis, which will soon be reverted.
      *
@@ -294,18 +294,18 @@ export class DesktopWindow implements DesktopEntity {
      * The temporary value can be found by looking up the keys of this object within 'currentState'.
      */
     private _temporaryState: Partial<EntityState>;
-    
+
     private _snapGroup: DesktopSnapGroup;
     private _tabGroup: DesktopTabGroup|null;
     private _prevGroup: DesktopSnapGroup|null;
     private _ready: boolean;
-    
+
     private _pendingActions: Promise<void>[];
     private _actionTags: WeakMap<Promise<void>, string>;
-    
+
     // Tracks event listeners registered on the fin window for easier clean-up.
     private _registeredListeners: Map<OpenFinWindowEvent, (event: fin.OpenFinWindowEventMap[OpenFinWindowEvent]) => void> = new Map();
-    
+
     private _moveInProgress = false;
     private _userInitiatedBoundsChange = false;
 
@@ -969,7 +969,6 @@ export class DesktopWindow implements DesktopEntity {
     }
 
     private handleBoundsChanged(event: fin.WindowBoundsEvent): void {
-        console.log('Resetting move in progress');
         this._moveInProgress = false;
 
         const bounds: fin.WindowBounds = this.checkBounds(event);
@@ -989,8 +988,7 @@ export class DesktopWindow implements DesktopEntity {
     }
 
     private handleBoundsChanging(event: fin.WindowBoundsEvent): void {
-        if(!this._moveInProgress) {
-            console.log('Setting move in progress');
+        if (!this._moveInProgress) {
             this._moveInProgress = true;
         }
 

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -253,29 +253,30 @@ export class DesktopWindow implements DesktopEntity {
      */
     public readonly onTeardown: Signal1<DesktopWindow, Promise<void>, Promise<void>> = new Signal1(Aggregators.AWAIT_VOID);
 
+    
     private _model: DesktopModel;
     private _identity: WindowIdentity;
     private _scope: WindowScope;
     private _id: string;  // Created from window uuid and name
-
+    
     private _window: Window;
-
+    
     /**
      * Cached state. Reflects the current state of the *actual* window object - basically, what you would get if you called any of the OpenFin API functions on
      * the window object.
      */
     private _currentState: EntityState;
-
+    
     /**
      * What the application "thinks" the state of this window is. This is the state of the window, excluding any changes made to the window by the service.
      */
     private _applicationState: EntityState;
-
+    
     /**
      * Lists all the modifications made to the window by the service. This is effectively a 'diff' between currentState and applicationState.
      */
     private _modifiedState: Partial<EntityState>;
-
+    
     /**
      * A subset of modifiedState - changes made to the window on a very short-term basis, which will soon be reverted.
      *
@@ -285,20 +286,21 @@ export class DesktopWindow implements DesktopEntity {
      * The temporary value can be found by looking up the keys of this object within 'currentState'.
      */
     private _temporaryState: Partial<EntityState>;
-
+    
     private _snapGroup: DesktopSnapGroup;
     private _tabGroup: DesktopTabGroup|null;
     private _prevGroup: DesktopSnapGroup|null;
     private _ready: boolean;
-
+    
     private _pendingActions: Promise<void>[];
     private _actionTags: WeakMap<Promise<void>, string>;
-
+    
     // Tracks event listeners registered on the fin window for easier clean-up.
     private _registeredListeners: Map<OpenFinWindowEvent, (event: fin.OpenFinWindowEventMap[OpenFinWindowEvent]) => void> = new Map();
-
+    
+    private _moveInProgress = false;
     private _userInitiatedBoundsChange = false;
-
+    
     constructor(model: DesktopModel, group: DesktopSnapGroup, window: fin.WindowOptions|Window, initialState?: EntityState) {
         const identity = DesktopWindow.getIdentity(window);
 
@@ -458,6 +460,10 @@ export class DesktopWindow implements DesktopEntity {
 
     public get applicationState(): EntityState {
         return this._applicationState;
+    }
+
+    public get moveInProgress(): boolean {
+        return this._moveInProgress;
     }
 
     /**
@@ -953,6 +959,9 @@ export class DesktopWindow implements DesktopEntity {
     }
 
     private handleBoundsChanged(event: fin.WindowBoundsEvent): void {
+        console.log('Resetting move in progress');
+        this._moveInProgress = false;
+
         const bounds: fin.WindowBounds = this.checkBounds(event);
         const halfSize: Point = {x: bounds.width / 2, y: bounds.height / 2};
         const center: Point = {x: bounds.left + halfSize.x, y: bounds.top + halfSize.y};
@@ -970,6 +979,11 @@ export class DesktopWindow implements DesktopEntity {
     }
 
     private handleBoundsChanging(event: fin.WindowBoundsEvent): void {
+        if(!this._moveInProgress) {
+            console.log('Setting move in progress');
+            this._moveInProgress = true;
+        }
+
         const bounds: fin.WindowBounds = this.checkBounds(event);
         const halfSize: Point = {x: bounds.width / 2, y: bounds.height / 2};
         const center: Point = {x: bounds.left + halfSize.x, y: bounds.top + halfSize.y};

--- a/test/demo/tabbing/tabGroupResizeConstraints.test.ts
+++ b/test/demo/tabbing/tabGroupResizeConstraints.test.ts
@@ -86,7 +86,7 @@ testParameterized(
         // Checks edge case where the target is large enough when untabbed but would not be once resized for tabbing
         {frame: true, windowCount: 2, windowConstraints: [{}, {minHeight: 200}], shouldTab: false},
     ],
-    createWindowTest(async (t, options: TabConstraintsOptions & {shouldTab: boolean}) => {
+    createWindowTest(async (t, options: TabConstraintsOptions&{shouldTab: boolean}) => {
         const windows = t.context.windows;
 
         await Promise.all(windows.map((win, index) => win.updateOptions(options.windowConstraints[index])));


### PR DESCRIPTION
Root cause of issue was found to be using stale position from currentState. This PR adds some mitigations including 
- slight delay in addTabInternal to allow bounds-changing events to be processed in the middle
- Added readonly public boolean to DesktopWindow which tracks if the window is moving (set in bounds-changing and unset in bounds-changed).
- Added logic to addTabInternal which will detect if the target window is moving and delay most of the adding operation until the movement has stopped (i.e. the onCommit signal is fired).