### PR TITLE
[SERVICE-359] Improve input guards on client methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dist/client"
   ],
   "scripts": {
-    "test:unit": "jest --color",
+    "test:unit": "jest --color --no-cache",
     "test:int": "node test/runner.js",
     "test": "npm run test:unit && npm run test:int",
     "check": "gts check && cd test && gts check",

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -9,7 +9,7 @@
  * This file is excluded from the public-facing TypeScript documentation.
  */
 import {Identity} from 'hadouken-js-adapter';
-import {WindowIdentity} from './main';
+import {WindowIdentity, IdentityRule, RegEx} from './main';
 import {ApplicationUIConfig, TabProperties} from './tabbing';
 
 
@@ -50,10 +50,47 @@ export function getId(): WindowIdentity {
  */
 export function parseIdentity(identity: WindowIdentity|Identity): WindowIdentity {
     if (!identity || !identity.uuid) {
-        throw new Error('Invalid Identity provided.  A valid Identity contains both a uuid and name');
+        throw new Error('Invalid Identity provided: A valid Identity contains both a uuid and name');
+    }
+    const uuidCheck = typeof identity.uuid === 'string';
+    const nameCheck = identity.uuid === undefined || typeof identity.name === 'string';
+    if (!uuidCheck && !nameCheck) {
+        throw new Error ('Invalid Identity provided: uuid and name must be strings');
+    } else if (!uuidCheck) {
+        throw new Error ('Invalid Identity provided: uuid must be a string');
+    } else if (!nameCheck) {
+        throw new Error ('Invalid Identity provided: name must be a string');
     }
 
     return {uuid: identity.uuid, name: identity.name || identity.uuid};
+}
+
+/**
+ * Like parseIdentity above, but also allows properties to be regex objects.
+ */
+export function parseIdentityRule(identity: IdentityRule): IdentityRule {
+    if (!identity || !identity.uuid) {
+        throw new Error('Invalid Identity provided: A valid Identity contains both a uuid and name');
+    }
+    const uuidCheck = typeof identity.uuid === 'string' || isRegex(identity.uuid);
+    const nameCheck = identity.uuid === undefined || typeof identity.name === 'string' || isRegex(identity.name);
+    if (!uuidCheck && !nameCheck) {
+        throw new Error ('Invalid Identity provided: uuid and name must be strings or RegEx objects');
+    } else if (!uuidCheck) {
+        throw new Error ('Invalid Identity provided: uuid must be a string or RegEx object');
+    } else if (!nameCheck) {
+        throw new Error ('Invalid Identity provided: name must be a string or RegEx object');
+    }
+    
+    return {uuid: identity.uuid, name: identity.name || identity.uuid};
+
+}
+
+// tslint:disable-next-line:no-any This is a type guard, and so can take any object.
+function isRegex(a: any): a is RegEx {
+    return !!a.expression && typeof a.expression === 'string' &&
+        (a.flags === undefined || typeof a.flags === 'string') &&
+        (a.invert === undefined || typeof a.invert === 'boolean');
 }
 
 

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -50,17 +50,17 @@ export function getId(): WindowIdentity {
  * Assumed that the supplied object has uuid & name.
  */
 export function parseIdentity(identity: WindowIdentity|Identity): WindowIdentity {
-    if (!identity || !identity.uuid) {
-        throw new Error('Invalid Identity provided: A valid Identity contains both a uuid and name');
+    if (identity === null || typeof identity !== 'object') {
+        throw new Error(ErrorMsgs.IDENTITY_REQUIRED);
     }
     const uuidCheck = typeof identity.uuid === 'string';
     const nameCheck = !identity.name || typeof identity.name === 'string';
     if (!uuidCheck && !nameCheck) {
-        throw new Error('Invalid Identity provided: uuid and name must be strings');
+        throw new Error(ErrorMsgs.INVALID_IDENTITY_BOTH);
     } else if (!uuidCheck) {
-        throw new Error('Invalid Identity provided: uuid must be a string');
+        throw new Error(ErrorMsgs.INVALID_IDENTITY_UUID);
     } else if (!nameCheck) {
-        throw new Error('Invalid Identity provided: name must be a string');
+        throw new Error(ErrorMsgs.INVALID_IDENTITY_NAME);
     }
 
     return {uuid: identity.uuid, name: identity.name || identity.uuid};
@@ -70,17 +70,17 @@ export function parseIdentity(identity: WindowIdentity|Identity): WindowIdentity
  * Like parseIdentity above, but also allows properties to be regex objects.
  */
 export function parseIdentityRule(identity: IdentityRule): IdentityRule {
-    if (!identity || !identity.uuid) {
-        throw new Error('Invalid Identity provided: A valid Identity contains both a uuid and name');
+    if (identity === null || typeof identity !== 'object') {
+        throw new Error(ErrorMsgs.IDENTITY_REQUIRED);
     }
     const uuidCheck = typeof identity.uuid === 'string' || isRegex(identity.uuid);
     const nameCheck = !identity.name || typeof identity.name === 'string' || isRegex(identity.name);
     if (!uuidCheck && !nameCheck) {
-        throw new Error('Invalid Identity provided: uuid and name must be strings or RegEx objects');
+        throw new Error(ErrorMsgs.INVALID_IDENTITYRULE_BOTH);
     } else if (!uuidCheck) {
-        throw new Error('Invalid Identity provided: uuid must be a string or RegEx object');
+        throw new Error(ErrorMsgs.INVALID_IDENTITYRULE_UUID);
     } else if (!nameCheck) {
-        throw new Error('Invalid Identity provided: name must be a string or RegEx object');
+        throw new Error(ErrorMsgs.INVALID_IDENTITYRULE_NAME);
     }
 
     return {uuid: identity.uuid, name: identity.name || identity.uuid};
@@ -150,4 +150,15 @@ export interface UpdateTabPropertiesPayload {
 export interface CreateTabGroupPayload {
     windows: WindowIdentity[];
     activeTab?: WindowIdentity;
+}
+
+export const enum ErrorMsgs {
+    IDENTITY_REQUIRED = 'Invalid arguments. Must pass an identity object',
+    INVALID_IDENTITY_UUID = 'Invalid Identity provided: uuid must be a string',
+    INVALID_IDENTITY_NAME = "Invalid Identity provided: name must be a string or undefined",
+    INVALID_IDENTITY_BOTH = "Invalid Identity provided: uuid and name must be strings",
+    INVALID_IDENTITYRULE_UUID = "Invalid Identity provided: uuid must be a string or RegEx object",
+    INVALID_IDENTITYRULE_NAME = "Invalid Identity provided: name must be a string, RegEx object, or undefined",
+    INVALID_IDENTITYRULE_BOTH = "Invalid Identity provided: uuid and name must be strings or RegEx objects",
+    PROPERTIES_REQUIRED = 'Properties are required'
 }

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -53,7 +53,7 @@ export function parseIdentity(identity: WindowIdentity|Identity): WindowIdentity
         throw new Error('Invalid Identity provided: A valid Identity contains both a uuid and name');
     }
     const uuidCheck = typeof identity.uuid === 'string';
-    const nameCheck = identity.uuid === undefined || typeof identity.name === 'string';
+    const nameCheck = identity.name === undefined || typeof identity.name === 'string';
     if (!uuidCheck && !nameCheck) {
         throw new Error ('Invalid Identity provided: uuid and name must be strings');
     } else if (!uuidCheck) {
@@ -73,7 +73,7 @@ export function parseIdentityRule(identity: IdentityRule): IdentityRule {
         throw new Error('Invalid Identity provided: A valid Identity contains both a uuid and name');
     }
     const uuidCheck = typeof identity.uuid === 'string' || isRegex(identity.uuid);
-    const nameCheck = identity.uuid === undefined || typeof identity.name === 'string' || isRegex(identity.name);
+    const nameCheck = identity.name === undefined || typeof identity.name === 'string' || isRegex(identity.name);
     if (!uuidCheck && !nameCheck) {
         throw new Error ('Invalid Identity provided: uuid and name must be strings or RegEx objects');
     } else if (!uuidCheck) {

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -54,7 +54,7 @@ export function parseIdentity(identity: WindowIdentity|Identity): WindowIdentity
         throw new Error('Invalid Identity provided: A valid Identity contains both a uuid and name');
     }
     const uuidCheck = typeof identity.uuid === 'string';
-    const nameCheck = identity.name === undefined || typeof identity.name === 'string';
+    const nameCheck = !identity.name || typeof identity.name === 'string';
     if (!uuidCheck && !nameCheck) {
         throw new Error('Invalid Identity provided: uuid and name must be strings');
     } else if (!uuidCheck) {
@@ -74,7 +74,7 @@ export function parseIdentityRule(identity: IdentityRule): IdentityRule {
         throw new Error('Invalid Identity provided: A valid Identity contains both a uuid and name');
     }
     const uuidCheck = typeof identity.uuid === 'string' || isRegex(identity.uuid);
-    const nameCheck = identity.name === undefined || typeof identity.name === 'string' || isRegex(identity.name);
+    const nameCheck = !identity.name || typeof identity.name === 'string' || isRegex(identity.name);
     if (!uuidCheck && !nameCheck) {
         throw new Error('Invalid Identity provided: uuid and name must be strings or RegEx objects');
     } else if (!uuidCheck) {

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -9,7 +9,8 @@
  * This file is excluded from the public-facing TypeScript documentation.
  */
 import {Identity} from 'hadouken-js-adapter';
-import {WindowIdentity, IdentityRule, RegEx} from './main';
+
+import {IdentityRule, RegEx, WindowIdentity} from './main';
 import {ApplicationUIConfig, TabProperties} from './tabbing';
 
 
@@ -55,11 +56,11 @@ export function parseIdentity(identity: WindowIdentity|Identity): WindowIdentity
     const uuidCheck = typeof identity.uuid === 'string';
     const nameCheck = identity.name === undefined || typeof identity.name === 'string';
     if (!uuidCheck && !nameCheck) {
-        throw new Error ('Invalid Identity provided: uuid and name must be strings');
+        throw new Error('Invalid Identity provided: uuid and name must be strings');
     } else if (!uuidCheck) {
-        throw new Error ('Invalid Identity provided: uuid must be a string');
+        throw new Error('Invalid Identity provided: uuid must be a string');
     } else if (!nameCheck) {
-        throw new Error ('Invalid Identity provided: name must be a string');
+        throw new Error('Invalid Identity provided: name must be a string');
     }
 
     return {uuid: identity.uuid, name: identity.name || identity.uuid};
@@ -75,21 +76,19 @@ export function parseIdentityRule(identity: IdentityRule): IdentityRule {
     const uuidCheck = typeof identity.uuid === 'string' || isRegex(identity.uuid);
     const nameCheck = identity.name === undefined || typeof identity.name === 'string' || isRegex(identity.name);
     if (!uuidCheck && !nameCheck) {
-        throw new Error ('Invalid Identity provided: uuid and name must be strings or RegEx objects');
+        throw new Error('Invalid Identity provided: uuid and name must be strings or RegEx objects');
     } else if (!uuidCheck) {
-        throw new Error ('Invalid Identity provided: uuid must be a string or RegEx object');
+        throw new Error('Invalid Identity provided: uuid must be a string or RegEx object');
     } else if (!nameCheck) {
-        throw new Error ('Invalid Identity provided: name must be a string or RegEx object');
+        throw new Error('Invalid Identity provided: name must be a string or RegEx object');
     }
-    
-    return {uuid: identity.uuid, name: identity.name || identity.uuid};
 
+    return {uuid: identity.uuid, name: identity.name || identity.uuid};
 }
 
 // tslint:disable-next-line:no-any This is a type guard, and so can take any object.
 function isRegex(a: any): a is RegEx {
-    return !!a.expression && typeof a.expression === 'string' &&
-        (a.flags === undefined || typeof a.flags === 'string') &&
+    return !!a.expression && typeof a.expression === 'string' && (a.flags === undefined || typeof a.flags === 'string') &&
         (a.invert === undefined || typeof a.invert === 'boolean');
 }
 

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -155,10 +155,10 @@ export interface CreateTabGroupPayload {
 export const enum ErrorMsgs {
     IDENTITY_REQUIRED = 'Invalid arguments. Must pass an identity object',
     INVALID_IDENTITY_UUID = 'Invalid Identity provided: uuid must be a string',
-    INVALID_IDENTITY_NAME = "Invalid Identity provided: name must be a string or undefined",
-    INVALID_IDENTITY_BOTH = "Invalid Identity provided: uuid and name must be strings",
-    INVALID_IDENTITYRULE_UUID = "Invalid Identity provided: uuid must be a string or RegEx object",
-    INVALID_IDENTITYRULE_NAME = "Invalid Identity provided: name must be a string, RegEx object, or undefined",
-    INVALID_IDENTITYRULE_BOTH = "Invalid Identity provided: uuid and name must be strings or RegEx objects",
+    INVALID_IDENTITY_NAME = 'Invalid Identity provided: name must be a string or undefined',
+    INVALID_IDENTITY_BOTH = 'Invalid Identity provided: uuid and name must be strings',
+    INVALID_IDENTITYRULE_UUID = 'Invalid Identity provided: uuid must be a string or RegEx object',
+    INVALID_IDENTITYRULE_NAME = 'Invalid Identity provided: name must be a string, RegEx object, or undefined',
+    INVALID_IDENTITYRULE_BOTH = 'Invalid Identity provided: uuid and name must be strings or RegEx objects',
     PROPERTIES_REQUIRED = 'Properties are required'
 }

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -98,9 +98,6 @@ export type WindowState = 'normal'|'minimized'|'maximized';
  * @param identity The window (or pattern of windows) to deregister, defaults to the current window
  */
 export async function deregister(identity: IdentityRule = getId() as IdentityRule): Promise<void> {
-    if (!identity.uuid || !identity.name) {
-        throw new Error('Invalid window identity provided');
-    }
     return tryServiceDispatch<IdentityRule, void>(RegisterAPI.DEREGISTER, parseIdentityRule(identity));
 }
 
@@ -130,8 +127,5 @@ export async function deregister(identity: IdentityRule = getId() as IdentityRul
  * @param identity The window (or pattern of windows) to register, defaults to the current window
  */
 export async function register(identity: IdentityRule = getId() as IdentityRule): Promise<void> {
-    if (!identity.uuid || !identity.name) {
-        throw new Error('Invalid window identity provided');
-    }
     return tryServiceDispatch<IdentityRule, void>(RegisterAPI.REGISTER, parseIdentityRule(identity));
 }

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -2,7 +2,7 @@
  * @module Index
  */
 import {tryServiceDispatch} from './connection';
-import {getId, RegisterAPI, parseIdentityRule} from './internal';
+import {getId, parseIdentityRule, RegisterAPI} from './internal';
 import * as snapAndDock from './snapanddock';
 import * as tabbing from './tabbing';
 import * as tabstrip from './tabstrip';

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -2,7 +2,7 @@
  * @module Index
  */
 import {tryServiceDispatch} from './connection';
-import {getId, RegisterAPI} from './internal';
+import {getId, RegisterAPI, parseIdentityRule} from './internal';
 import * as snapAndDock from './snapanddock';
 import * as tabbing from './tabbing';
 import * as tabstrip from './tabstrip';
@@ -101,7 +101,7 @@ export async function deregister(identity: IdentityRule = getId() as IdentityRul
     if (!identity.uuid || !identity.name) {
         throw new Error('Invalid window identity provided');
     }
-    return tryServiceDispatch<IdentityRule, void>(RegisterAPI.DEREGISTER, identity);
+    return tryServiceDispatch<IdentityRule, void>(RegisterAPI.DEREGISTER, parseIdentityRule(identity));
 }
 
 /**
@@ -133,5 +133,5 @@ export async function register(identity: IdentityRule = getId() as IdentityRule)
     if (!identity.uuid || !identity.name) {
         throw new Error('Invalid window identity provided');
     }
-    return tryServiceDispatch<IdentityRule, void>(RegisterAPI.REGISTER, identity);
+    return tryServiceDispatch<IdentityRule, void>(RegisterAPI.REGISTER, parseIdentityRule(identity));
 }

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -4,7 +4,7 @@
 import {Identity} from 'hadouken-js-adapter';
 
 import {eventEmitter, tryServiceDispatch} from './connection';
-import {getId, SnapAndDockAPI} from './internal';
+import {getId, SnapAndDockAPI, parseIdentity} from './internal';
 
 
 /**
@@ -116,7 +116,7 @@ export function removeEventListener<K extends EventMap>(eventType: K['type'], li
  * @throws `Error`: If the window specified by `identity` has been de-registered
  */
 export async function undockWindow(identity: Identity = getId()): Promise<void> {
-    return tryServiceDispatch<Identity, void>(SnapAndDockAPI.UNDOCK_WINDOW, identity);
+    return tryServiceDispatch<Identity, void>(SnapAndDockAPI.UNDOCK_WINDOW, parseIdentity(identity));
 }
 
 /**
@@ -144,5 +144,5 @@ export async function undockWindow(identity: Identity = getId()): Promise<void> 
  * @throws `Error`: If the window specified by `identity` has been de-registered
  */
 export async function undockGroup(identity: Identity = getId()): Promise<void> {
-    return tryServiceDispatch<Identity, void>(SnapAndDockAPI.UNDOCK_GROUP, identity);
+    return tryServiceDispatch<Identity, void>(SnapAndDockAPI.UNDOCK_GROUP, parseIdentity(identity));
 }

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -4,7 +4,7 @@
 import {Identity} from 'hadouken-js-adapter';
 
 import {eventEmitter, tryServiceDispatch} from './connection';
-import {getId, SnapAndDockAPI, parseIdentity} from './internal';
+import {getId, parseIdentity, SnapAndDockAPI} from './internal';
 
 
 /**

--- a/src/client/tabbing.ts
+++ b/src/client/tabbing.ts
@@ -4,7 +4,7 @@
 import {Identity} from 'hadouken-js-adapter';
 
 import {eventEmitter, tryServiceDispatch} from './connection';
-import {AddTabPayload, CreateTabGroupPayload, getId, parseIdentity, SetTabstripPayload, TabAPI, UpdateTabPropertiesPayload} from './internal';
+import {AddTabPayload, CreateTabGroupPayload, getId, parseIdentity, SetTabstripPayload, TabAPI, UpdateTabPropertiesPayload, ErrorMsgs} from './internal';
 import {WindowIdentity} from './main';
 
 /**
@@ -484,7 +484,7 @@ export async function restoreTabGroup(identity: Identity = getId()): Promise<voi
  */
 export async function updateTabProperties(properties: Partial<TabProperties>, identity: Identity = getId()): Promise<void> {
     if (!properties) {
-        throw new Error('Properties are required');
+        throw new Error(ErrorMsgs.PROPERTIES_REQUIRED);
     }
     return tryServiceDispatch<UpdateTabPropertiesPayload, void>(TabAPI.UPDATETABPROPERTIES, {window: parseIdentity(identity), properties});
 }

--- a/src/client/tabbing.ts
+++ b/src/client/tabbing.ts
@@ -4,7 +4,7 @@
 import {Identity} from 'hadouken-js-adapter';
 
 import {eventEmitter, tryServiceDispatch} from './connection';
-import {AddTabPayload, CreateTabGroupPayload, getId, parseIdentity, SetTabstripPayload, TabAPI, UpdateTabPropertiesPayload, ErrorMsgs} from './internal';
+import {AddTabPayload, CreateTabGroupPayload, ErrorMsgs, getId, parseIdentity, SetTabstripPayload, TabAPI, UpdateTabPropertiesPayload} from './internal';
 import {WindowIdentity} from './main';
 
 /**

--- a/src/provider/APIHandler.ts
+++ b/src/provider/APIHandler.ts
@@ -131,12 +131,12 @@ export class APIHandler {
         }
     }
 
-    private undockWindow(identity: WindowIdentity): void {
-        this._snapService.undock(identity);
+    private async undockWindow(identity: WindowIdentity): Promise<void> {
+        return this._snapService.undock(identity);
     }
 
-    private undockGroup(identity: WindowIdentity): void {
-        this._snapService.explodeGroup(identity);
+    private async undockGroup(identity: WindowIdentity): Promise<void> {
+        return this._snapService.explodeGroup(identity);
     }
 
     private appReady(payload: void, identity: Identity): void {

--- a/test/client/TabApi.unittest.ts
+++ b/test/client/TabApi.unittest.ts
@@ -1,7 +1,7 @@
 import {ChannelClient} from 'hadouken-js-adapter/out/types/src/api/interappbus/channel/client';
 
 import {stub} from './utils/FinMock';
-import {ErrorMsgs} from './utils/ErrorMsgs';
+import {ErrorMsgs} from '../../src/client/internal';
 
 import {channelPromise} from '../../src/client/connection';
 import {TabAPI} from '../../src/client/internal';
@@ -10,7 +10,7 @@ import {tabbing, WindowIdentity} from '../../src/client/main';
 stub();
 
 let channel: ChannelClient;
-let channelDispatch: jest.SpyInstance<typeof channel.dispatch>
+let channelDispatch: jest.SpyInstance<typeof channel.dispatch>;
 
 beforeEach(async () => {
     jest.restoreAllMocks();
@@ -22,17 +22,17 @@ describe('Tabbing API Actions', () => {
     describe('When calling addTab', () => {
         it('Calling with invalid identity rejects with error message', async () => {
             const promise = tabbing.tabWindowToWindow(null!, null!);
-            await expect(promise).rejects.toThrowError(ErrorMsgs.INVALID_IDENTITY);
+            await expect(promise).rejects.toThrowError(ErrorMsgs.IDENTITY_REQUIRED);
         });
 
         it('Calling with invalid uuid rejects with error message', async () => {
             const promise = tabbing.tabWindowToWindow({uuid: null!, name: 'somename'}, null!);
-            await expect(promise).rejects.toThrowError(ErrorMsgs.INVALID_IDENTITY);
+            await expect(promise).rejects.toThrowError(ErrorMsgs.IDENTITY_REQUIRED);
         });
 
         it('Calling with invalid name rejects with error message', async () => {
             const promise = tabbing.tabWindowToWindow({uuid: 'someuuid', name: null!}, null!);
-            await expect(promise).rejects.toThrowError(ErrorMsgs.INVALID_IDENTITY);
+            await expect(promise).rejects.toThrowError(ErrorMsgs.IDENTITY_REQUIRED);
         });
 
         it('Calling with valid arguments sends a TAB_WINDOW_TO_WINDOW message', async () => {
@@ -47,15 +47,22 @@ describe('Tabbing API Actions', () => {
 
     describe('When calling removeTab', () => {
         it('Calling with invalid uuid rejects with error message', async () => {
-            const promise = tabbing.removeTab({uuid: null!, name: 'somerandomname'});
-            await expect(promise).rejects.toThrowError(ErrorMsgs.INVALID_IDENTITY);
+            // @ts-ignore Intentional bad parameters
+            const promise = tabbing.removeTab({uuid: true, name: 'somerandomname'});
+            await expect(promise).rejects.toThrowError(ErrorMsgs.INVALID_IDENTITY_UUID);
         });
 
-        it('Calling with invalid name assumes main application window', async () => {
+        it('Calling with invalid name rejects with error message', async () => {
+            // @ts-ignore Intentional bad parameters
+            const promise = tabbing.removeTab({uuid: 'somerandomuuid', name: 1}); 
+            await expect(promise).rejects.toThrowError(ErrorMsgs.INVALID_IDENTITY_NAME);
+        });
+
+        it('Calling with undefined name assumes main application window', async () => {
             const uuid = 'some random uuid';
             const expectedPayload: WindowIdentity = {uuid, name: uuid};
 
-            await tabbing.removeTab({uuid, name: null!});
+            await tabbing.removeTab({uuid, name: undefined});
             await expect(channelDispatch).toBeCalledWith(TabAPI.REMOVETAB, expectedPayload);
         });
 
@@ -82,7 +89,7 @@ describe('Tabbing API Actions', () => {
             const name = 'testname';
 
             const promise = tabbing.setActiveTab({uuid, name});
-            await expect(promise).rejects.toThrowError(ErrorMsgs.INVALID_IDENTITY);
+            await expect(promise).rejects.toThrowError(ErrorMsgs.INVALID_IDENTITY_UUID);
         });
 
         it('Calling with invalid name assumes main application window', async () => {
@@ -117,7 +124,7 @@ describe('Tabbing API Actions', () => {
             const name = 'somename';
             
             const promise = tabbing.closeTab({uuid, name});
-            await expect(promise).rejects.toThrowError(ErrorMsgs.INVALID_IDENTITY);
+            await expect(promise).rejects.toThrowError(ErrorMsgs.INVALID_IDENTITY_UUID);
         });
 
         it('Calling with invalid name assumes main application window', async () => {

--- a/test/client/TabGroupActions.unittest.ts
+++ b/test/client/TabGroupActions.unittest.ts
@@ -12,7 +12,7 @@ import {WindowIdentity} from '../../src/client/main';
 stub();
 
 let channel: ChannelClient;
-let channelDispatch: jest.SpyInstance<typeof channel.dispatch>
+let channelDispatch: jest.SpyInstance<typeof channel.dispatch>;
 
 beforeEach(async () => {
     jest.restoreAllMocks();

--- a/test/client/TabStripApi.unittest.ts
+++ b/test/client/TabStripApi.unittest.ts
@@ -1,7 +1,7 @@
 import {ChannelClient} from 'hadouken-js-adapter/out/types/src/api/interappbus/channel/client';
 
 import {stub} from './utils/FinMock';
-import {ErrorMsgs} from './utils/ErrorMsgs';
+import {ErrorMsgs} from '../../src/client/internal';
 
 import {channelPromise} from '../../src/client/connection';
 import {TabAPI, UpdateTabPropertiesPayload} from '../../src/client/internal';
@@ -12,7 +12,7 @@ import {TabProperties} from "../../src/client/tabbing";
 stub();
 
 let channel: ChannelClient;
-let channelDispatch: jest.SpyInstance<typeof channel.dispatch>
+let channelDispatch: jest.SpyInstance<typeof channel.dispatch>;
 
 beforeEach(async () => {
     jest.restoreAllMocks();
@@ -28,7 +28,7 @@ describe('Tabstrip API Actions', () => {
             const tabProperties: TabProperties = {title: 'sometitle', icon: 'someicon'};
 
             const promise = tabbing.updateTabProperties(tabProperties, {uuid, name});
-            await expect(promise).rejects.toThrowError(ErrorMsgs.INVALID_IDENTITY);
+            await expect(promise).rejects.toThrowError(ErrorMsgs.INVALID_IDENTITY_UUID);
         });
 
         it('Calling with invalid name assumes main application window', async () => {

--- a/test/client/utils/ErrorMsgs.ts
+++ b/test/client/utils/ErrorMsgs.ts
@@ -1,6 +1,6 @@
 export const enum ErrorMsgs {
     EVENT_REQUIRED = 'Event is required',
-    INVALID_IDENTITY = 'Invalid Identity provided.  A valid Identity contains both a uuid and name',
+    INVALID_IDENTITY = 'Invalid Identity provided: A valid Identity contains both a uuid and name',
     INVALID_TARGET_WINDOW = 'Invalid targetWindow provided',
     INVALID_WINDOW = 'Invalid window provided',
     PROPERTIES_REQUIRED = 'Properties are required'

--- a/test/client/utils/ErrorMsgs.ts
+++ b/test/client/utils/ErrorMsgs.ts
@@ -1,7 +1,0 @@
-export const enum ErrorMsgs {
-    EVENT_REQUIRED = 'Event is required',
-    INVALID_IDENTITY = 'Invalid Identity provided: A valid Identity contains both a uuid and name',
-    INVALID_TARGET_WINDOW = 'Invalid targetWindow provided',
-    INVALID_WINDOW = 'Invalid window provided',
-    PROPERTIES_REQUIRED = 'Properties are required'
-}


### PR DESCRIPTION
- Added some additional checks to the `parseIdentity` checks, specifically around the types of the arguments provided.
- Made a new `parseIdentityRule` method which does a similar thing but for identities allowing Regex.

Note: I've also included a fix for an error I encountered during this story where the undock methods weren't properly returning provider-side errors to the client.