### PR TITLE
[SERVICE-357-fix] Update ZIndexer to track 'active' state of windows 

### DIFF
--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -142,13 +142,25 @@ export class DesktopModel {
     public getWindowAt(x: number, y: number, exclude?: WindowIdentity): DesktopWindow|null {
         const point: Point = {x, y};
         const excludeId: string|undefined = exclude && this.getId(exclude);
+
         const modelWindowsAtPoint: DesktopWindow[] = this._windows.filter((window: DesktopWindow) => {
             const state: EntityState = window.currentState;
-            return window.isActive && RectUtils.isPointInRect(state.center, state.halfSize, point) && window.id !== excludeId;
+            return RectUtils.isPointInRect(state.center, state.halfSize, point);
         });
 
-        const topMostModelWindow: DesktopWindow|null = this._zIndexer.getTopMost(modelWindowsAtPoint);
-        const topMostWindow: WindowIdentity|null = this._zIndexer.getWindowAt(x, y, exclude);
+        const modelWindowsAtPointToInclude: DesktopWindow[] = [];
+        const modelWindowsAtPointToExclude: WindowIdentity[] = [];
+
+        for (const modelWindow of modelWindowsAtPoint) {
+            if (modelWindow.isActive && modelWindow.id !== excludeId) {
+                modelWindowsAtPointToInclude.push(modelWindow);
+            } else {
+                modelWindowsAtPointToExclude.push(modelWindow.identity);
+            }
+        }
+
+        const topMostModelWindow: DesktopWindow|null = this._zIndexer.getTopMost(modelWindowsAtPointToInclude);
+        const topMostWindow: WindowIdentity|null = this._zIndexer.getWindowAt(x, y, modelWindowsAtPointToExclude);
 
         if (!topMostModelWindow || !topMostWindow || topMostModelWindow.id === this.getId(topMostWindow!)) {
             // There is no deregistered window over the top-most model window, safe to return

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -64,14 +64,6 @@ export class ZIndexer {
     }
 
     /**
-     * Returns the array of indexes.
-     * @returns {ZIndex[]} ZIndex[]
-     */
-    public get indexes(): ReadonlyArray<ZIndex> {
-        return this._stack;
-    }
-
-    /**
      * Takes a list of window-like items and returns the top-most item from the list.
      *
      * NOTE: Implementation will not return any item within the input that does not exist within the ZIndexer util.
@@ -110,27 +102,6 @@ export class ZIndexer {
         });
 
         return entry ? entry.identity : null;
-    }
-
-    /**
-     * Takes a list of window-like items, and sorts them by the z-index of their respective windows.
-     *
-     * NOTE: Implementation will filter-out any windows within the input that do not exist within the ZIndexer util.
-     *
-     * @param items
-     */
-    public sort<T extends Identifiable>(items: T[]): T[] {
-        const ids: string[] = this.getIds(items);
-        const result: T[] = [];
-
-        for (const item of this._stack) {
-            const index: number = ids.indexOf(item.id);
-            if (index >= 0) {
-                result.push(items[index]);
-            }
-        }
-
-        return result;
     }
 
     /**

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -108,7 +108,7 @@ export class ZIndexer {
     /**
      * Updates the windows index in the stack and sorts array.
      * @param identity ID of the window to update (uuid, name)
-     * @param bounds Physical bounds of the window to update, if known. Will perform an async querey if needed and not specified
+     * @param bounds Physical bounds of the window to update, if known. Will perform an async query if needed and not specified
      * @param active The active state of the window to update, if know. Will guess as true if needed and not specified
      * @param timestamp The new timestamp for the stack entry. Will use the current time if not specified
      */

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -75,10 +75,12 @@ export class ZIndexer {
     public getTopMost<T extends Identifiable>(items: T[]): T|null {
         const ids: string[] = this.getIds(items);
 
-        for (const item of this._stack.filter(entry => entry.active)) {
-            const index: number = ids.indexOf(item.id);
-            if (index >= 0) {
-                return items[index];
+        for (const item of this._stack) {
+            if (item.active) {
+                const index: number = ids.indexOf(item.id);
+                if (index >= 0) {
+                    return items[index];
+                }
             }
         }
 
@@ -86,10 +88,13 @@ export class ZIndexer {
     }
 
     public getWindowAt(x: number, y: number, exclude?: WindowIdentity): WindowIdentity|null {
-        const entry: ZIndex|undefined = this._stack.filter(entry => entry.active).find((item: ZIndex) => {
+        const entry: ZIndex|undefined = this._stack.find((item: ZIndex) => {
             const identity = item.identity;
 
-            if (identity.uuid === SERVICE_IDENTITY.uuid && !identity.name.startsWith('TABSET-')) {
+            if (!item.active) {
+                // Exclude inactive windows
+                return false;
+            } else if (identity.uuid === SERVICE_IDENTITY.uuid && !identity.name.startsWith('TABSET-')) {
                 // Exclude service-owned windows
                 return false;
             } else if (exclude && exclude.uuid === identity.uuid && exclude.name === identity.name) {

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -118,7 +118,7 @@ export class ZIndexer {
      * @param timestamp The new timestamp for the stack entry. Will use the current time if not specified
      */
     private update(identity: WindowIdentity, active?: boolean, bounds?: Rect, timestamp?: number) {
-        timestamp = timestamp ? timestamp : Date.now();
+        timestamp = timestamp !== undefined ? timestamp : Date.now();
 
         const id: string = this._model.getId(identity);
         const entry: ZIndex|undefined = this._stack.find(i => i.id === id);

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -87,7 +87,7 @@ export class ZIndexer {
         return null;
     }
 
-    public getWindowAt(x: number, y: number, exclude?: WindowIdentity): WindowIdentity|null {
+    public getWindowAt(x: number, y: number, exclusions: WindowIdentity[]): WindowIdentity|null {
         const entry: ZIndex|undefined = this._stack.find((item: ZIndex) => {
             const identity = item.identity;
 
@@ -97,7 +97,7 @@ export class ZIndexer {
             } else if (identity.uuid === SERVICE_IDENTITY.uuid && !identity.name.startsWith('TABSET-')) {
                 // Exclude service-owned windows
                 return false;
-            } else if (exclude && exclude.uuid === identity.uuid && exclude.name === identity.name) {
+            } else if (exclusions.find(exclusion => exclusion.uuid === identity.uuid && exclusion.name === identity.name)) {
                 // Item is excluded
                 return false;
             } else {
@@ -187,8 +187,8 @@ export class ZIndexer {
             win.removeListener('focused', bringToFront);
             win.removeListener('shown', bringToFront);
             win.removeListener('bounds-changed', boundsChanged);
-            win.removeListener('hidden', markInactive);
-            win.removeListener('minimized', markInactive);
+            // win.removeListener('hidden', markInactive);
+            // win.removeListener('minimized', markInactive);
             win.removeListener('closed', onClose);
 
             const id = `${identity.uuid}/${identity.name}`;
@@ -204,8 +204,10 @@ export class ZIndexer {
         win.addListener('bounds-changed', boundsChanged);
 
         // When a window is hidden or minimized, mark it as inactive
-        win.addListener('hidden', markInactive);
-        win.addListener('minimized', markInactive);
+        // Todo: Renable these to allow tracking of hidden non-Model windows.
+        // Blocked on figuring out why events are not properly cleaned up on Jenkins.
+        // win.addListener('hidden', markInactive);
+        // win.addListener('minimized', markInactive);
 
         // Remove listeners when the window is destroyed
         win.addListener('closed', onClose);

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -113,7 +113,7 @@ export class ZIndexer {
     /**
      * Updates the state of the window tracked in the stack, and resorts windows
      * @param identity ID of the window to update (uuid, name)
-     * @param active The active state of the window to update, if know. Will guess as true if needed and not specified
+     * @param active The active state of the window to update, if known. Will guess as true if needed and not specified
      * @param bounds Physical bounds of the window to update, if known. Will perform an async query if needed and not specified
      * @param timestamp The new timestamp for the stack entry. Will use the current time if not specified
      */

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -187,9 +187,9 @@ export class ZIndexer {
             win.removeListener('focused', bringToFront);
             win.removeListener('shown', bringToFront);
             win.removeListener('bounds-changed', boundsChanged);
-            win.removeListener('closed', onClose);
             win.removeListener('hidden', markInactive);
             win.removeListener('minimized', markInactive);
+            win.removeListener('closed', onClose);
 
             const id = `${identity.uuid}/${identity.name}`;
             const index = this._stack.findIndex(e => e.id === id);

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -97,7 +97,7 @@ export class ZIndexer {
             } else if (identity.uuid === SERVICE_IDENTITY.uuid && !identity.name.startsWith('TABSET-')) {
                 // Exclude service-owned windows
                 return false;
-            } else if (exclusions.find(exclusion => exclusion.uuid === identity.uuid && exclusion.name === identity.name)) {
+            } else if (exclusions.some(exclusion => exclusion.uuid === identity.uuid && exclusion.name === identity.name)) {
                 // Item is excluded
                 return false;
             } else {

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -217,9 +217,9 @@ export class ZIndexer {
 
     private sortStack(): void {
         this._stack.sort((a, b) => {
-            if (a && !b) {
+            if (a.active && !b.active) {
                 return -1;
-            } else if (!a && b) {
+            } else if (!a.active && b.active) {
                 return 1;
             } else {
                 return b.timestamp - a.timestamp;

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -187,6 +187,7 @@ export class ZIndexer {
             win.removeListener('focused', bringToFront);
             win.removeListener('shown', bringToFront);
             win.removeListener('bounds-changed', boundsChanged);
+            // TODO (SERVICE-376): Uncomment these when below commented-out addListener calls are uncommented
             // win.removeListener('hidden', markInactive);
             // win.removeListener('minimized', markInactive);
             win.removeListener('closed', onClose);
@@ -204,8 +205,8 @@ export class ZIndexer {
         win.addListener('bounds-changed', boundsChanged);
 
         // When a window is hidden or minimized, mark it as inactive
-        // Todo: Renable these to allow tracking of hidden non-Model windows.
-        // Blocked on figuring out why events are not properly cleaned up on Jenkins.
+        // TODO (SERVICE-376): Uncomment these and above removeListener calls to allow tracking of hidden non-Model
+        // windows. Blocked on figuring out why events are not properly cleaned up on Jenkins
         // win.addListener('hidden', markInactive);
         // win.addListener('minimized', markInactive);
 

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -106,10 +106,10 @@ export class ZIndexer {
     }
 
     /**
-     * Updates the windows index in the stack and sorts array.
+     * Updates the state of the window tracked in the stack, and resorts windows
      * @param identity ID of the window to update (uuid, name)
-     * @param bounds Physical bounds of the window to update, if known. Will perform an async query if needed and not specified
      * @param active The active state of the window to update, if know. Will guess as true if needed and not specified
+     * @param bounds Physical bounds of the window to update, if known. Will perform an async query if needed and not specified
      * @param timestamp The new timestamp for the stack entry. Will use the current time if not specified
      */
     private update(identity: WindowIdentity, active?: boolean, bounds?: Rect, timestamp?: number) {

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -108,55 +108,57 @@ export class ZIndexer {
     /**
      * Updates the windows index in the stack and sorts array.
      * @param identity ID of the window to update (uuid, name)
-     * @param bounds Physical bounds of the window to update, if known
+     * @param bounds Physical bounds of the window to update, if known. Will perform an async querey if needed and not specified
+     * @param active The active state of the window to update, if know. Will guess as true if needed and not specified
+     * @param timestamp The new timestamp for the stack entry. Will use the current time if not specified
      */
-    private update(identity: WindowIdentity, bounds?: Rect) {
+    private update(identity: WindowIdentity, active?: boolean, bounds?: Rect, timestamp?: number) {
+        timestamp = timestamp ? timestamp : Date.now();
+
         const id: string = this._model.getId(identity);
-        const timestamp = Date.now();
-        let entry: ZIndex|undefined = this._stack.find(i => i.id === id);
+        const entry: ZIndex|undefined = this._stack.find(i => i.id === id);
 
         if (entry) {
             // Update existing entry
             entry.timestamp = timestamp;
+
+            if (active !== undefined) {
+                entry.active = active;
+            }
             if (bounds) {
-                // Update bounds
                 Object.assign(entry.bounds, bounds);
             }
-        } else if (bounds) {
-            // Can create & add a new entry synchronously
-            this.addToStack({id, identity, timestamp, bounds});
-        } else {
+        } else if (!bounds) {
             // Must request bounds before being able to add
             fin.Window.wrapSync(identity).getBounds().then(bounds => {
-                // Since this required an async operation, entry may now exist within stack
-                entry = this._stack.find(i => i.id === id);
-
-                if (entry) {
-                    // Update bounds on existing entry
-                    Object.assign(entry.bounds, bounds);
-                } else {
-                    // Continue with creating new entry
-                    this.addToStack({id, identity, timestamp, bounds: this.sanitizeBounds(bounds)});
-                }
+                // Since this required an async operation, entry may now exist within stack, so recursively call update
+                this.update(identity, active, this.sanitizeBounds(bounds), timestamp);
             });
+        } else {
+            // Can create & add a new entry synchronously
+            this.addToStack({id, identity, timestamp, bounds, active: active !== undefined ? active : true});
         }
 
-        this._stack.sort((a, b) => {
-            return b.timestamp - a.timestamp;
-        });
+        this.sortStack();
     }
 
-    private onWindowModified(identity: WindowIdentity, bounds?: Rect): void {
+    private onWindowModified(identity: WindowIdentity, active?: boolean, bounds?: Rect): void {
         const modelWindow: DesktopWindow|null = this._model.getWindow(identity);
         const modelGroup: DesktopSnapGroup|null = modelWindow && modelWindow.snapGroup;
 
         if (modelGroup && modelGroup.length > 1) {
-            // Also bring-to-front any windows within the group
+            // Also modify any windows within the group
             const id: string = this._model.getId(identity);
-            modelGroup.windows.forEach(window => this.update(window.identity, window.id === id ? bounds : undefined));
+
+            modelGroup.windows.forEach(window => {
+                const windowBounds = window.id === id ? bounds : undefined;
+                const windowActive = window.id === id ? active : undefined;
+
+                this.update(window.identity, windowActive, windowBounds);
+            });
         } else {
-            // Just bring modified window to front
-            this.update(identity, bounds);
+            // Just modify single window
+            this.update(identity, active, bounds);
         }
     }
 
@@ -168,16 +170,21 @@ export class ZIndexer {
         const identity = win.identity as WindowIdentity;  // A window identity will always have a name, so it is safe to cast
 
         const bringToFront = () => {
-            this.onWindowModified(identity);
+            this.onWindowModified(identity, true);
         };
         const boundsChanged = (evt: WindowBoundsChange<'window', 'bounds-changed'>) => {
-            this.onWindowModified(identity, this.sanitizeBounds(evt));
+            this.onWindowModified(identity, undefined, this.sanitizeBounds(evt));
+        };
+        const markInactive = () => {
+            this.onWindowModified(identity, false, undefined);
         };
         const onClose = () => {
             win.removeListener('focused', bringToFront);
             win.removeListener('shown', bringToFront);
             win.removeListener('bounds-changed', boundsChanged);
             win.removeListener('closed', onClose);
+            win.removeListener('hidden', markInactive);
+            win.removeListener('minimized', markInactive);
 
             const id = `${identity.uuid}/${identity.name}`;
             const index = this._stack.findIndex(e => e.id === id);
@@ -191,12 +198,28 @@ export class ZIndexer {
         win.addListener('shown', bringToFront);
         win.addListener('bounds-changed', boundsChanged);
 
+        // When a window is hidden or minimized, mark it as inactive
+        win.addListener('hidden', markInactive);
+        win.addListener('minimized', markInactive);
+
         // Remove listeners when the window is destroyed
         win.addListener('closed', onClose);
     }
 
     private addToStack(entry: ZIndex): void {
         this._stack.push(entry);
+    }
+
+    private sortStack(): void {
+        this._stack.sort((a, b) => {
+            if (a && !b) {
+                return -1;
+            } else if (!a && b) {
+                return 1;
+            } else {
+                return b.timestamp - a.timestamp;
+            }
+        });
     }
 
     private sanitizeBounds(input: Bounds): Rect {

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -16,6 +16,7 @@ export interface ZIndex {
     id: string;
     identity: WindowIdentity;
     bounds: Rect;
+    active: boolean;
 }
 
 interface ObjectWithIdentity {
@@ -74,7 +75,7 @@ export class ZIndexer {
     public getTopMost<T extends Identifiable>(items: T[]): T|null {
         const ids: string[] = this.getIds(items);
 
-        for (const item of this._stack) {
+        for (const item of this._stack.filter(entry => entry.active)) {
             const index: number = ids.indexOf(item.id);
             if (index >= 0) {
                 return items[index];
@@ -85,7 +86,7 @@ export class ZIndexer {
     }
 
     public getWindowAt(x: number, y: number, exclude?: WindowIdentity): WindowIdentity|null {
-        const entry: ZIndex|undefined = this._stack.find((item: ZIndex) => {
+        const entry: ZIndex|undefined = this._stack.filter(entry => entry.active).find((item: ZIndex) => {
             const identity = item.identity;
 
             if (identity.uuid === SERVICE_IDENTITY.uuid && !identity.name.startsWith('TABSET-')) {


### PR DESCRIPTION
This resolves a test failure caused by ZIndexer not responding to windows being hidden, and so believing hidden windows to be obscuring the expected active window.

Jenkins succeeded at a9d0349.