### PR TITLE
[SERVICE-375] Undock docked windows when maximizing

### DIFF
--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -933,6 +933,9 @@ export class DesktopWindow implements DesktopEntity {
         this.registerListener('hidden', () => this.updateState({hidden: true}, ActionOrigin.APPLICATION));
         this.registerListener('maximized', () => {
             this.updateState({state: 'maximized'}, ActionOrigin.APPLICATION);
+            // Validate the group on maximize. This will ungroup the maximized window and
+            // split the group as appropriate. Mitigation for SERVICE-375.
+            this.snapGroup.validate();
         });
         this.registerListener('minimized', () => {
             this.updateState({state: 'minimized'}, ActionOrigin.APPLICATION);

--- a/test/demo/snapanddock/validateGroup.test.ts
+++ b/test/demo/snapanddock/validateGroup.test.ts
@@ -13,7 +13,7 @@ interface ValidateGroupOptions extends CreateWindowData {
     arrangement: string;
     undockIndex: number;  // Zero-indexed
     remainingGroups: number[][];
-    undockBy: 'service'|'runtime';
+    undockBy: 'service'|'runtime'|'maximize';
 }
 
 const undockFunctions = {
@@ -22,6 +22,9 @@ const undockFunctions = {
     },
     'runtime': async (win: _Window) => {
         return win.leaveGroup();
+    },
+    'maximize': async (win: _Window) => {
+        return win.maximize();
     }
 };
 
@@ -99,6 +102,8 @@ testParameterized<ValidateGroupOptions, WindowContext>(
         {frame: false, undockBy: 'runtime', windowCount: 5, arrangement: 'hourglass', undockIndex: 2, remainingGroups: [[0, 1], [2], [3, 4]]},
         {frame: false, undockBy: 'runtime', windowCount: 9, arrangement: 'dumbell', undockIndex: 4, remainingGroups: [[0, 1, 2, 3], [4], [5, 6, 7, 8]]},
         {frame: false, undockBy: 'runtime', windowCount: 9, arrangement: 'x', undockIndex: 2, remainingGroups: [[0, 1], [3, 4], [5, 6], [7, 8], [2]]},
+        {frame: true, undockBy: 'maximize', windowCount: 3, arrangement: 'line', undockIndex: 1, remainingGroups: [[0], [1], [2]]},
+        {frame: true, undockBy: 'maximize', windowCount: 3, arrangement: 'line', undockIndex: 2, remainingGroups: [[0, 1], [2]]},
     ],
     createWindowTest(async (t, testOptions: ValidateGroupOptions) => {
         const windows = t.context.windows;


### PR DESCRIPTION
This was accomplished by adding a call to `snapGroup.validate()` in the maximize event callback on `DesktopWindow`s. Since we now track the visually apparent bounds of maximised windows, the service will recognise that the group is no longer contiguous and take the appropriate actions (e.g. undocking windows or splitting the group).

I expect that this is still some very small time windows where moving the maximized window could cause issues. This is pretty much unavoidable as we are only able to react to the event, not intercept it mid-flight. I have not been able to reproduce this myself, so I expect the window is small enough to not be a major problem.