### PR TITLE
Add typedoc theme as a submodule & use it in typedoc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "typedoc-template"]
+	path = typedoc-template
+	url = https://github.com/openfin/typedoc-template

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npm run test:unit && npm run test:int",
     "check": "gts check && cd test && gts check",
     "clean": "gts clean && rimraf gen",
-    "docs:api": "typedoc --name \"OpenFin Layouts\" --out ./dist/docs/api --excludeNotExported --excludePrivate --excludeProtected --hideGenerator --readme DOCS.md --tsconfig src/client/tsconfig.json --readme none",
+    "docs:api": "typedoc --name \"OpenFin Layouts\" --theme ./typedoc-template --out ./dist/docs/api --excludeNotExported --excludePrivate --excludeProtected --hideGenerator --readme DOCS.md --tsconfig src/client/tsconfig.json --readme none",
     "docs:config": "bootprint json-schema ./res/provider/config/layouts-config.schema.json ./dist/docs/config",
     "docs": "npm run docs:api && npm run docs:config",
     "fix": "gts fix && cd test && gts fix",


### PR DESCRIPTION
Added the [redesigned typedoc template](https://github.com/openfin/typedoc-template) as a submodule and made typedoc use it when generating API docs.