### PR TITLE
[N/A] Set message-timeout to 60 seconds for createFromManifest lag

### DIFF
--- a/res/provider/app.json
+++ b/res/provider/app.json
@@ -14,7 +14,7 @@
         "enableAppLogging": true
     },
     "runtime": {
-        "arguments": "--enable-aggressive-domstorage-flushing",
+        "arguments": "--enable-aggressive-domstorage-flushing --message-timeout=60000",
         "version": "9.61.38.40"
     }
 }


### PR DESCRIPTION
This restores @MichaelMCoates original mitigation for restore failures when restoring many manifest apps, which is the low risk fix for 1.0.

> When restoring a large workspace that uses many applications created from manifest, the core/RVM don't currently account for that level of load. If application launches hang a bit long, they timeout silently, which breaks restoration. Setting this timeout extends the amount of time before the timeout fails, until we have a more permanent solution.

Succeeded on Jenkins.