### PR TITLE
[N/A] Moved API/config doc location when deploying to the CDN

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,8 +51,8 @@ pipeline {
                     MANIFEST_NAME = "app.staging.json"
 
                     S3_LOC = env.DSERVICE_S3_ROOT + "layouts/" + BUILD_VERSION
-                    DOCS_CHANNEL_LOC = env.DSERVICE_S3_ROOT + "layouts/docs/" + CHANNEL
-                    DOCS_VERSIONED_LOC = env.DSERVICE_S3_ROOT + "layouts/docs/" + BUILD_VERSION
+                    DOCS_CHANNEL_LOC = env.DSERVICE_S3_ROOT_DOCS + "layouts/" + CHANNEL
+                    DOCS_VERSIONED_LOC = env.DSERVICE_S3_ROOT_DOCS + "layouts/" + BUILD_VERSION
                     MANIFEST_LOC = env.DSERVICE_S3_ROOT + "layouts/" + MANIFEST_NAME
                 }
                 sh "npm i --ignore-scripts"
@@ -92,8 +92,8 @@ pipeline {
                     MANIFEST_NAME = "app.json"
 
                     S3_LOC = env.DSERVICE_S3_ROOT + "layouts/" + BUILD_VERSION
-                    DOCS_CHANNEL_LOC = env.DSERVICE_S3_ROOT + "layouts/docs/" + CHANNEL
-                    DOCS_VERSIONED_LOC = env.DSERVICE_S3_ROOT + "layouts/docs/" + BUILD_VERSION
+                    DOCS_CHANNEL_LOC = env.DSERVICE_S3_ROOT_DOCS + "layouts/" + CHANNEL
+                    DOCS_VERSIONED_LOC = env.DSERVICE_S3_ROOT_DOCS + "layouts/" + BUILD_VERSION
                     MANIFEST_LOC = env.DSERVICE_S3_ROOT + "layouts/" + MANIFEST_NAME
                 }
                 sh "npm i --ignore-scripts"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,10 +65,10 @@ pipeline {
                 sh "aws s3 cp ./dist/provider ${S3_LOC}/ --recursive"
                 sh "aws s3 cp ./dist/client/openfin-layouts.js ${S3_LOC}/"
 
-                sh "aws s3 rm ${DOCS_CHANNEL_LOC} --recursive"
                 sh "aws s3 cp ./dist/docs ${DOCS_CHANNEL_LOC} --recursive"
                 sh "aws s3 cp ./dist/docs ${DOCS_VERSIONED_LOC} --recursive"
                 sh "aws s3 cp ./dist/provider/app.json ${MANIFEST_LOC}"
+
                 withCredentials([string(credentialsId: "NPM_TOKEN_WRITE", variable: 'NPM_TOKEN')]) {
                     sh "echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > $WORKSPACE/.npmrc"
                 }
@@ -79,7 +79,7 @@ pipeline {
             }
         }
 
-        stage ('Build & Deploy (Production)') {
+        stage('Build & Deploy (Production)') {
             agent { label 'linux-slave' }
             when { branch "master" }
             steps {
@@ -106,10 +106,10 @@ pipeline {
                 sh "aws s3 cp ./dist/provider ${S3_LOC}/ --recursive"
                 sh "aws s3 cp ./dist/client/openfin-layouts.js ${S3_LOC}/"
 
-                sh "aws s3 rm ${DOCS_CHANNEL_LOC} --recursive"
                 sh "aws s3 cp ./dist/docs ${DOCS_CHANNEL_LOC} --recursive"
                 sh "aws s3 cp ./dist/docs ${DOCS_VERSIONED_LOC} --recursive"
                 sh "aws s3 cp ./dist/provider/app.json ${MANIFEST_LOC}"
+
                 withCredentials([string(credentialsId: "NPM_TOKEN_WRITE", variable: 'NPM_TOKEN')]) {
                     sh "echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > $WORKSPACE/.npmrc"
                 }


### PR DESCRIPTION
Have changed the location the generated docs are deployed to as part of the build process.

Now deployed to `/docs/services/layouts/<version>`, as per other projects. Docs folder is still sub-divided into `api` and `config`.