### PR TITLE
[N/A] Fix silent failure on some client undock calls

### DIFF
--- a/src/provider/APIHandler.ts
+++ b/src/provider/APIHandler.ts
@@ -131,12 +131,12 @@ export class APIHandler {
         }
     }
 
-    private undockWindow(identity: WindowIdentity): void {
-        this._snapService.undock(identity);
+    private async undockWindow(identity: WindowIdentity): Promise<void> {
+        return this._snapService.undock(identity);
     }
 
-    private undockGroup(identity: WindowIdentity): void {
-        this._snapService.explodeGroup(identity);
+    private async undockGroup(identity: WindowIdentity): Promise<void> {
+        return this._snapService.explodeGroup(identity);
     }
 
     private appReady(payload: void, identity: Identity): void {


### PR DESCRIPTION
Found a small issue where APIHandler wasn't properly chaining the undock promises. This meant that the promise on the far end always resolved (just about) immediately, regardless of the result of the internal call. 

In particular it meant that errors in the undock call were never reaching it to the client, instead topping out inside their respective top-level channel action handlers.

I've changed the undock handlers to be async functions and properly return the promise, so the client will not return a rejected promise on any provider-side undock errors.