### PR TITLE
[SERVICE-373] Tab properties now initialised with window title

### DIFF
--- a/src/fin.d.ts
+++ b/src/fin.d.ts
@@ -1110,6 +1110,7 @@ declare namespace fin {
          * 'frame-enabled' is generated when a disabled frame has becomes enabled.
          */
         enableFrame(callback?: () => void, errorCallback?: (reason: string) => void): void;
+        executeJavaScript(code: string, callback?: (result: any) => void, errorCallback?: (reason: string) => void): void;
         /**
          * Flashes the window's frame and taskbar icon until the window is activated.
          */

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -567,7 +567,6 @@ export class DesktopTabGroup implements DesktopEntity {
         }
 
         // Add tab
-        const tabProps = tabService.getTabProperties(tab);
         this._tabs.splice(index, 0, tab);
         tab.onTeardown.add(this.onWindowTeardown, this);
         tab.onTransform.add(this.onTabTransform, this);
@@ -623,6 +622,7 @@ export class DesktopTabGroup implements DesktopEntity {
         await tab.setTabGroup(this);
         await tab.setSnapGroup(this._window.snapGroup);
 
+        const tabProps = tabService.getTabProperties(tab);
         const event:
             TabAddedEvent = {tabstripIdentity: this.identity, identity: tab.identity, properties: tabProps, index: this._tabs.indexOf(tab), type: 'tab-added'};
         this.sendTabEvent(tab, event);

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -149,6 +149,15 @@ export class DesktopWindow implements DesktopEntity {
                     }
                 };
 
+                // Get window title
+                const {title, url} = info;
+                let windowTitle = title;
+                if (title && (title === url || title === url.substr(url.indexOf('://') + 3))) {
+                    // If there is no <title> tag on document, getInfo will return the URL (minus protocol) as the title.
+                    // In these cases, the actual title will be the window name - not it's URL
+                    windowTitle = window.identity.name || '';
+                }
+
                 return {
                     center,
                     halfSize,
@@ -157,7 +166,7 @@ export class DesktopWindow implements DesktopEntity {
                     hidden: !results[2],
                     state: options.state!,
                     icon: options.icon || `https://www.google.com/s2/favicons?domain=${options.url}`,
-                    title: info.title!,
+                    title: windowTitle,
                     showTaskbarIcon: options.showTaskbarIcon!,
                     opacity: options.opacity!,
                     alwaysOnTop: options.alwaysOnTop!,

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1,19 +1,17 @@
 import deepEqual from 'fast-deep-equal';
 import {Identity, Window} from 'hadouken-js-adapter';
+import {WindowInfo} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
 import {WindowScope} from '../../../gen/provider/config/layouts-config';
 import {SERVICE_IDENTITY} from '../../client/internal';
-
 import {WindowState} from '../../client/workspaces';
-import {APIHandler} from '../APIHandler';
 import {EVENT_CHANNEL_TOPIC, EventMap} from '../APIMessages';
 import {apiHandler} from '../main';
 import {Aggregators, Signal1, Signal2} from '../Signal';
-import {promiseMap} from '../snapanddock/utils/async';
 import {Debounced} from '../snapanddock/utils/Debounced';
 import {isWin10} from '../snapanddock/utils/platform';
 import {Point} from '../snapanddock/utils/PointUtils';
-import {Rectangle, RectUtils} from '../snapanddock/utils/RectUtils';
+import {Rectangle} from '../snapanddock/utils/RectUtils';
 
 import {DesktopEntity} from './DesktopEntity';
 import {DesktopModel} from './DesktopModel';
@@ -117,10 +115,11 @@ export class DesktopWindow implements DesktopEntity {
     public static activeTransactions: Transaction[] = [];
 
     public static async getWindowState(window: Window): Promise<EntityState> {
-        return Promise.all([window.getOptions(), window.isShowing(), window.getBounds()])
-            .then((results: [fin.WindowOptions, boolean, fin.WindowBounds]): EntityState => {
+        return Promise.all([window.getOptions(), window.getInfo(), window.isShowing(), window.getBounds()])
+            .then((results: [fin.WindowOptions, WindowInfo, boolean, fin.WindowBounds]): EntityState => {
                 const options: fin.WindowOptions = results[0];
-                const bounds: fin.WindowBounds = results[2];
+                const info: WindowInfo = results[1];
+                const bounds: fin.WindowBounds = results[3];
                 const halfSize: Point = {x: bounds.width / 2, y: bounds.height / 2};
                 const center: Point = {x: bounds.left + halfSize.x, y: bounds.top + halfSize.y};
 
@@ -155,10 +154,10 @@ export class DesktopWindow implements DesktopEntity {
                     halfSize,
                     resizeConstraints,
                     frame: options.frame!,
-                    hidden: !results[1],
+                    hidden: !results[2],
                     state: options.state!,
                     icon: options.icon || `https://www.google.com/s2/favicons?domain=${options.url}`,
-                    title: options.name!,
+                    title: info.title!,
                     showTaskbarIcon: options.showTaskbarIcon!,
                     opacity: options.opacity!,
                     alwaysOnTop: options.alwaysOnTop!,

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -1,3 +1,4 @@
+import deepEqual from 'fast-deep-equal';
 import {Scope, Tabstrip} from '../../../gen/provider/config/layouts-config';
 import {TabProperties, TabPropertiesUpdatedEvent} from '../../client/tabbing';
 import {TabGroup, TabGroupDimensions} from '../../client/workspaces';
@@ -252,7 +253,7 @@ export class TabService {
         const tabProps: TabProperties = this.getTabProperties(tab);
         const newProps: TabProperties = {...tabProps, ...properties};
 
-        if (newProps.icon !== tabProps.icon || newProps.title !== tabProps.title) {
+        if (!deepEqual(newProps, tabProps)) {
             // Save properties
             Object.assign(tabProps, properties);
             localStorage.setItem(tab.id, JSON.stringify(tabProps));

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -1,6 +1,7 @@
 import {Scope, Tabstrip} from '../../../gen/provider/config/layouts-config';
 import {TabProperties, TabPropertiesUpdatedEvent} from '../../client/tabbing';
 import {TabGroup, TabGroupDimensions} from '../../client/workspaces';
+import {EventMap} from '../APIMessages';
 import {ConfigStore} from '../main';
 import {DesktopEntity} from '../model/DesktopEntity';
 import {DesktopModel} from '../model/DesktopModel';
@@ -227,21 +228,38 @@ export class TabService {
         }
 
         const {icon, title} = tab.currentState;
+
+        // Title isn't always available when window is created
+        // If title is empty, re-request from window then send update to tabstrip
+        if (title === '') {
+            tab.refresh().then(() => {
+                const {icon: newIcon, title: newTitle} = tab.currentState;
+
+                if (newTitle !== '') {
+                    const properties: TabProperties = {icon: newIcon, title: newTitle};
+                    const event: TabPropertiesUpdatedEvent = {identity: tab.identity, properties, type: 'tab-properties-updated'};
+                    this.sendTabEvent(tab, event);
+                }
+            }, console.warn);
+        }
+
         // Special handling for workspace placeholder windows
         const modifiedTitle = tab.identity.uuid === fin.Window.me.uuid && title.startsWith('Placeholder-') ? 'Loading...' : title;
-        return {icon, title: modifiedTitle};
+        return {icon, title: modifiedTitle || tab.identity.name};
     }
 
     public updateTabProperties(tab: DesktopWindow, properties: Partial<TabProperties>): void {
         const tabProps: TabProperties = this.getTabProperties(tab);
-        Object.assign(tabProps, properties);
-        localStorage.setItem(tab.id, JSON.stringify(tabProps));
+        const newProps: TabProperties = {...tabProps, ...properties};
 
-        const event: TabPropertiesUpdatedEvent = {identity: tab.identity, properties: tabProps, type: 'tab-properties-updated'};
-        tab.sendEvent(event);
+        if (newProps.icon !== tabProps.icon || newProps.title !== tabProps.title) {
+            // Save properties
+            Object.assign(tabProps, properties);
+            localStorage.setItem(tab.id, JSON.stringify(tabProps));
 
-        if (tab.tabGroup) {
-            tab.tabGroup.window.sendEvent(event);
+            // Send events
+            const event: TabPropertiesUpdatedEvent = {identity: tab.identity, properties: tabProps, type: 'tab-properties-updated'};
+            this.sendTabEvent(tab, event);
         }
     }
 
@@ -319,6 +337,19 @@ export class TabService {
 
     private getScope(x: WindowIdentity|DesktopEntity): Scope {
         return (x as DesktopEntity).scope || {level: 'window', ...x as WindowIdentity};
+    }
+
+    /**
+     * Sends an event to both a tab window, and the tabstrip of the tab's tabgroup - if the window is tabbed.
+     *
+     * @param tab Modified window
+     * @param event Event to send
+     */
+    private sendTabEvent(tab: DesktopWindow, event: EventMap): void {
+        tab.sendEvent(event);
+        if (tab.tabGroup) {
+            tab.tabGroup.window.sendEvent(event);
+        }
     }
 
 

--- a/test/provider/tabOnDragOver.test.ts
+++ b/test/provider/tabOnDragOver.test.ts
@@ -1,27 +1,47 @@
 import {test} from 'ava';
-import {Fin, Window} from 'hadouken-js-adapter';
+import {Identity, Window} from 'hadouken-js-adapter';
 import * as robot from 'robotjs';
 
+import {WindowIdentity} from '../../src/provider/model/DesktopWindow';
+import {executeJavascriptOnService} from '../demo/utils/serviceUtils';
 import {teardown} from '../teardown';
 
 import {assertAllMaximized, assertAllNormalState, assertNotTabbed, assertTabbed} from './utils/assertions';
-import {getConnection} from './utils/connect';
 import {createChildWindow} from './utils/createChildWindow';
 import {delay} from './utils/delay';
 import {dragWindowToOtherWindow} from './utils/dragWindowTo';
 import {getBounds} from './utils/getBounds';
 import {tabWindowsTogether} from './utils/tabWindowsTogether';
 
-let fin: Fin;
+/**
+ * Fetches the tab title of a window. Will fetch the text from the DOM element within the tabstrip window.
+ *
+ * Assumes that `identity` is a tabbed window.
+ *
+ * @param identity Tabbed window
+ */
+async function getTabTitle(identity: Identity) {
+    return executeJavascriptOnService(function(this: ProviderWindow, tabIdentity: WindowIdentity) {
+        return new Promise((resolve, reject) => {
+            const tab = this.model.getWindow(tabIdentity)!;
+            const tabGroup = tab.tabGroup!;
+            const tabIndex = tabGroup.tabs.findIndex(t => t.id === tab.id);
+            const tabstripIdentity = tabGroup.identity;
+
+            const tabstrip = fin.desktop.Window.wrap(tabstripIdentity.uuid, tabstripIdentity.name!);
+            tabstrip.executeJavaScript(
+                `document.getElementsByClassName("tab")[${tabIndex}].getElementsByClassName("tab-content")[0].innerText`, resolve, reject);
+        });
+    }, identity as WindowIdentity);
+}
+
 
 let wins: Window[] = [];
 
-test.before(async () => {
-    fin = await getConnection();
-});
 test.beforeEach(async () => {
     // Spawn two windows - wins[0] unframed, wins[1] framed.  Any additional windows needed should be created in the test.
     wins[0] = await createChildWindow({
+        name: 'tab-window-1',
         autoShow: true,
         saveWindowState: false,
         defaultTop: 100,
@@ -32,6 +52,7 @@ test.beforeEach(async () => {
         frame: false
     });
     wins[1] = await createChildWindow({
+        name: 'tab-window-2',
         autoShow: true,
         saveWindowState: false,
         defaultTop: 300,
@@ -64,6 +85,19 @@ test('Drag window over window - should create tabgroup', async t => {
 
     // Test that the windows are tabbed
     await assertTabbed(wins[0], wins[1], t);
+});
+
+test('Drag window over window - window title is displayed in tabstrip', async t => {
+    await tabWindowsTogether(wins[0], wins[1]);
+    await assertTabbed(wins[0], wins[1], t);
+
+    const tabTitles = await Promise.all(wins.map(w => getTabTitle(w.identity)));
+
+    // First window programmatically sets document.title
+    t.is(tabTitles[0], 'Window 1');
+
+    // Second window doesn't set a title, tab title should default to window name
+    t.is(tabTitles[1], 'tab-window-2');
 });
 
 test('Drag window over window, invalid region - should not create tabgroup', async t => {


### PR DESCRIPTION
Using `getInfo()` to fetch document title from each window. This isn't always immediately available, so service will re-request the window title when tabbing, if the title isn't already known.

It seems the API returns the URL of the page in cases where there is no `<title>` tag in the DOM. The service will detect these cases, and use the window name instead (as per earlier behaviour).