### PR TITLE
[N/A] Fix bad path logic in error window creation

### DIFF
--- a/src/provider/utils/error.ts
+++ b/src/provider/utils/error.ts
@@ -1,11 +1,12 @@
 export async function createErrorBox(title: string, message: string) {
     const uuid = 'layouts-error-' + fin.desktop.getUuid();
+    const launchDir = location.href.slice(0, location.href.lastIndexOf('/'));
     const errorApp = await fin.Application.create({
-        url: window.location.origin + '/provider/errors/error.html',
+        url: launchDir + '/errors/error.html',
         uuid,
         name: uuid,
         mainWindowOptions: {
-            icon: window.location.origin + '/provider/errors/error-icon.png',
+            icon: launchDir + '/errors/error-icon.png',
             defaultHeight: 150,  // size increased later to fully fit error message
             defaultWidth: 570,
             defaultCentered: true,


### PR DESCRIPTION
Error window was being pointed to a non-existent file when running off of the cdn. Fixed the relative path calculation to actually make sense for setups other than the local demo.