### PR TITLE
[N/A] Sequentially launch applications during restoration to avoid createFromManifest timeout

### DIFF
--- a/res/provider/app.json
+++ b/res/provider/app.json
@@ -14,7 +14,7 @@
         "enableAppLogging": true
     },
     "runtime": {
-        "arguments": "--enable-aggressive-domstorage-flushing --message-timeout=60000",
+        "arguments": "--enable-aggressive-domstorage-flushing",
         "version": "9.61.38.40"
     }
 }

--- a/res/provider/app.json
+++ b/res/provider/app.json
@@ -14,7 +14,7 @@
         "enableAppLogging": true
     },
     "runtime": {
-        "arguments": "--enable-aggressive-domstorage-flushing",
+        "arguments": "--enable-aggressive-domstorage-flushing --message-timeout=60000",
         "version": "9.61.38.40"
     }
 }

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -280,7 +280,7 @@ const restoreApp = async(app: WorkspaceApp, delayIdx: number, startupApps: Promi
                 console.log('App has manifestUrl:', app);
                 // Delay the `createFromManifest` call so that we don't lock up/time out.
                 // Should be resolved by RUN-5040 and RVM-814
-                await delay(1000 * delayIdx);
+                await delay(1500 * delayIdx);
                 ofAppNotRunning = await fin.Application.createFromManifest(manifestUrl);
             } else {
                 // If application created programmatically

--- a/test/demo/utils/AppInitializer.ts
+++ b/test/demo/utils/AppInitializer.ts
@@ -85,8 +85,8 @@ export function createAppsArray(numAppsToCreate: number, numberOfChildren: numbe
         }
 
         // Save the app information
-        const defaultTop = (appsCreated * 290) + 50;
-        const appOptions = {...OPTIONS_BASE, ...testOptions, uuid: id, name: id, defaultTop, defaultLeft: 100};
+        const defaultTop = testOptions && testOptions.defaultTop ? testOptions.defaultTop : (appsCreated * 290) + 50;
+        const appOptions = {...OPTIONS_BASE, ...testOptions, uuid: id, defaultTop, name: id, defaultLeft: 100};
 
         let appInitializerOptions: AppInitializerParams = {...APP_INITIALIZER_BASE_PROGRAMMATIC, appOptions, childWindows};
 

--- a/test/demo/utils/workspacesUtils.ts
+++ b/test/demo/utils/workspacesUtils.ts
@@ -98,6 +98,7 @@ export interface TestCreationOptions {
     url?: string;
     manifest?: boolean;
     autoShow?: boolean;
+    defaultTop?: number;
 }
 
 export function createBasicSaveAndRestoreTest(

--- a/test/demo/workspaces/createManifestSaveAndRestoreTimeout.test.ts
+++ b/test/demo/workspaces/createManifestSaveAndRestoreTimeout.test.ts
@@ -1,0 +1,25 @@
+import test from 'ava';
+import {teardown} from '../../teardown';
+import {AppContext, CreateAppData, createAppTest} from '../utils/createAppTest';
+import {testParameterized} from '../utils/parameterizedTestUtils';
+import {assertWindowRestored, closeAllPreviews, createCloseAndRestoreLayout, createBasicSaveAndRestoreTest} from '../utils/workspacesUtils';
+
+const manifestApplications = createBasicSaveAndRestoreTest(
+            10, 0, {manifest: true, url: 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=false'});
+
+test.afterEach.always(async (t) => {
+    await closeAllPreviews(t);
+    await teardown(t);
+});
+
+testParameterized<CreateAppData, AppContext>(
+    (testOptions: CreateAppData): string =>
+        `CreateFromManifest SaveAndRestore - Restoring 10 applications created from a manifest`,
+    [manifestApplications],
+    createAppTest(async (t, applicationData: CreateAppData) => {
+        await createCloseAndRestoreLayout(t);
+
+        for (const applicationInfo of t.context.testAppData) {
+            await assertWindowRestored(t, applicationInfo.uuid, applicationInfo.uuid);
+        }
+    }));

--- a/test/demo/workspaces/createManifestSaveAndRestoreTimeout.test.ts
+++ b/test/demo/workspaces/createManifestSaveAndRestoreTimeout.test.ts
@@ -12,6 +12,7 @@ test.afterEach.always(async (t) => {
     await teardown(t);
 });
 
+// This test should be solved by RUN-5040 and RVM-814. Current workaround is sequential launching in restore
 testParameterized<CreateAppData, AppContext>(
     (testOptions: CreateAppData): string =>
         `CreateFromManifest SaveAndRestore - Restoring 10 applications created from a manifest`,

--- a/test/demo/workspaces/createManifestSaveAndRestoreTimeout.test.ts
+++ b/test/demo/workspaces/createManifestSaveAndRestoreTimeout.test.ts
@@ -2,10 +2,20 @@ import test from 'ava';
 import {teardown} from '../../teardown';
 import {AppContext, CreateAppData, createAppTest} from '../utils/createAppTest';
 import {testParameterized} from '../utils/parameterizedTestUtils';
-import {assertWindowRestored, closeAllPreviews, createCloseAndRestoreLayout, createBasicSaveAndRestoreTest} from '../utils/workspacesUtils';
+import {assertWindowRestored, closeAllPreviews, createCloseAndRestoreLayout} from '../utils/workspacesUtils';
+import {createAppsArray} from '../utils/AppInitializer';
 
-const manifestApplications = createBasicSaveAndRestoreTest(
-            10, 0, {manifest: true, url: 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=false'});
+const tenManifestApplications = createAppsArray(
+            10, 0, {manifest: true, url: 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=false', defaultTop: 100});
+
+const thirtyManifestApplications = createAppsArray(
+            20, 0, {manifest: true, url: 'http://localhost:1337/test/saveRestoreTestingApp.html?deregistered=false', defaultTop: 100});
+
+const tenProgrammaticApplications = createAppsArray(
+            10, 0, {defaultTop: 100});
+
+const thirtyProgrammaticApplications = createAppsArray(
+            20, 0, {defaultTop: 100});
 
 test.afterEach.always(async (t) => {
     await closeAllPreviews(t);
@@ -15,8 +25,8 @@ test.afterEach.always(async (t) => {
 // This test should be solved by RUN-5040 and RVM-814. Current workaround is sequential launching in restore
 testParameterized<CreateAppData, AppContext>(
     (testOptions: CreateAppData): string =>
-        `CreateFromManifest SaveAndRestore - Restoring 10 applications created from a manifest`,
-    [manifestApplications],
+        `SaveAndRestore Mass App Creation - Restoring ${testOptions.apps.length} applications created ${testOptions.apps[0].createType === 'manifest' ? 'from a manifest' : 'programmatically'}`,
+    [{apps: tenManifestApplications}, {apps: thirtyManifestApplications}, {apps: tenProgrammaticApplications}, {apps: thirtyProgrammaticApplications}],
     createAppTest(async (t, applicationData: CreateAppData) => {
         await createCloseAndRestoreLayout(t);
 


### PR DESCRIPTION
*DO NOT MERGE*


When restoring a large workspace that uses many applications created from manifest, the core/RVM don't currently account for that level of load. If application launches hang a bit long, they timeout silently, which breaks restoration. 

By restoring the applications sequentially vs. all at once, we avoid this timeout. Temporary solution until RUN-5040 and RVM-814 are resolved.