### PR TITLE
[N/A] Track which apps have made a call to appReadyForRestore, as a heuristic for which apps are good S&R citizens

### DIFF
--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -167,7 +167,14 @@ export const generateWorkspace = async(payload: null, identity: Identity): Promi
 
     const apps = await promiseMap(preLayout.apps, async (app: WorkspaceApp) => {
         const defaultResponse = {...app};
-        if (apiHandler.isClientConnection({uuid: app.uuid, name: app.mainWindow.name}) && appCanRestore(app.uuid)) {
+        if (!apiHandler.isClientConnection({uuid: app.uuid, name: app.mainWindow.name}))
+        {
+            console.log('Unconnected application', app.uuid);
+            return defaultResponse;
+        } else if (!appCanRestore(app.uuid)) {
+            console.log('Connected application, but did not signal ability to restore', app.uuid);
+            return defaultResponse;
+        } else {
             console.log('Connected application', app.uuid);
 
             // HOW TO DEAL WITH HUNG REQUEST HERE? RESHAPE IF GET NOTHING BACK?
@@ -181,8 +188,6 @@ export const generateWorkspace = async(payload: null, identity: Identity): Promi
             }
             defaultResponse.customData = customData;
             defaultResponse.confirmed = true;
-            return defaultResponse;
-        } else {
             return defaultResponse;
         }
     });

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -167,8 +167,7 @@ export const generateWorkspace = async(payload: null, identity: Identity): Promi
 
     const apps = await promiseMap(preLayout.apps, async (app: WorkspaceApp) => {
         const defaultResponse = {...app};
-        if (!apiHandler.isClientConnection({uuid: app.uuid, name: app.mainWindow.name}))
-        {
+        if (!apiHandler.isClientConnection({uuid: app.uuid, name: app.mainWindow.name})) {
             console.log('Unconnected application', app.uuid);
             return defaultResponse;
         } else if (!appCanRestore(app.uuid)) {

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -12,6 +12,7 @@ import {WindowIdentity} from '../model/DesktopWindow';
 import {promiseMap} from '../snapanddock/utils/async';
 
 import {getGroup} from './group';
+import {appCanRestore} from './restore';
 import {addToWindowObject, adjustSizeOfFormerlyTabbedWindows, canRestoreProgrammatically, inWindowObject, parseVersionString, wasCreatedFromManifest, WindowObject} from './utils';
 
 // This value should be updated any time changes are made to the Workspace schema.
@@ -166,7 +167,7 @@ export const generateWorkspace = async(payload: null, identity: Identity): Promi
 
     const apps = await promiseMap(preLayout.apps, async (app: WorkspaceApp) => {
         const defaultResponse = {...app};
-        if (apiHandler.isClientConnection({uuid: app.uuid, name: app.mainWindow.name})) {
+        if (apiHandler.isClientConnection({uuid: app.uuid, name: app.mainWindow.name}) && appCanRestore(app.uuid)) {
             console.log('Connected application', app.uuid);
 
             // HOW TO DEAL WITH HUNG REQUEST HERE? RESHAPE IF GET NOTHING BACK?

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -22,6 +22,9 @@ const CLIENT_STARTUP_TIMEOUT = 60000;
 // Duration in milliseconds that we give a client app to restore itself when restoring a Workspace
 const CLIENT_RESTORE_TIMEOUT = 60000;
 
+// All apps that we've ever received a appReadyForRestore call from. Used as a heuristic to determine which apps properly implement S&R features
+const allAppsEverReady = new Map<string, boolean>();
+
 const appsToRestoreWhenReady = new Map<string, AppToRestore>();
 
 // A token unique to the current run of restoreWorkspace, needed so that we can correctly release the exclusivity token after a timeout if needed
@@ -33,6 +36,8 @@ interface AppToRestore {
 }
 
 export const appReadyForRestore = async(uuid: string): Promise<void> => {
+    allAppsEverReady.set(uuid, true);
+
     const appToRestore = appsToRestoreWhenReady.get(uuid)!;
 
     if (appToRestore) {
@@ -105,6 +110,10 @@ export const restoreWorkspace = async(payload: Workspace): Promise<Workspace> =>
 
     // Send the workspace back to the requester of the restore
     return workspace;
+};
+
+export const appCanRestore = (uuid: string): boolean => {
+    return allAppsEverReady.has(uuid);
 };
 
 const requestClientRestoreApp = async(workspaceApp: WorkspaceApp, resolve: Function): Promise<void> => {


### PR DESCRIPTION
Obviously all apps registered with layouts should be good S&R citizens, but this handles a case I ran into with Trade Blotter where it isn't.

Open to these being deemed unnecessary and we instead place a strong requirement on apps to Do The Right Thing.

Jenkins in progress at  e003775