### PR TITLE
[SERVICE-354] Calling 'createTabGroup' from a tabbed window causes other windows in the tab group to be ejected to the wrong positions (Partial fix)

### DIFF
--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -580,6 +580,11 @@ export class DesktopTabGroup implements DesktopEntity {
             await Promise.all([this._window.sync(), tab.sync()]);
         }
 
+        // Remove from snap group before we position tab, so as to not indrectly move anything else
+        if (tab.snapGroup.isNonTrivial()) {
+            await tab.setSnapGroup(new DesktopSnapGroup());
+        }
+
         // Position window
         if (this._tabs.length === 1) {
             const tabState: EntityState = tab.currentState;
@@ -604,7 +609,7 @@ export class DesktopTabGroup implements DesktopEntity {
         }
 
         await tab.setTabGroup(this);
-        tab.setSnapGroup(this._window.snapGroup);
+        await tab.setSnapGroup(this._window.snapGroup);
 
         const event:
             TabAddedEvent = {tabstripIdentity: this.identity, identity: tab.identity, properties: tabProps, index: this._tabs.indexOf(tab), type: 'tab-added'};

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -580,7 +580,7 @@ export class DesktopTabGroup implements DesktopEntity {
             await Promise.all([this._window.sync(), tab.sync()]);
         }
 
-        // Remove from snap group before we position tab, so as to not indrectly move anything else
+        // Remove tab from snap group before we position it, so as to not indirectly move anything else
         if (tab.snapGroup.isNonTrivial()) {
             await tab.setSnapGroup(new DesktopSnapGroup());
         }


### PR DESCRIPTION
This fixes an issue encountered on a similar path to SERVICE-354.

To reproduce the issue, create a tab group of two tabs, and then snap to an untabbed window. Then, call createTabGroupWithTabs for one of the tabbed windows, and the untabbed window. This would result in a tabstrip that was offset from any windowed.

This also adds an await to setSnapGroup in the edited function, out of caution.