### PR TITLE
[SERVICE-358] Possible to close a tabstrip independent of its tabs

### DIFF
--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -681,8 +681,6 @@ export class DesktopTabGroup implements DesktopEntity {
     private async onTabGroupTeardown(): Promise<void> {
         if (!this._closingOnTabRemoval) {
             return this.removeAllTabs(true);
-        } else {
-            return Promise.resolve();
         }
     }
 

--- a/test/demo/tabbing/tabGroupResizeConstraints.test.ts
+++ b/test/demo/tabbing/tabGroupResizeConstraints.test.ts
@@ -86,7 +86,7 @@ testParameterized(
         // Checks edge case where the target is large enough when untabbed but would not be once resized for tabbing
         {frame: true, windowCount: 2, windowConstraints: [{}, {minHeight: 200}], shouldTab: false},
     ],
-    createWindowTest(async (t, options: TabConstraintsOptions & {shouldTab: boolean}) => {
+    createWindowTest(async (t, options: TabConstraintsOptions&{shouldTab: boolean}) => {
         const windows = t.context.windows;
 
         await Promise.all(windows.map((win, index) => win.updateOptions(options.windowConstraints[index])));


### PR DESCRIPTION
DesktopTabGroup listens for teardown of tabstrip window and closes all tabs as needed

Passed Jenkins at d5060e5