### PR TITLE
[SERVICE-357] Prevented tabbing "through" de-registered windows.

### DIFF
--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -140,8 +140,22 @@ export class DesktopModel {
     }
 
     public getWindowAt(x: number, y: number, exclude?: WindowIdentity): DesktopWindow|null {
-        const identityAtPoint: WindowIdentity|null = this._zIndexer.getWindowAt(x, y, exclude);
-        return identityAtPoint && this.getWindow(identityAtPoint);
+        const point: Point = {x, y};
+        const excludeId: string|undefined = exclude && this.getId(exclude);
+        const windowsAtPoint: DesktopWindow[] = this._windows.filter((window: DesktopWindow) => {
+            const state: EntityState = window.currentState;
+            return window.isActive && RectUtils.isPointInRect(state.center, state.halfSize, point) && window.id !== excludeId;
+        });
+
+        const topMostWindow: DesktopWindow|null = this._zIndexer.getTopMost(windowsAtPoint);
+        const nonModelWindow: WindowIdentity|null = this._zIndexer.getWindowAt(x, y, exclude);
+
+        if (!topMostWindow || !nonModelWindow || topMostWindow.id === this.getId(nonModelWindow!)) {
+            return topMostWindow;
+        } else {
+            // Model found a window at this point, but it is obscured by a de-registered window
+            return null;
+        }
     }
 
     public getTabGroup(id: string): DesktopTabGroup|null {

--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -142,18 +142,19 @@ export class DesktopModel {
     public getWindowAt(x: number, y: number, exclude?: WindowIdentity): DesktopWindow|null {
         const point: Point = {x, y};
         const excludeId: string|undefined = exclude && this.getId(exclude);
-        const windowsAtPoint: DesktopWindow[] = this._windows.filter((window: DesktopWindow) => {
+        const modelWindowsAtPoint: DesktopWindow[] = this._windows.filter((window: DesktopWindow) => {
             const state: EntityState = window.currentState;
             return window.isActive && RectUtils.isPointInRect(state.center, state.halfSize, point) && window.id !== excludeId;
         });
 
-        const topMostWindow: DesktopWindow|null = this._zIndexer.getTopMost(windowsAtPoint);
-        const nonModelWindow: WindowIdentity|null = this._zIndexer.getWindowAt(x, y, exclude);
+        const topMostModelWindow: DesktopWindow|null = this._zIndexer.getTopMost(modelWindowsAtPoint);
+        const topMostWindow: WindowIdentity|null = this._zIndexer.getWindowAt(x, y, exclude);
 
-        if (!topMostWindow || !nonModelWindow || topMostWindow.id === this.getId(nonModelWindow!)) {
-            return topMostWindow;
+        if (!topMostModelWindow || !topMostWindow || topMostModelWindow.id === this.getId(topMostWindow!)) {
+            // There is no deregistered window over the top-most model window, safe to return
+            return topMostModelWindow;
         } else {
-            // Model found a window at this point, but it is obscured by a de-registered window
+            // Model found a window at this point, but it is obscured by a deregistered window
             return null;
         }
     }

--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -140,14 +140,8 @@ export class DesktopModel {
     }
 
     public getWindowAt(x: number, y: number, exclude?: WindowIdentity): DesktopWindow|null {
-        const point: Point = {x, y};
-        const excludeId: string|undefined = exclude && this.getId(exclude);
-        const windowsAtPoint: DesktopWindow[] = this._windows.filter((window: DesktopWindow) => {
-            const state: EntityState = window.currentState;
-            return window.isActive && RectUtils.isPointInRect(state.center, state.halfSize, point) && window.id !== excludeId;
-        });
-
-        return this._zIndexer.getTopMost(windowsAtPoint);
+        const identityAtPoint: WindowIdentity|null = this._zIndexer.getWindowAt(x, y, exclude);
+        return identityAtPoint && this.getWindow(identityAtPoint);
     }
 
     public getTabGroup(id: string): DesktopTabGroup|null {

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -1,6 +1,11 @@
 import {WindowEvent} from 'hadouken-js-adapter/out/types/src/api/events/base';
+import {WindowBoundsChange} from 'hadouken-js-adapter/out/types/src/api/events/window';
 import {ApplicationInfo} from 'hadouken-js-adapter/out/types/src/api/system/application';
+import {Rect} from 'hadouken-js-adapter/out/types/src/api/system/monitor';
+import Bounds from 'hadouken-js-adapter/out/types/src/api/window/bounds';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
+
+import {SERVICE_IDENTITY} from '../../client/internal';
 
 import {DesktopModel} from './DesktopModel';
 import {DesktopSnapGroup} from './DesktopSnapGroup';
@@ -10,6 +15,7 @@ export interface ZIndex {
     timestamp: number;
     id: string;
     identity: WindowIdentity;
+    bounds: Rect;
 }
 
 interface ObjectWithIdentity {
@@ -66,26 +72,6 @@ export class ZIndexer {
     }
 
     /**
-     * Updates the windows index in the stack and sorts array.
-     * @param identity ID of the window to update (uuid, name)
-     */
-    public update(identity: WindowIdentity) {
-        const id: string = this._model.getId(identity);
-        const entry: ZIndex|undefined = this._stack.find(i => i.id === id);
-        const time = Date.now();
-
-        if (entry) {
-            entry.timestamp = time;
-        } else {
-            this._stack.push({id, identity, timestamp: time});
-        }
-
-        this._stack.sort((a, b) => {
-            return b.timestamp - a.timestamp;
-        });
-    }
-
-    /**
      * Takes a list of window-like items and returns the top-most item from the list.
      *
      * NOTE: Implementation will not return any item within the input that does not exist within the ZIndexer util.
@@ -104,6 +90,26 @@ export class ZIndexer {
         }
 
         return null;
+    }
+
+    public getWindowAt(x: number, y: number, exclude?: WindowIdentity): WindowIdentity|null {
+        const entry: ZIndex|undefined = this._stack.find((item: ZIndex) => {
+            const identity = item.identity;
+
+            if (identity.uuid === SERVICE_IDENTITY.uuid && !identity.name.startsWith('TABSET-')) {
+                // Exclude service-owned windows
+                return false;
+            } else if (exclude && exclude.uuid === identity.uuid && exclude.name === identity.name) {
+                // Item is excluded
+                return false;
+            } else {
+                // Check if position is within window bounds
+                const bounds = item.bounds;
+                return x >= bounds.left && x <= bounds.right && y >= bounds.top && y <= bounds.bottom;
+            }
+        });
+
+        return entry ? entry.identity : null;
     }
 
     /**
@@ -128,6 +134,53 @@ export class ZIndexer {
     }
 
     /**
+     * Updates the windows index in the stack and sorts array.
+     * @param identity ID of the window to update (uuid, name)
+     * @param bounds Physical bounds of the window to update, if known
+     */
+    private update(identity: WindowIdentity, bounds?: Rect) {
+        const id: string = this._model.getId(identity);
+        const entry: ZIndex|undefined = this._stack.find(i => i.id === id);
+        const timestamp = Date.now();
+
+        if (entry) {
+            entry.timestamp = timestamp;
+            if (bounds) {
+                // Update bounds
+                Object.assign(entry.bounds, bounds);
+            }
+        } else {
+            const entry: ZIndex = {id, identity, timestamp, bounds: bounds!};
+            if (entry.bounds) {
+                this.addToStack(entry);
+            } else {
+                fin.Window.wrapSync(identity).getBounds().then(bounds => {
+                    entry.bounds = this.sanitizeBounds(bounds);
+                    this.addToStack(entry);
+                });
+            }
+        }
+
+        this._stack.sort((a, b) => {
+            return b.timestamp - a.timestamp;
+        });
+    }
+
+    private onWindowModified(identity: WindowIdentity, bounds?: Rect): void {
+        const modelWindow: DesktopWindow|null = this._model.getWindow(identity);
+        const modelGroup: DesktopSnapGroup|null = modelWindow && modelWindow.snapGroup;
+
+        if (modelGroup && modelGroup.length > 1) {
+            // Also bring-to-front any windows within the group
+            const id: string = this._model.getId(identity);
+            modelGroup.windows.forEach(window => this.update(window.identity, window.id === id ? bounds : undefined));
+        } else {
+            // Just bring modified window to front
+            this.update(identity, bounds);
+        }
+    }
+
+    /**
      * Creates window event listeners on a specified window.
      * @param win Window to add the event listeners to.
      */
@@ -135,31 +188,39 @@ export class ZIndexer {
         const identity = win.identity as WindowIdentity;  // A window identity will always have a name, so it is safe to cast
 
         const bringToFront = () => {
-            const modelWindow: DesktopWindow|null = this._model.getWindow(identity);
-            const modelGroup: DesktopSnapGroup|null = modelWindow && modelWindow.snapGroup;
-
-            if (modelGroup && modelGroup.length > 1) {
-                // Also bring-to-front any windows within the group
-                modelGroup.windows.forEach(window => this.update(window.identity));
-            } else {
-                // Just bring modified window to front
-                this.update(identity);
-            }
+            this.onWindowModified(identity);
+        };
+        const boundsChanged = (evt: WindowBoundsChange<'window', 'bounds-changed'>) => {
+            this.onWindowModified(identity, this.sanitizeBounds(evt));
         };
         const onClose = () => {
             win.removeListener('focused', bringToFront);
             win.removeListener('shown', bringToFront);
-            win.removeListener('bounds-changed', bringToFront);
+            win.removeListener('bounds-changed', boundsChanged);
             win.removeListener('closed', onClose);
+
+            const id = `${identity.uuid}/${identity.name}`;
+            const index = this._stack.findIndex(e => e.id === id);
+            if (index >= 0) {
+                this._stack.splice(index, 1);
+            }
         };
 
         // When a window is brought to the front of the stack, update the z-index of the window and any grouped windows
         win.addListener('focused', bringToFront);
         win.addListener('shown', bringToFront);
-        win.addListener('bounds-changed', bringToFront);
+        win.addListener('bounds-changed', boundsChanged);
 
         // Remove listeners when the window is destroyed
         win.addListener('closed', onClose);
+    }
+
+    private addToStack(entry: ZIndex): void {
+        this._stack.push(entry);
+    }
+
+    private sanitizeBounds(input: Bounds): Rect {
+        return {left: input.left, top: input.top, right: input.right || (input.left + input.width), bottom: input.bottom || (input.top + input.height)};
     }
 
     private getIds(items: Identifiable[]): string[] {

--- a/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
+++ b/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
@@ -18,6 +18,7 @@ const deregisteredManifestParentandChild =
     createAppsArray(1, 2, {manifest: true, url: 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=true'});
 const combinedManifestApps = registeredManifestApp.concat(deregisteredManifestParentandChild);
 
+// First grouping includes a deregistered window. It exists to move the deregistered window out the way of the registered window underneath.
 const windowGrouping = [[3, 1], [0, 2]];
 
 test.afterEach.always(async (t) => {

--- a/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
+++ b/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
@@ -1,6 +1,8 @@
 import test from 'ava';
+
 import {assertGrouped, assertTabbed} from '../../provider/utils/assertions';
 import {delay} from '../../provider/utils/delay';
+import {teardown} from '../../teardown';
 import {createAppsArray} from '../utils/AppInitializer';
 import {AppContext, CreateAppData, createAppTest} from '../utils/createAppTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
@@ -8,16 +10,20 @@ import {assertWindowRestored, closeAllPreviews, createCloseAndRestoreLayout} fro
 
 const registeredProgrammaticApp = createAppsArray(1, 0);
 const deregisteredProgrammaticParentandChild =
-    createAppsArray(1, 1, {manifest: false, url: 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=true'});
+    createAppsArray(1, 2, {manifest: false, url: 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=true'});
 const combinedProgrammaticApps = registeredProgrammaticApp.concat(deregisteredProgrammaticParentandChild);
 
 const registeredManifestApp = createAppsArray(1, 0, {manifest: true, url: 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=false'});
 const deregisteredManifestParentandChild =
-    createAppsArray(1, 1, {manifest: true, url: 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=true'});
+    createAppsArray(1, 2, {manifest: true, url: 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=true'});
 const combinedManifestApps = registeredManifestApp.concat(deregisteredManifestParentandChild);
 
-const windowGrouping = [[0, 2]];
+const windowGrouping = [[3, 1], [0, 2]];
 
+test.afterEach.always(async (t) => {
+    await closeAllPreviews(t);
+    await teardown(t);
+});
 
 testParameterized<CreateAppData, AppContext>(
     (testOptions: CreateAppData): string =>
@@ -25,7 +31,7 @@ testParameterized<CreateAppData, AppContext>(
     [{apps: combinedProgrammaticApps, tabWindowGrouping: windowGrouping}, {apps: combinedManifestApps, tabWindowGrouping: windowGrouping}],
     createAppTest(async (t, applicationData: CreateAppData) => {
         if (applicationData.tabWindowGrouping) {
-            const group = applicationData.tabWindowGrouping[0];
+            const group = applicationData.tabWindowGrouping[1];
             const win1 = t.context.windows[group[0]];
             const win2 = t.context.windows[group[1]];
 
@@ -50,6 +56,3 @@ testParameterized<CreateAppData, AppContext>(
             t.fail('Improper test options passed in. Test options must include tabWindowGroupings in order to test');
         }
     }));
-
-
-test.afterEach.always(closeAllPreviews);

--- a/test/provider/tabOnDragOver.test.ts
+++ b/test/provider/tabOnDragOver.test.ts
@@ -531,7 +531,7 @@ test('Cannot tab to an obscured window', async t => {
     await Promise.all(wins.map(win => assertNotTabbed(win, t)));
 });
 
-test('Cannot tab to an obscures window that is not registered to the service', async t => {
+test('Cannot tab to a window that is obscured by a window not registered to the service', async t => {
     const win3 = await createChildWindow({
         autoShow: true,
         saveWindowState: false,

--- a/test/provider/tabOnDragOver.test.ts
+++ b/test/provider/tabOnDragOver.test.ts
@@ -8,7 +8,7 @@ import {assertAllMaximized, assertAllNormalState, assertNotTabbed, assertTabbed}
 import {getConnection} from './utils/connect';
 import {createChildWindow} from './utils/createChildWindow';
 import {delay} from './utils/delay';
-import {dragWindowToOtherWindow} from './utils/dragWindowTo';
+import {dragWindowTo, dragWindowToOtherWindow} from './utils/dragWindowTo';
 import {getBounds} from './utils/getBounds';
 import {tabWindowsTogether} from './utils/tabWindowsTogether';
 
@@ -267,8 +267,8 @@ test('Tearout tab dragged into tab group, invalid region - should not add tab to
     const win3 = await createChildWindow({
         autoShow: true,
         saveWindowState: false,
-        defaultTop: 500,
-        defaultLeft: 500,
+        defaultTop: 80,
+        defaultLeft: 200,
         defaultHeight: 200,
         defaultWidth: 200,
         url: 'http://localhost:1337/demo/tabbing/default.html',
@@ -510,4 +510,42 @@ test('Drag window into tabgroup then tearout - window should be maximizable if-a
     wins[1].maximize();
 
     assertAllMaximized(t, wins);
+});
+
+test('Cannot tab to an obscured window', async t => {
+    const win3 = await createChildWindow({
+        autoShow: true,
+        saveWindowState: false,
+        defaultTop: 20,
+        defaultLeft: 200,
+        defaultHeight: 200,
+        defaultWidth: 200,
+        url: 'http://localhost:1337/demo/tabbing/default.html',
+        frame: true
+    });
+    wins.push(win3);
+
+    await delay(500);
+    await dragWindowTo(wins[1], 250, 120);
+    await delay(500);
+    await Promise.all(wins.map(win => assertNotTabbed(win, t)));
+});
+
+test('Cannot tab to an obscures window that is not registered to the service', async t => {
+    const win3 = await createChildWindow({
+        autoShow: true,
+        saveWindowState: false,
+        defaultTop: 20,
+        defaultLeft: 200,
+        defaultHeight: 200,
+        defaultWidth: 200,
+        url: 'http://localhost:1337/test/popup-deregistered.html',
+        frame: true
+    });
+    wins.push(win3);
+
+    await delay(500);
+    await dragWindowTo(wins[1], 250, 120);
+    await delay(500);
+    await Promise.all(wins.map(win => assertNotTabbed(win, t)));
 });


### PR DESCRIPTION
 The model's `getWindowAt` method will no longer return windows that are covered by a de-registered window

This was achieved by using the `ZIndexer` to perform the actual check (since it also tracks non-registered windows), which required having the `ZIndexer` also log the bounds of a window. No extra events were required to do this, instead the util stores the bounds data that comes from the `bounds-changed` events.

Only `bounds-changed` events are used for the position tracking, meaning that data for any window currently being moved will be stale. In actual usage, any active window is always excluded from the `getWindowAt` check.