### PR TITLE
[SERVICE-328, SERVICE-377] Updated API docs, removed need for v1 types within client

### DIFF
--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -14,10 +14,10 @@
 import {EventEmitter} from 'events';
 import {ChannelClient} from 'hadouken-js-adapter/out/types/src/api/interappbus/channel/client';
 
-import {Events as SnapAndDockEvents} from '../client/snapanddock';
-import {Events as TabbingEvents} from '../client/tabbing';
-import {Events as TabstripEvents} from '../client/tabstrip';
-import {Events as WorkspacesEvents} from '../client/workspaces';
+import {SnapAndDockEvent} from '../client/snapanddock';
+import {TabbingEvent} from '../client/tabbing';
+import {TabstripEvent} from '../client/tabstrip';
+import {WorkspacesEvent} from '../client/workspaces';
 
 import {APITopic, SERVICE_CHANNEL} from './internal';
 
@@ -31,7 +31,7 @@ declare const PACKAGE_VERSION: string;
 /**
  * Defines all events that are fired by the service
  */
-export type Events = TabstripEvents|TabbingEvents|WorkspacesEvents|SnapAndDockEvents;
+export type LayoutsEvent = TabstripEvent|TabbingEvent|WorkspacesEvent|SnapAndDockEvent;
 
 /**
  * The event emitter to emit events received from the service.  All addEventListeners will tap into this.
@@ -46,7 +46,7 @@ export const channelPromise: Promise<ChannelClient> = typeof fin === 'undefined'
     fin.InterApplicationBus.Channel.connect(SERVICE_CHANNEL, {payload: {version: PACKAGE_VERSION}}).then((channel: ChannelClient) => {
         // Register service listeners
         channel.register('WARN', (payload: any) => console.warn(payload));  // tslint:disable-line:no-any
-        channel.register('event', (event: Events) => {
+        channel.register('event', (event: LayoutsEvent) => {
             eventEmitter.emit(event.type, event);
         });
         // Any unregistered action will simply return false

--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -13,7 +13,12 @@
  */
 import {EventEmitter} from 'events';
 import {ChannelClient} from 'hadouken-js-adapter/out/types/src/api/interappbus/channel/client';
-import {EventMap} from '../provider/APIMessages';
+
+import {Events as SnapAndDockEvents} from '../client/snapanddock';
+import {Events as TabbingEvents} from '../client/tabbing';
+import {Events as TabstripEvents} from '../client/tabstrip';
+import {Events as WorkspacesEvents} from '../client/workspaces';
+
 import {APITopic, SERVICE_CHANNEL} from './internal';
 
 /**
@@ -22,6 +27,11 @@ import {APITopic, SERVICE_CHANNEL} from './internal';
  * Webpack replaces any instances of this constant with a hard-coded string at build time.
  */
 declare const PACKAGE_VERSION: string;
+
+/**
+ * Defines all events that are fired by the service
+ */
+export type Events = TabstripEvents|TabbingEvents|WorkspacesEvents|SnapAndDockEvents;
 
 /**
  * The event emitter to emit events received from the service.  All addEventListeners will tap into this.
@@ -36,7 +46,7 @@ export const channelPromise: Promise<ChannelClient> = typeof fin === 'undefined'
     fin.InterApplicationBus.Channel.connect(SERVICE_CHANNEL, {payload: {version: PACKAGE_VERSION}}).then((channel: ChannelClient) => {
         // Register service listeners
         channel.register('WARN', (payload: any) => console.warn(payload));  // tslint:disable-line:no-any
-        channel.register('event', (event: EventMap) => {
+        channel.register('event', (event: Events) => {
             eventEmitter.emit(event.type, event);
         });
         // Any unregistered action will simply return false

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -37,12 +37,12 @@ export interface WindowIdentity {
  */
 export interface IdentityRule {
     /**
-     * Application identifier
+     * Application identifier or pattern
      */
     uuid: string|RegEx;
 
     /**
-     * Window identifier
+     * Window identifier or pattern
      */
     name: string|RegEx;
 }
@@ -113,7 +113,9 @@ export async function deregister(identity: IdentityRule = getId() as IdentityRul
  *
  * This API can be used to programmatically override configuration set at an app-wide level, such as in the application manifest.
  *
- * Note that applications that intend to use the service should always do this by adding the service declaration to their application manifest.
+ * This API is provided to complement {@link deregister}, to allow programmatic override of default service behavior or configuration
+ * specified in an application manifest. This API is not required or intended for initial opt-in of your application to the service,
+ * which is achieved through the `"services"` attribute within an application manifest.
  *
  * ```ts
  * import {register} from 'openfin-layouts';

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -36,7 +36,14 @@ export interface WindowIdentity {
  * If using a regex, it must be specified in JSON-like format, using the {@link RegEx} type - JS regex literals are not supported.
  */
 export interface IdentityRule {
+    /**
+     * Application identifier
+     */
     uuid: string|RegEx;
+
+    /**
+     * Window identifier
+     */
     name: string|RegEx;
 }
 
@@ -49,13 +56,13 @@ export interface RegEx {
     /**
      * Defines the regex pattern.
      *
-     * Do not wrap the expression in `/` characters - specify the pattern string as you would when passing to the RegExp constructor.
+     * Do not wrap the expression in `/` characters - specify the pattern string as you would when passing to the `RegExp` constructor.
      */
     expression: string;
 
     /**
-     * Any additional flags that form part of this expression. Supported same [values
-     * ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Parameters)as the native JS `RegExp` class.
+     * Any additional flags that form part of this expression. Supports same
+     * [values](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Parameters) as the native JS `RegExp` class.
      */
     flags?: string;
 
@@ -66,18 +73,13 @@ export interface RegEx {
 }
 
 /**
- * Window state, corresponds to `WindowOptions.state`
- */
-export type WindowState = 'normal'|'minimized'|'maximized';
-
-/**
  * Allows a window to opt-out of this service.
  *
  * This will disable *all* layouts-related functionality for the given window.
  *
  * Multiple windows can be deregistered at once by using regex patterns on `identity.uuid`/`identity.name`.
  *
- * This API can be used to selectively programmatically override configuration set at an app-wide level, such as in the application manifest.
+ * This API can be used to programmatically override configuration set at an app-wide level, such as in the application manifest.
  *
  * ```ts
  * import {deregister} from 'openfin-layouts';
@@ -109,7 +111,9 @@ export async function deregister(identity: IdentityRule = getId() as IdentityRul
  *
  * This will enable *all* layouts-related functionality for the given window unless alternative behaviors are set in the layout configuration.
  *
- * This API can be used to selectively programmatically override configuration set at an app-wide level, such as in the application manifest.
+ * This API can be used to programmatically override configuration set at an app-wide level, such as in the application manifest.
+ *
+ * Note that applications that intend to use the service should always do this by adding the service declaration to their application manifest.
  *
  * ```ts
  * import {register} from 'openfin-layouts';

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -36,14 +36,7 @@ export interface WindowIdentity {
  * If using a regex, it must be specified in JSON-like format, using the {@link RegEx} type - JS regex literals are not supported.
  */
 export interface IdentityRule {
-    /**
-     * Application identifier
-     */
     uuid: string|RegEx;
-
-    /**
-     * Window identifier
-     */
     name: string|RegEx;
 }
 
@@ -56,13 +49,13 @@ export interface RegEx {
     /**
      * Defines the regex pattern.
      *
-     * Do not wrap the expression in `/` characters - specify the pattern string as you would when passing to the `RegExp` constructor.
+     * Do not wrap the expression in `/` characters - specify the pattern string as you would when passing to the RegExp constructor.
      */
     expression: string;
 
     /**
-     * Any additional flags that form part of this expression. Supports same
-     * [values](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Parameters) as the native JS `RegExp` class.
+     * Any additional flags that form part of this expression. Supported same [values
+     * ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Parameters)as the native JS `RegExp` class.
      */
     flags?: string;
 
@@ -73,13 +66,18 @@ export interface RegEx {
 }
 
 /**
+ * Window state, corresponds to `WindowOptions.state`
+ */
+export type WindowState = 'normal'|'minimized'|'maximized';
+
+/**
  * Allows a window to opt-out of this service.
  *
  * This will disable *all* layouts-related functionality for the given window.
  *
  * Multiple windows can be deregistered at once by using regex patterns on `identity.uuid`/`identity.name`.
  *
- * This API can be used to programmatically override configuration set at an app-wide level, such as in the application manifest.
+ * This API can be used to selectively programmatically override configuration set at an app-wide level, such as in the application manifest.
  *
  * ```ts
  * import {deregister} from 'openfin-layouts';
@@ -111,9 +109,7 @@ export async function deregister(identity: IdentityRule = getId() as IdentityRul
  *
  * This will enable *all* layouts-related functionality for the given window unless alternative behaviors are set in the layout configuration.
  *
- * This API can be used to programmatically override configuration set at an app-wide level, such as in the application manifest.
- *
- * Note that applications that intend to use the service should always do this by adding the service declaration to their application manifest.
+ * This API can be used to selectively programmatically override configuration set at an app-wide level, such as in the application manifest.
  *
  * ```ts
  * import {register} from 'openfin-layouts';

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -15,6 +15,7 @@ import {getId, SnapAndDockAPI} from './internal';
  *
  * ```ts
  * import {addEventListener} from 'openfin-layouts';
+ * import {WindowDockedEvent} from 'openfin-layouts/dist/client/snapanddock';
  *
  * addEventListener('window-docked', async (event: WindowDockedEvent) => {
  *     console.log("Docked to another window");
@@ -28,9 +29,9 @@ import {getId, SnapAndDockAPI} from './internal';
  *     console.log("Windows in current group: ", await fin.Window.getCurrentSync().getGroup());
  * });
  * ```
- *
- * The service considers any windows that are tabbed together to also be in the same snap group, so this event will also fire when a window is added to a tab
- * group. This may change in future versions of the service.
+ * 
+ * This event is fired when the window first becomes docked. The window will not receive an event if an additional 
+ * window is added to the group later.
  *
  * @event
  */
@@ -46,6 +47,7 @@ export interface WindowDockedEvent {
  *
  * ```ts
  * import {addEventListener} from 'openfin-layouts';
+ * import {WindowUndockedEvent} from 'openfin-layouts/dist/client/snapanddock';
  *
  * addEventListener('window-undocked', async (event: WindowUndockedEvent) => {
  *     console.log("Undocked from another window");
@@ -59,6 +61,9 @@ export interface WindowDockedEvent {
  *     console.log("Windows in current group: ", await fin.Window.getCurrentSync().getGroup());
  * });
  * ```
+ * 
+ * This event is fired when the current window becomes undocked from a group. A window will not receive this event if 
+ * another window within the same group is undocked.
  *
  * @event
  */
@@ -74,7 +79,6 @@ export type EventMap = WindowDockedEvent|WindowUndockedEvent;
 
 export function addEventListener(eventType: 'window-docked', listener: (event: WindowDockedEvent) => void): void;
 export function addEventListener(eventType: 'window-undocked', listener: (event: WindowUndockedEvent) => void): void;
-
 export function addEventListener<K extends EventMap>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -29,8 +29,8 @@ import {getId, SnapAndDockAPI} from './internal';
  *     console.log("Windows in current group: ", await fin.Window.getCurrentSync().getGroup());
  * });
  * ```
- * 
- * This event is fired when the window first becomes docked. The window will not receive an event if an additional 
+ *
+ * This event is fired when the window first becomes docked. The window will not receive an event if an additional
  * window is added to the group later.
  *
  * @event
@@ -61,8 +61,8 @@ export interface WindowDockedEvent {
  *     console.log("Windows in current group: ", await fin.Window.getCurrentSync().getGroup());
  * });
  * ```
- * 
- * This event is fired when the current window becomes undocked from a group. A window will not receive this event if 
+ *
+ * This event is fired when the current window becomes undocked from a group. A window will not receive this event if
  * another window within the same group is undocked.
  *
  * @event
@@ -74,12 +74,12 @@ export interface WindowUndockedEvent {
 /**
  * @hidden
  */
-export type EventMap = WindowDockedEvent|WindowUndockedEvent;
+export type Events = WindowDockedEvent|WindowUndockedEvent;
 
 
 export function addEventListener(eventType: 'window-docked', listener: (event: WindowDockedEvent) => void): void;
 export function addEventListener(eventType: 'window-undocked', listener: (event: WindowUndockedEvent) => void): void;
-export function addEventListener<K extends EventMap>(eventType: K['type'], listener: (event: K) => void): void {
+export function addEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }
@@ -89,7 +89,7 @@ export function addEventListener<K extends EventMap>(eventType: K['type'], liste
 
 export function removeEventListener(eventType: 'window-docked', listener: (event: WindowDockedEvent) => void): void;
 export function removeEventListener(eventType: 'window-undocked', listener: (event: WindowUndockedEvent) => void): void;
-export function removeEventListener<K extends EventMap>(eventType: K['type'], listener: (event: K) => void): void {
+export function removeEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -15,7 +15,6 @@ import {getId, SnapAndDockAPI} from './internal';
  *
  * ```ts
  * import {addEventListener} from 'openfin-layouts';
- * import {WindowDockedEvent} from 'openfin-layouts/dist/client/snapanddock';
  *
  * addEventListener('window-docked', async (event: WindowDockedEvent) => {
  *     console.log("Docked to another window");
@@ -29,9 +28,9 @@ import {getId, SnapAndDockAPI} from './internal';
  *     console.log("Windows in current group: ", await fin.Window.getCurrentSync().getGroup());
  * });
  * ```
- * 
- * This event is fired when the window first becomes docked. The window will not receive an event if an additional 
- * window is added to the group later.
+ *
+ * The service considers any windows that are tabbed together to also be in the same snap group, so this event will also fire when a window is added to a tab
+ * group. This may change in future versions of the service.
  *
  * @event
  */
@@ -47,7 +46,6 @@ export interface WindowDockedEvent {
  *
  * ```ts
  * import {addEventListener} from 'openfin-layouts';
- * import {WindowUndockedEvent} from 'openfin-layouts/dist/client/snapanddock';
  *
  * addEventListener('window-undocked', async (event: WindowUndockedEvent) => {
  *     console.log("Undocked from another window");
@@ -61,9 +59,6 @@ export interface WindowDockedEvent {
  *     console.log("Windows in current group: ", await fin.Window.getCurrentSync().getGroup());
  * });
  * ```
- * 
- * This event is fired when the current window becomes undocked from a group. A window will not receive this event if 
- * another window within the same group is undocked.
  *
  * @event
  */
@@ -79,6 +74,7 @@ export type EventMap = WindowDockedEvent|WindowUndockedEvent;
 
 export function addEventListener(eventType: 'window-docked', listener: (event: WindowDockedEvent) => void): void;
 export function addEventListener(eventType: 'window-undocked', listener: (event: WindowUndockedEvent) => void): void;
+
 export function addEventListener<K extends EventMap>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -74,12 +74,12 @@ export interface WindowUndockedEvent {
 /**
  * @hidden
  */
-export type Events = WindowDockedEvent|WindowUndockedEvent;
+export type SnapAndDockEvent = WindowDockedEvent|WindowUndockedEvent;
 
 
 export function addEventListener(eventType: 'window-docked', listener: (event: WindowDockedEvent) => void): void;
 export function addEventListener(eventType: 'window-undocked', listener: (event: WindowUndockedEvent) => void): void;
-export function addEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
+export function addEventListener<K extends SnapAndDockEvent>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }
@@ -89,7 +89,7 @@ export function addEventListener<K extends Events>(eventType: K['type'], listene
 
 export function removeEventListener(eventType: 'window-docked', listener: (event: WindowDockedEvent) => void): void;
 export function removeEventListener(eventType: 'window-undocked', listener: (event: WindowUndockedEvent) => void): void;
-export function removeEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
+export function removeEventListener<K extends SnapAndDockEvent>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }

--- a/src/client/tabbing.ts
+++ b/src/client/tabbing.ts
@@ -12,8 +12,9 @@ import {WindowIdentity} from './main';
  *
  * ```ts
  * import {tabbing} from 'openfin-layouts';
+ * import {TabActivatedEvent} from 'openfin-layouts/dist/client/tabbing';
  *
- * tabbing.addEventListener('tab-activated', (event: TabGroupEvent) => {
+ * tabbing.addEventListener('tab-activated', (event: TabActivatedEvent) => {
  *     const activeTab = event.identity;
  *     console.log("Active tab:", activeTab.uuid, activeTab.name);
  * });
@@ -22,8 +23,10 @@ import {WindowIdentity} from './main';
  * @event
  */
 export interface TabActivatedEvent {
+    type: 'tab-activated';
+
     /**
-     * String that uniquely identifies the current tabset.
+     * Identity object that uniquely identifies the current tabset.
      */
     tabstripIdentity: WindowIdentity;
 
@@ -31,8 +34,6 @@ export interface TabActivatedEvent {
      * Identifies the window that is the source of the current event.
      */
     identity: WindowIdentity;
-
-    type: 'tab-activated';
 }
 
 /**
@@ -42,8 +43,9 @@ export interface TabActivatedEvent {
  *
  * ```ts
  * import {tabbing} from 'openfin-layouts';
+ * import {TabRemovedEvent} from 'openfin-layouts/dist/client/tabbing';
  *
- * tabbing.addEventListener('tab-removed', async (event: TabGroupEvent) => {
+ * tabbing.addEventListener('tab-removed', async (event: TabRemovedEvent) => {
  *     console.log("Window removed from tab group");
  * });
  * ```
@@ -53,8 +55,10 @@ export interface TabActivatedEvent {
  * @event
  */
 export interface TabRemovedEvent {
+    type: 'tab-removed';
+
     /**
-     * String that uniquely identifies the current tabset.
+     * Identity object that uniquely identifies the current tabset.
      */
     tabstripIdentity: WindowIdentity;
 
@@ -62,8 +66,6 @@ export interface TabRemovedEvent {
      * Identifies the window that is the source of the current event.
      */
     identity: WindowIdentity;
-
-    type: 'tab-removed';
 }
 
 /**
@@ -74,6 +76,7 @@ export interface TabRemovedEvent {
  *
  * ```ts
  * import {tabbing} from 'openfin-layouts';
+ * import {TabAddedEvent} from 'openfin-layouts/dist/client/tabbing';
  *
  * tabbing.addEventListener('tab-added', async (event: TabAddedEvent) => {
  *     console.log("Window added to tab group: ", event.identity);
@@ -86,8 +89,10 @@ export interface TabRemovedEvent {
  * @event
  */
 export interface TabAddedEvent {
+    type: 'tab-added';
+
     /**
-     * String that uniquely identifies the current tabset.
+     * Identity object that uniquely identifies the current tabset.
      */
     tabstripIdentity: WindowIdentity;
 
@@ -95,6 +100,7 @@ export interface TabAddedEvent {
      * Identifies the window that is the source of the current event.
      */
     identity: WindowIdentity;
+
     /**
      * The properties of the newly-added tab.
      *
@@ -109,8 +115,6 @@ export interface TabAddedEvent {
      * An integer in the range `[0, <tab count>-1]`.
      */
     index: number;
-
-    type: 'tab-added';
 }
 
 /**
@@ -120,6 +124,7 @@ export interface TabAddedEvent {
  *
  * ```ts
  * import {tabbing} from 'openfin-layouts';
+ * import {TabPropertiesUpdatedEvent} from 'openfin-layouts/dist/client/tabbing';
  *
  * tabbing.addEventListener('tab-properties-updated', (event: TabPropertiesUpdatedEvent) => {
  *     const tabIdentity = event.identity;
@@ -131,6 +136,8 @@ export interface TabAddedEvent {
  * @event
  */
 export interface TabPropertiesUpdatedEvent {
+    type: 'tab-properties-updated';
+
     /**
      * Identifies the window that is the source of the current event.
      */
@@ -143,8 +150,6 @@ export interface TabPropertiesUpdatedEvent {
      * updated in the {@link updateTabProperties} call.
      */
     properties: TabProperties;
-
-    type: 'tab-properties-updated';
 }
 
 /**
@@ -162,7 +167,7 @@ export interface TabProperties {
     /**
      * Tab title - the text that is shown on the tab widget so that a user can identify the contents of that tab.
      *
-     * This will be initialised to the 'name' of the associated window object.
+     * This will be initialised to the title of the page, or the 'name' of the associated window object if no title is defined.
      */
     title: string;
 
@@ -196,7 +201,6 @@ export function addEventListener(eventType: 'tab-added', listener: (event: TabAd
 export function addEventListener(eventType: 'tab-removed', listener: (event: TabRemovedEvent) => void): void;
 export function addEventListener(eventType: 'tab-activated', listener: (event: TabActivatedEvent) => void): void;
 export function addEventListener(eventType: 'tab-properties-updated', listener: (event: TabPropertiesUpdatedEvent) => void): void;
-
 export function addEventListener<K extends EventMap>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
@@ -327,7 +331,7 @@ export async function tabWindowToWindow(windowToAdd: Identity, targetWindow: Ide
  *
  * @param identity Identity of the window context to remove.  If no `Identity` is provided as an argument, the current window context will be used.
  * @throws `Error`: If `identity` is not a valid {@link https://developer.openfin.co/docs/javascript/stable/global.html#Identity | Identity}.
- * @throws `Error`: If `identity` is not an existing tab in a tabstrip.
+ * @throws `Error`: If `identity` refers to a window that doesn't exist, or is deregistered from the service.
  */
 export async function removeTab(identity: Identity = getId()): Promise<void> {
     return tryServiceDispatch<Identity, void>(TabAPI.REMOVETAB, parseIdentity(identity));
@@ -366,10 +370,12 @@ export async function setActiveTab(identity: Identity = getId()): Promise<void> 
  * // Closes another windows context tab.
  * tabbing.closeTab({uuid: 'App1', name: 'App1'});
  * ```
+ * 
+ * Note that the `identity` doesn't need to be tabbed for this call to take effect - so long as the window is known with the service.
  *
  * @param identity Identity of the window context to close.  If no `Identity` is provided as an argument the current window context will be used.
  * @throws `Error`: If `identity` is not a valid {@link https://developer.openfin.co/docs/javascript/stable/global.html#Identity | Identity}.
- * @throws `Error`: If `identity` is not an existing tab in a tabstrip.
+ * @throws `Error`: If `identity` refers to a window that doesn't exist, or is deregistered from the service.
  */
 export async function closeTab(identity: Identity = getId()): Promise<void> {
     return tryServiceDispatch<Identity, void>(TabAPI.CLOSETAB, parseIdentity(identity));
@@ -403,10 +409,10 @@ export async function minimizeTabGroup(identity: Identity = getId()): Promise<vo
  * ```ts
  * import {tabbing} from 'openfin-layouts';
  *
- * // Minimizes the tab group for the current window context.
+ * // Maximizes the tab group for the current window context.
  * tabbing.maxmimizeTabGroup();
  *
- * // Minimizes the tab group for another windows context.
+ * // Maximizes the tab group for another windows context.
  * tabbing.maximizeTabGroup({uuid: 'App1', name: 'App1'});
  * ```
  *
@@ -417,28 +423,6 @@ export async function minimizeTabGroup(identity: Identity = getId()): Promise<vo
  */
 export async function maximizeTabGroup(identity: Identity = getId()): Promise<void> {
     return tryServiceDispatch<Identity, void>(TabAPI.MAXIMIZETABGROUP, parseIdentity(identity));
-}
-
-/**
- * Closes the tab group for the window context.
- *
- * ```ts
- * import {tabbing} from 'openfin-layouts';
- *
- * // Closes the tab group for the current window context.
- * tabbing.closeTabGroup();
- *
- * // Closes the tab group for another windows context.
- * tabbing.closeTabGroup({uuid: 'App1', name: 'App1'});
- * ```
- *
- * @param identity Identity of the window context to close the tab group for.  If no `Identity` is provided as an argument the current window context will be
- * used.
- * @throws `Error`: If `identity` is not a valid {@link https://developer.openfin.co/docs/javascript/stable/global.html#Identity | Identity}.
- * @throws `Error`: If `identity` is not an existing tab in a tabstrip.
- */
-export async function closeTabGroup(identity: Identity = getId()): Promise<void> {
-    return tryServiceDispatch<Identity, void>(TabAPI.CLOSETABGROUP, parseIdentity(identity));
 }
 
 /**
@@ -461,6 +445,28 @@ export async function closeTabGroup(identity: Identity = getId()): Promise<void>
  */
 export async function restoreTabGroup(identity: Identity = getId()): Promise<void> {
     return tryServiceDispatch<Identity, void>(TabAPI.RESTORETABGROUP, parseIdentity(identity));
+}
+
+/**
+ * Closes the tab group for the window context.
+ *
+ * ```ts
+ * import {tabbing} from 'openfin-layouts';
+ *
+ * // Closes the tab group for the current window context.
+ * tabbing.closeTabGroup();
+ *
+ * // Closes the tab group for another windows context.
+ * tabbing.closeTabGroup({uuid: 'App1', name: 'App1'});
+ * ```
+ *
+ * @param identity Identity of the window context to close the tab group for.  If no `Identity` is provided as an argument the current window context will be
+ * used.
+ * @throws `Error`: If `identity` is not a valid {@link https://developer.openfin.co/docs/javascript/stable/global.html#Identity | Identity}.
+ * @throws `Error`: If `identity` is not an existing tab in a tabstrip.
+ */
+export async function closeTabGroup(identity: Identity = getId()): Promise<void> {
+    return tryServiceDispatch<Identity, void>(TabAPI.CLOSETABGROUP, parseIdentity(identity));
 }
 
 /**

--- a/src/client/tabbing.ts
+++ b/src/client/tabbing.ts
@@ -155,7 +155,7 @@ export interface TabPropertiesUpdatedEvent {
 /**
  * @hidden
  */
-export type EventMap = TabAddedEvent|TabRemovedEvent|TabActivatedEvent|TabPropertiesUpdatedEvent;
+export type Events = TabAddedEvent|TabRemovedEvent|TabActivatedEvent|TabPropertiesUpdatedEvent;
 
 /**
  * Represents the state of a tab within a tabstrip.
@@ -201,7 +201,7 @@ export function addEventListener(eventType: 'tab-added', listener: (event: TabAd
 export function addEventListener(eventType: 'tab-removed', listener: (event: TabRemovedEvent) => void): void;
 export function addEventListener(eventType: 'tab-activated', listener: (event: TabActivatedEvent) => void): void;
 export function addEventListener(eventType: 'tab-properties-updated', listener: (event: TabPropertiesUpdatedEvent) => void): void;
-export function addEventListener<K extends EventMap>(eventType: K['type'], listener: (event: K) => void): void {
+export function addEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }
@@ -213,7 +213,7 @@ export function removeEventListener(eventType: 'tab-added', listener: (event: Ta
 export function removeEventListener(eventType: 'tab-removed', listener: (event: TabRemovedEvent) => void): void;
 export function removeEventListener(eventType: 'tab-activated', listener: (event: TabActivatedEvent) => void): void;
 export function removeEventListener(eventType: 'tab-properties-updated', listener: (event: TabPropertiesUpdatedEvent) => void): void;
-export function removeEventListener<K extends EventMap>(eventType: K['type'], listener: (event: K) => void): void {
+export function removeEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }
@@ -370,7 +370,7 @@ export async function setActiveTab(identity: Identity = getId()): Promise<void> 
  * // Closes another windows context tab.
  * tabbing.closeTab({uuid: 'App1', name: 'App1'});
  * ```
- * 
+ *
  * Note that the `identity` doesn't need to be tabbed for this call to take effect - so long as the window is known with the service.
  *
  * @param identity Identity of the window context to close.  If no `Identity` is provided as an argument the current window context will be used.

--- a/src/client/tabbing.ts
+++ b/src/client/tabbing.ts
@@ -155,7 +155,7 @@ export interface TabPropertiesUpdatedEvent {
 /**
  * @hidden
  */
-export type Events = TabAddedEvent|TabRemovedEvent|TabActivatedEvent|TabPropertiesUpdatedEvent;
+export type TabbingEvent = TabAddedEvent|TabRemovedEvent|TabActivatedEvent|TabPropertiesUpdatedEvent;
 
 /**
  * Represents the state of a tab within a tabstrip.
@@ -201,7 +201,7 @@ export function addEventListener(eventType: 'tab-added', listener: (event: TabAd
 export function addEventListener(eventType: 'tab-removed', listener: (event: TabRemovedEvent) => void): void;
 export function addEventListener(eventType: 'tab-activated', listener: (event: TabActivatedEvent) => void): void;
 export function addEventListener(eventType: 'tab-properties-updated', listener: (event: TabPropertiesUpdatedEvent) => void): void;
-export function addEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
+export function addEventListener<K extends TabbingEvent>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }
@@ -213,7 +213,7 @@ export function removeEventListener(eventType: 'tab-added', listener: (event: Ta
 export function removeEventListener(eventType: 'tab-removed', listener: (event: TabRemovedEvent) => void): void;
 export function removeEventListener(eventType: 'tab-activated', listener: (event: TabActivatedEvent) => void): void;
 export function removeEventListener(eventType: 'tab-properties-updated', listener: (event: TabPropertiesUpdatedEvent) => void): void;
-export function removeEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
+export function removeEventListener<K extends TabbingEvent>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }

--- a/src/client/tabstrip.ts
+++ b/src/client/tabstrip.ts
@@ -6,15 +6,19 @@ import {Identity} from 'hadouken-js-adapter';
 import {eventEmitter, tryServiceDispatch} from './connection';
 import {parseIdentity, TabAPI} from './internal';
 import {WindowIdentity} from './main';
+
 /**
  * Functions required to implement a tabstrip
  */
 
 
 /**
- * Fired when a tab group is restored from being maximized or minimized..  See {@link addEventListener}.
+ * Fired when a tab group is restored back to normal state from being maximized or minimized.  See {@link addEventListener}.
  *
  * ```ts
+ * import {tabstrip} from 'openfin-layouts';
+ * import {TabGroupRestoredEvent} from 'openfin-layouts/dist/client/tabstrip';
+ *
  * tabstrip.addEventListener('tab-group-restored', (event: TabGroupRestoredEvent) => {
  *     const tabGroupID = event.identity;
  *     console.log(`Tab group restored: ${tabGroupID.uuid}/${tabGroupID.name}`);
@@ -24,12 +28,12 @@ import {WindowIdentity} from './main';
  * @event
  */
 export interface TabGroupRestoredEvent {
+    type: 'tab-group-restored';
+
     /**
      * Identifies the window that is the source of the current event.
      */
     identity: WindowIdentity;
-
-    type: 'tab-group-restored';
 }
 
 /**
@@ -37,6 +41,8 @@ export interface TabGroupRestoredEvent {
  *
  * ```ts
  * import {tabstrip} from 'openfin-layouts';
+ * import {TabGroupMinimizedEvent} from 'openfin-layouts/dist/client/tabstrip';
+ *
  *
  * tabstrip.addEventListener('tab-group-minimized', (event: TabGroupMinimizedEvent) => {
  *     const tabGroupID = event.identity;
@@ -47,12 +53,12 @@ export interface TabGroupRestoredEvent {
  * @event
  */
 export interface TabGroupMinimizedEvent {
+    type: 'tab-group-minimized';
+
     /**
      * Identifies the window that is the source of the current event.
      */
     identity: WindowIdentity;
-
-    type: 'tab-group-minimized';
 }
 
 /**
@@ -60,6 +66,8 @@ export interface TabGroupMinimizedEvent {
  *
  * ```ts
  * import {tabstrip} from 'openfin-layouts';
+ * import {TabGroupMaximizedEvent} from 'openfin-layouts/dist/client/tabstrip';
+ *
  *
  * tabstrip.addEventListener('tab-group-maximized', (event: TabGroupMaximizedEvent) => {
  *     const tabGroupID = event.identity;
@@ -70,12 +78,12 @@ export interface TabGroupMinimizedEvent {
  * @event
  */
 export interface TabGroupMaximizedEvent {
+    type: 'tab-group-maximized';
+
     /**
      * Identifies the window that is the source of the current event.
      */
     identity: WindowIdentity;
-
-    type: 'tab-group-maximized';
 }
 
 /**

--- a/src/client/tabstrip.ts
+++ b/src/client/tabstrip.ts
@@ -89,13 +89,13 @@ export interface TabGroupMaximizedEvent {
 /**
  * @hidden
  */
-export type Events = TabGroupRestoredEvent|TabGroupMinimizedEvent|TabGroupMaximizedEvent;
+export type TabstripEvent = TabGroupRestoredEvent|TabGroupMinimizedEvent|TabGroupMaximizedEvent;
 
 
 export function addEventListener(eventType: 'tab-group-restored', listener: (event: TabGroupRestoredEvent) => void): void;
 export function addEventListener(eventType: 'tab-group-minimized', listener: (event: TabGroupMinimizedEvent) => void): void;
 export function addEventListener(eventType: 'tab-group-maximized', listener: (event: TabGroupMaximizedEvent) => void): void;
-export function addEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
+export function addEventListener<K extends TabstripEvent>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }
@@ -106,7 +106,7 @@ export function addEventListener<K extends Events>(eventType: K['type'], listene
 export function removeEventListener(eventType: 'tab-group-restored', listener: (event: TabGroupRestoredEvent) => void): void;
 export function removeEventListener(eventType: 'tab-group-minimized', listener: (event: TabGroupMinimizedEvent) => void): void;
 export function removeEventListener(eventType: 'tab-group-maximized', listener: (event: TabGroupMaximizedEvent) => void): void;
-export function removeEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
+export function removeEventListener<K extends TabstripEvent>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }

--- a/src/client/tabstrip.ts
+++ b/src/client/tabstrip.ts
@@ -6,19 +6,15 @@ import {Identity} from 'hadouken-js-adapter';
 import {eventEmitter, tryServiceDispatch} from './connection';
 import {parseIdentity, TabAPI} from './internal';
 import {WindowIdentity} from './main';
-
 /**
  * Functions required to implement a tabstrip
  */
 
 
 /**
- * Fired when a tab group is restored back to normal state from being maximized or minimized.  See {@link addEventListener}.
+ * Fired when a tab group is restored from being maximized or minimized..  See {@link addEventListener}.
  *
  * ```ts
- * import {tabstrip} from 'openfin-layouts';
- * import {TabGroupRestoredEvent} from 'openfin-layouts/dist/client/tabstrip';
- *
  * tabstrip.addEventListener('tab-group-restored', (event: TabGroupRestoredEvent) => {
  *     const tabGroupID = event.identity;
  *     console.log(`Tab group restored: ${tabGroupID.uuid}/${tabGroupID.name}`);
@@ -28,12 +24,12 @@ import {WindowIdentity} from './main';
  * @event
  */
 export interface TabGroupRestoredEvent {
-    type: 'tab-group-restored';
-
     /**
      * Identifies the window that is the source of the current event.
      */
     identity: WindowIdentity;
+
+    type: 'tab-group-restored';
 }
 
 /**
@@ -41,8 +37,6 @@ export interface TabGroupRestoredEvent {
  *
  * ```ts
  * import {tabstrip} from 'openfin-layouts';
- * import {TabGroupMinimizedEvent} from 'openfin-layouts/dist/client/tabstrip';
- *
  *
  * tabstrip.addEventListener('tab-group-minimized', (event: TabGroupMinimizedEvent) => {
  *     const tabGroupID = event.identity;
@@ -53,12 +47,12 @@ export interface TabGroupRestoredEvent {
  * @event
  */
 export interface TabGroupMinimizedEvent {
-    type: 'tab-group-minimized';
-
     /**
      * Identifies the window that is the source of the current event.
      */
     identity: WindowIdentity;
+
+    type: 'tab-group-minimized';
 }
 
 /**
@@ -66,8 +60,6 @@ export interface TabGroupMinimizedEvent {
  *
  * ```ts
  * import {tabstrip} from 'openfin-layouts';
- * import {TabGroupMaximizedEvent} from 'openfin-layouts/dist/client/tabstrip';
- *
  *
  * tabstrip.addEventListener('tab-group-maximized', (event: TabGroupMaximizedEvent) => {
  *     const tabGroupID = event.identity;
@@ -78,12 +70,12 @@ export interface TabGroupMinimizedEvent {
  * @event
  */
 export interface TabGroupMaximizedEvent {
-    type: 'tab-group-maximized';
-
     /**
      * Identifies the window that is the source of the current event.
      */
     identity: WindowIdentity;
+
+    type: 'tab-group-maximized';
 }
 
 /**

--- a/src/client/tabstrip.ts
+++ b/src/client/tabstrip.ts
@@ -89,13 +89,13 @@ export interface TabGroupMaximizedEvent {
 /**
  * @hidden
  */
-export type EventMap = TabGroupRestoredEvent|TabGroupMinimizedEvent|TabGroupMaximizedEvent;
+export type Events = TabGroupRestoredEvent|TabGroupMinimizedEvent|TabGroupMaximizedEvent;
 
 
 export function addEventListener(eventType: 'tab-group-restored', listener: (event: TabGroupRestoredEvent) => void): void;
 export function addEventListener(eventType: 'tab-group-minimized', listener: (event: TabGroupMinimizedEvent) => void): void;
 export function addEventListener(eventType: 'tab-group-maximized', listener: (event: TabGroupMaximizedEvent) => void): void;
-export function addEventListener<K extends EventMap>(eventType: K['type'], listener: (event: K) => void): void {
+export function addEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }
@@ -106,7 +106,7 @@ export function addEventListener<K extends EventMap>(eventType: K['type'], liste
 export function removeEventListener(eventType: 'tab-group-restored', listener: (event: TabGroupRestoredEvent) => void): void;
 export function removeEventListener(eventType: 'tab-group-minimized', listener: (event: TabGroupMinimizedEvent) => void): void;
 export function removeEventListener(eventType: 'tab-group-maximized', listener: (event: TabGroupMaximizedEvent) => void): void;
-export function removeEventListener<K extends EventMap>(eventType: K['type'], listener: (event: K) => void): void {
+export function removeEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }

--- a/src/client/workspaces.ts
+++ b/src/client/workspaces.ts
@@ -82,8 +82,11 @@ export interface WorkspaceApp {
      *
      * This is only present if the application was started programatically. For applications started from a manifest,
      * `manifestUrl` will be present instead.
+     *
+     * The [type](http://cdn.openfin.co/jsdocs/stable/fin.desktop.Application.html#~options) of this matches the
+     * options passed to `fin.Application.create` and those returned by `Applicaiton.getOptions()`.
      */
-    initialOptions?: fin.ApplicationOptions;
+    initialOptions?: object;
 
     /**
      * The UUID of the application that initially launched this app.

--- a/src/client/workspaces.ts
+++ b/src/client/workspaces.ts
@@ -307,11 +307,11 @@ export interface WorkspaceGeneratedEvent {
 /**
  * @hidden
  */
-export type Events = WorkspaceRestoredEvent|WorkspaceGeneratedEvent;
+export type WorkspacesEvent = WorkspaceRestoredEvent|WorkspaceGeneratedEvent;
 
 export function addEventListener(eventType: 'workspace-restored', listener: (event: WorkspaceRestoredEvent) => void): void;
 export function addEventListener(eventType: 'workspace-generated', listener: (event: WorkspaceGeneratedEvent) => void): void;
-export function addEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
+export function addEventListener<K extends WorkspacesEvent>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }
@@ -321,7 +321,7 @@ export function addEventListener<K extends Events>(eventType: K['type'], listene
 
 export function removeEventListener(eventType: 'workspace-restored', listener: (event: WorkspaceRestoredEvent) => void): void;
 export function removeEventListener(eventType: 'workspace-generated', listener: (event: WorkspaceGeneratedEvent) => void): void;
-export function removeEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
+export function removeEventListener<K extends WorkspacesEvent>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }

--- a/src/client/workspaces.ts
+++ b/src/client/workspaces.ts
@@ -343,12 +343,11 @@ export async function setGenerateHandler(customDataDecorator: () => CustomData):
 /**
  * Registers a callback that will restore the application to a previous state.
  *
- * If an application has set a {@link setRestoreHandler} callback, and called the {@link ready} function, the layouts service 
- * will send it its Workspace data when the {@link restore} function is called, and wait for this function to return. If 
- * an application has saved its child windows, it *MUST* create those child windows with the same names defined in its 
- * Workspace. If this function does not return, or this function does not create the app's child windows appropriately, 
+ * If an application has set a {@link setRestoreHandler} callback, and called the {@link ready} function, the layouts service
+ * will send it its Workspace data when the {@link restore} function is called, and wait for this function to return. If
+ * an application has saved its child windows, it *MUST* create those child windows with the same names defined in its
+ * Workspace. If this function does not return, or this function does not create the app's child windows appropriately,
  * {@link restore} will hang indefinitely.
- * 
  */
 export async function setRestoreHandler(listener: (layoutApp: WorkspaceApp) => WorkspaceApp | false | Promise<WorkspaceApp|false>): Promise<boolean> {
     const channel: ChannelClient = await channelPromise;
@@ -363,11 +362,10 @@ export async function setRestoreHandler(listener: (layoutApp: WorkspaceApp) => W
  * explicitly de-registered itself from the service. It will also contain positioning, tabbing and grouping information
  * for each application. This data will be passed to {@link restore}, which will create the applications and
  * position them appropriately.
- * 
- * If an application wishes to restore its child windows and store custom data, it must properly integrate with the
- * layouts service by both registering {@link setGenerateHandler|generate} and {@link setRestoreHandler|restore} callbacks, and 
- * calling the {@link ready} function. If this is not done properly, workspace restoration may be disrupted.
  *
+ * If an application wishes to restore its child windows and store custom data, it must properly integrate with the
+ * layouts service by both registering {@link setGenerateHandler|generate} and {@link setRestoreHandler|restore} callbacks, and
+ * calling the {@link ready} function. If this is not done properly, workspace restoration may be disrupted.
  */
 export async function generate(): Promise<Workspace> {
     return tryServiceDispatch<undefined, Workspace>(WorkspaceAPI.GENERATE_LAYOUT);
@@ -377,33 +375,32 @@ export async function generate(): Promise<Workspace> {
  * Takes a Workspace object created by the {@link generate} function and restores the state of the desktop at the time it was generated
  *
  * Restoration begins by reading the Workspace object, and determining what applications and windows are running or not.
- * 
+ *
  * If an application or child window is not up and running, the layouts service will create a transparent placeholder window for it, as an
- * indication to the user that a window is in the process of loading. The placeholder window will listen for its corresponding window to 
+ * indication to the user that a window is in the process of loading. The placeholder window will listen for its corresponding window to
  * come up, and subsequently close itself.
- * 
+ *
  * Once all placeholder windows are up, the layouts service will ungroup and untab any windows participating in restoration. This is done to
- * prevent a window from dragging its group around the desktop, into a location that wasn't originally intended. Restore does not touch 
+ * prevent a window from dragging its group around the desktop, into a location that wasn't originally intended. Restore does not touch
  * any windows that were not declared in the Workspace object.
- * 
- * Once all windows are ungrouped, the layouts service will then tab together all windows involved in a tabgroup. Placeholder windows are 
+ *
+ * Once all windows are ungrouped, the layouts service will then tab together all windows involved in a tabgroup. Placeholder windows are
  * included in this tabbing step. Once a placeholder window's corresponding restored window comes up, that restored window takes
- * the place of the placeholder window in the tabset. 
- * 
+ * the place of the placeholder window in the tabset.
+ *
  * Once all groups have been set up, the layouts service will then begin opening and positioning the applications and windows.
- * 
+ *
  * If an application is up and running, the layouts service will position it in its proper place. If the application isn't running,
  * the layouts service will attempt to launch it after it has been launched. It is then positioned.
- * 
- * If the application has registered {@link setGenerateHandler|generate} and {@link setRestoreHandler|restore} callbacks, and called 
- * the {@link ready} function, the layouts service will send it its Workspace data. If an application has saved its child windows, 
+ *
+ * If the application has registered {@link setGenerateHandler|generate} and {@link setRestoreHandler|restore} callbacks, and called
+ * the {@link ready} function, the layouts service will send it its Workspace data. If an application has saved its child windows,
  * it *MUST* create those child windows with the same names defined in its Workspace. If it does not do so, {@link restore} will fail.
  *
  * Once all applications and child windows have been spun up and positioned, and all placeholder windows have been closed, the layouts
- * service will then group all windows that were formerly snapped together. 
- * 
+ * service will then group all windows that were formerly snapped together.
+ *
  * Finally, the layouts service will send a 'workspace-restored' event to all windows, and complete restoration.
- * 
  */
 export async function restore(payload: Workspace): Promise<Workspace> {
     return tryServiceDispatch<Workspace, Workspace>(WorkspaceAPI.RESTORE_LAYOUT, payload);
@@ -417,7 +414,6 @@ export async function restore(payload: Workspace): Promise<Workspace> {
  *
  * Note that by not calling this function, and workspace {@link restore} operation will hang
  * indefinitely.
- * 
  */
 export async function ready(): Promise<Workspace> {
     return tryServiceDispatch<undefined, Workspace>(WorkspaceAPI.APPLICATION_READY);

--- a/src/client/workspaces.ts
+++ b/src/client/workspaces.ts
@@ -304,11 +304,11 @@ export interface WorkspaceGeneratedEvent {
 /**
  * @hidden
  */
-export type EventMap = WorkspaceRestoredEvent|WorkspaceGeneratedEvent;
+export type Events = WorkspaceRestoredEvent|WorkspaceGeneratedEvent;
 
 export function addEventListener(eventType: 'workspace-restored', listener: (event: WorkspaceRestoredEvent) => void): void;
 export function addEventListener(eventType: 'workspace-generated', listener: (event: WorkspaceGeneratedEvent) => void): void;
-export function addEventListener<K extends EventMap>(eventType: K['type'], listener: (event: K) => void): void {
+export function addEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }
@@ -318,7 +318,7 @@ export function addEventListener<K extends EventMap>(eventType: K['type'], liste
 
 export function removeEventListener(eventType: 'workspace-restored', listener: (event: WorkspaceRestoredEvent) => void): void;
 export function removeEventListener(eventType: 'workspace-generated', listener: (event: WorkspaceGeneratedEvent) => void): void;
-export function removeEventListener<K extends EventMap>(eventType: K['type'], listener: (event: K) => void): void {
+export function removeEventListener<K extends Events>(eventType: K['type'], listener: (event: K) => void): void {
     if (typeof fin === 'undefined') {
         throw new Error('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.');
     }

--- a/src/demo/normalApp.ts
+++ b/src/demo/normalApp.ts
@@ -53,7 +53,7 @@ export async function onAppRes(layoutApp: WorkspaceApp): Promise<WorkspaceApp> {
     const openWindows = await ofApp.getChildWindows();
     const openAndPosition = layoutApp.childWindows.map(async (win: WorkspaceWindow, index: number) => {
         if (!openWindows.some((w: _Window) => w.identity.name === win.name)) {
-            await openChild(win.name, index, win.frame, win.state, win.info.url, win);
+            await openChild(win.name, index, win.frame, win.state, win.url, win.bounds);
         } else {
             await positionWindow(win);
         }
@@ -69,7 +69,7 @@ const positionWindow = async (win: WorkspaceWindow) => {
         const {isShowing, isTabbed} = win;
 
         const ofWin = await fin.Window.wrap(win);
-        await ofWin.setBounds(win);
+        await ofWin.setBounds(win.bounds);
 
         if (isTabbed) {
             await ofWin.show();

--- a/src/demo/normalApp.ts
+++ b/src/demo/normalApp.ts
@@ -53,7 +53,7 @@ export async function onAppRes(layoutApp: WorkspaceApp): Promise<WorkspaceApp> {
     const openWindows = await ofApp.getChildWindows();
     const openAndPosition = layoutApp.childWindows.map(async (win: WorkspaceWindow, index: number) => {
         if (!openWindows.some((w: _Window) => w.identity.name === win.name)) {
-            await openChild(win.name, index, win.frame, win.state, win.url, win.bounds);
+            await openChild(win.name, index, win.frame, win.state, win.info.url, win);
         } else {
             await positionWindow(win);
         }
@@ -69,7 +69,7 @@ const positionWindow = async (win: WorkspaceWindow) => {
         const {isShowing, isTabbed} = win;
 
         const ofWin = await fin.Window.wrap(win);
-        await ofWin.setBounds(win.bounds);
+        await ofWin.setBounds(win);
 
         if (isTabbed) {
             await ofWin.show();

--- a/src/demo/testbed/App.ts
+++ b/src/demo/testbed/App.ts
@@ -54,7 +54,8 @@ export class App {
 
             await Promise.all(workspace.childWindows.map(async (win: WorkspaceWindow, index: number) => {
                 if (!openWindows.some((w: _Window) => w.identity.name === win.name)) {
-                    await createWindow({id: win.name, frame: win.frame, size: {x: win.width, y: win.height}, position: {x: win.left, y: win.top}});
+                    const bounds = win.bounds;
+                    await createWindow({id: win.name, frame: win.frame, size: {x: bounds.width, y: bounds.height}, position: {x: bounds.left, y: bounds.top}});
                 } else {
                     await this.positionWindow(win);
                 }
@@ -133,7 +134,7 @@ export class App {
             const {isShowing, isTabbed} = win;
 
             const ofWin = await fin.Window.wrap(win);
-            await ofWin.setBounds(win);
+            await ofWin.setBounds(win.bounds);
 
             if (isTabbed) {
                 await ofWin.show();

--- a/src/demo/testbed/App.ts
+++ b/src/demo/testbed/App.ts
@@ -54,8 +54,7 @@ export class App {
 
             await Promise.all(workspace.childWindows.map(async (win: WorkspaceWindow, index: number) => {
                 if (!openWindows.some((w: _Window) => w.identity.name === win.name)) {
-                    const bounds = win.bounds;
-                    await createWindow({id: win.name, frame: win.frame, size: {x: bounds.width, y: bounds.height}, position: {x: bounds.left, y: bounds.top}});
+                    await createWindow({id: win.name, frame: win.frame, size: {x: win.width, y: win.height}, position: {x: win.left, y: win.top}});
                 } else {
                     await this.positionWindow(win);
                 }
@@ -134,7 +133,7 @@ export class App {
             const {isShowing, isTabbed} = win;
 
             const ofWin = await fin.Window.wrap(win);
-            await ofWin.setBounds(win.bounds);
+            await ofWin.setBounds(win);
 
             if (isTabbed) {
                 await ofWin.show();

--- a/src/demo/testbed/EventsUI.ts
+++ b/src/demo/testbed/EventsUI.ts
@@ -1,5 +1,5 @@
 
-import {Events} from '../../client/connection';
+import {LayoutsEvent} from '../../client/connection';
 
 import {Elements} from './View';
 
@@ -57,7 +57,7 @@ export class EventsUI {
             promise);
     }
 
-    public addEvent(event: Events): void {
+    public addEvent(event: LayoutsEvent): void {
         this.addItem(`Recieved Event: ${event.type}`, eLogStatus.INFO, 'bolt');
     }
 

--- a/src/demo/testbed/EventsUI.ts
+++ b/src/demo/testbed/EventsUI.ts
@@ -1,4 +1,5 @@
-import {EventMap} from '../../provider/APIMessages';
+
+import {Events} from '../../client/connection';
 
 import {Elements} from './View';
 
@@ -56,7 +57,7 @@ export class EventsUI {
             promise);
     }
 
-    public addEvent(event: EventMap): void {
+    public addEvent(event: Events): void {
         this.addItem(`Recieved Event: ${event.type}`, eLogStatus.INFO, 'bolt');
     }
 

--- a/src/provider/APIMessages.ts
+++ b/src/provider/APIMessages.ts
@@ -6,7 +6,7 @@
  *
  *
  */
-import {Events} from '../client/connection';
+import {LayoutsEvent} from '../client/connection';
 import {WorkspaceAPI} from '../client/internal';
 import {WindowIdentity} from '../client/main';
 import {WorkspaceApp} from '../client/workspaces';
@@ -19,7 +19,7 @@ export const EVENT_CHANNEL_TOPIC = 'event';
 export type MessageMap = {
     [WorkspaceAPI.RESTORE_HANDLER]: WorkspaceApp,
     [WorkspaceAPI.GENERATE_HANDLER]: WorkspaceApp,
-    [EVENT_CHANNEL_TOPIC]: Events
+    [EVENT_CHANNEL_TOPIC]: LayoutsEvent
 };
 
 export enum ErrorType {

--- a/src/provider/APIMessages.ts
+++ b/src/provider/APIMessages.ts
@@ -6,12 +6,10 @@
  *
  *
  */
+import {Events} from '../client/connection';
 import {WorkspaceAPI} from '../client/internal';
 import {WindowIdentity} from '../client/main';
-import {EventMap as SnapAndDockEventMap} from '../client/snapanddock';
-import {EventMap as TabbingEventMap} from '../client/tabbing';
-import {EventMap as TabstripEventMap} from '../client/tabstrip';
-import {EventMap as WorkspacesEventMap, WorkspaceApp} from '../client/workspaces';
+import {WorkspaceApp} from '../client/workspaces';
 
 /**
  * Sets the channel topic used to send events to the windows.  All windows which include the client will be listening to this topic name.
@@ -21,10 +19,8 @@ export const EVENT_CHANNEL_TOPIC = 'event';
 export type MessageMap = {
     [WorkspaceAPI.RESTORE_HANDLER]: WorkspaceApp,
     [WorkspaceAPI.GENERATE_HANDLER]: WorkspaceApp,
-    [EVENT_CHANNEL_TOPIC]: EventMap
+    [EVENT_CHANNEL_TOPIC]: Events
 };
-
-export type EventMap = TabstripEventMap|TabbingEventMap|WorkspacesEventMap|SnapAndDockEventMap;
 
 export enum ErrorType {
     /**

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -1,10 +1,10 @@
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
 import {Scope} from '../../../gen/provider/config/layouts-config';
+import {Events} from '../../client/connection';
 import {ApplicationUIConfig, TabActivatedEvent, TabAddedEvent, TabRemovedEvent} from '../../client/tabbing';
 import {TabGroupMaximizedEvent, TabGroupMinimizedEvent, TabGroupRestoredEvent} from '../../client/tabstrip';
 import {TabGroupDimensions, WindowState} from '../../client/workspaces';
-import {EventMap} from '../APIMessages';
 import {tabService} from '../main';
 import {Signal1} from '../Signal';
 import {Debounced} from '../snapanddock/utils/Debounced';
@@ -696,7 +696,7 @@ export class DesktopTabGroup implements DesktopEntity {
         }
     }
 
-    private async sendTabEvent(tab: DesktopWindow, event: EventMap): Promise<void> {
+    private async sendTabEvent(tab: DesktopWindow, event: Events): Promise<void> {
         await Promise.all([
             // Send event to application
             tab.sendEvent(event),

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -1,7 +1,7 @@
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
 import {Scope} from '../../../gen/provider/config/layouts-config';
-import {Events} from '../../client/connection';
+import {LayoutsEvent} from '../../client/connection';
 import {ApplicationUIConfig, TabActivatedEvent, TabAddedEvent, TabRemovedEvent} from '../../client/tabbing';
 import {TabGroupMaximizedEvent, TabGroupMinimizedEvent, TabGroupRestoredEvent} from '../../client/tabstrip';
 import {TabGroupDimensions, WindowState} from '../../client/workspaces';
@@ -696,7 +696,7 @@ export class DesktopTabGroup implements DesktopEntity {
         }
     }
 
-    private async sendTabEvent(tab: DesktopWindow, event: Events): Promise<void> {
+    private async sendTabEvent(tab: DesktopWindow, event: LayoutsEvent): Promise<void> {
         await Promise.all([
             // Send event to application
             tab.sendEvent(event),

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -3,7 +3,7 @@ import {Identity, Window} from 'hadouken-js-adapter';
 import {WindowInfo} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
 import {WindowScope} from '../../../gen/provider/config/layouts-config';
-import {Events} from '../../client/connection';
+import {LayoutsEvent} from '../../client/connection';
 import {SERVICE_IDENTITY} from '../../client/internal';
 import {WindowState} from '../../client/workspaces';
 import {EVENT_CHANNEL_TOPIC} from '../APIMessages';
@@ -658,7 +658,7 @@ export class DesktopWindow implements DesktopEntity {
             return this.updateState({[property]: value}, ActionOrigin.SERVICE);  // TODO: Is this the right origin type?
         }
     }
-    public async sendEvent<T extends Events>(event: T): Promise<void> {
+    public async sendEvent<T extends LayoutsEvent>(event: T): Promise<void> {
         if (this._ready && apiHandler.isClientConnection(this.identity)) {
             return apiHandler.sendToClient(this._identity, EVENT_CHANNEL_TOPIC, event);
         }

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -3,9 +3,10 @@ import {Identity, Window} from 'hadouken-js-adapter';
 import {WindowInfo} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
 import {WindowScope} from '../../../gen/provider/config/layouts-config';
+import {Events} from '../../client/connection';
 import {SERVICE_IDENTITY} from '../../client/internal';
 import {WindowState} from '../../client/workspaces';
-import {EVENT_CHANNEL_TOPIC, EventMap} from '../APIMessages';
+import {EVENT_CHANNEL_TOPIC} from '../APIMessages';
 import {apiHandler} from '../main';
 import {Aggregators, Signal1, Signal2} from '../Signal';
 import {Debounced} from '../snapanddock/utils/Debounced';
@@ -657,7 +658,7 @@ export class DesktopWindow implements DesktopEntity {
             return this.updateState({[property]: value}, ActionOrigin.SERVICE);  // TODO: Is this the right origin type?
         }
     }
-    public async sendEvent<T extends EventMap>(event: T): Promise<void> {
+    public async sendEvent<T extends Events>(event: T): Promise<void> {
         if (this._ready && apiHandler.isClientConnection(this.identity)) {
             return apiHandler.sendToClient(this._identity, EVENT_CHANNEL_TOPIC, event);
         }

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -1,8 +1,9 @@
 import deepEqual from 'fast-deep-equal';
+
 import {Scope, Tabstrip} from '../../../gen/provider/config/layouts-config';
+import {Events} from '../../client/connection';
 import {TabProperties, TabPropertiesUpdatedEvent} from '../../client/tabbing';
 import {TabGroup, TabGroupDimensions} from '../../client/workspaces';
-import {EventMap} from '../APIMessages';
 import {ConfigStore} from '../main';
 import {DesktopEntity} from '../model/DesktopEntity';
 import {DesktopModel} from '../model/DesktopModel';
@@ -364,7 +365,7 @@ export class TabService {
      * @param tab Modified window
      * @param event Event to send
      */
-    private sendTabEvent(tab: DesktopWindow, event: EventMap): void {
+    private sendTabEvent(tab: DesktopWindow, event: Events): void {
         tab.sendEvent(event);
         if (tab.tabGroup) {
             tab.tabGroup.window.sendEvent(event);

--- a/src/provider/tabbing/TabService.ts
+++ b/src/provider/tabbing/TabService.ts
@@ -1,7 +1,7 @@
 import deepEqual from 'fast-deep-equal';
 
 import {Scope, Tabstrip} from '../../../gen/provider/config/layouts-config';
-import {Events} from '../../client/connection';
+import {LayoutsEvent} from '../../client/connection';
 import {TabProperties, TabPropertiesUpdatedEvent} from '../../client/tabbing';
 import {TabGroup, TabGroupDimensions} from '../../client/workspaces';
 import {ConfigStore} from '../main';
@@ -365,7 +365,7 @@ export class TabService {
      * @param tab Modified window
      * @param event Event to send
      */
-    private sendTabEvent(tab: DesktopWindow, event: Events): void {
+    private sendTabEvent(tab: DesktopWindow, event: LayoutsEvent): void {
         tab.sendEvent(event);
         if (tab.tabGroup) {
             tab.tabGroup.window.sendEvent(event);

--- a/src/provider/workspaces/create.ts
+++ b/src/provider/workspaces/create.ts
@@ -1,6 +1,7 @@
 import {Window} from 'hadouken-js-adapter';
 import {ApplicationInfo} from 'hadouken-js-adapter/out/types/src/api/application/application';
 import {WindowDetail, WindowInfo as WindowInfo_System} from 'hadouken-js-adapter/out/types/src/api/system/window';
+import Bounds from 'hadouken-js-adapter/out/types/src/api/window/bounds';
 import {WindowInfo as WindowInfo_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 import {Identity} from 'hadouken-js-adapter/out/types/src/identity';
 
@@ -32,7 +33,7 @@ interface WorkspaceWindowData {
     isTabbed: boolean;
 }
 
-export const getCurrentWorkspace = async(): Promise<Workspace> => {
+export async function getCurrentWorkspace(): Promise<Workspace> {
     // Not yet using monitor info
     const monitorInfo = await fin.System.getMonitorInfo() || {};
     let tabGroups = await tabService.getTabSaveInfo();
@@ -112,10 +113,8 @@ export const getCurrentWorkspace = async(): Promise<Workspace> => {
 
             // Grab the layout information for the main app window
             const mainOfWin: Window = await ofApp.getWindow();
-            const mainWindowLayoutData = await getWorkspaceWindowData(mainOfWin, tabbedWindows);
-            const mainWindow: WorkspaceWindow = {...windowInfo.mainWindow, ...mainWindowLayoutData};
-            const mainWinIdentity = {uuid, name: mainWindow.name};
-            adjustSizeOfFormerlyTabbedWindows(mainWinIdentity, formerlyTabbedWindows, mainWindow);
+            const mainWindow: WorkspaceWindow = await getWorkspaceWindow(mainOfWin, windowInfo.mainWindow, tabbedWindows);
+            adjustSizeOfFormerlyTabbedWindows(mainWindow, formerlyTabbedWindows);
 
             // Filter for deregistered child windows
             windowInfo.childWindows = windowInfo.childWindows.filter((win: WindowDetail) => {
@@ -123,22 +122,18 @@ export const getCurrentWorkspace = async(): Promise<Workspace> => {
             });
 
             // Grab the layout information for the child windows
-            const childWindows: WorkspaceWindow[] = await promiseMap(windowInfo.childWindows, async (childWin: WindowDetail) => {
-                const {name} = childWin;
-                const childWinIdentity = {uuid, name};
+            const childWindows: WorkspaceWindow[] = await promiseMap(windowInfo.childWindows, async (childWinDetail: WindowDetail) => {
+                const childWinIdentity = {uuid, name: childWinDetail.name || uuid};
                 const ofWin = fin.Window.wrapSync(childWinIdentity);
-                const windowLayoutData = await getWorkspaceWindowData(ofWin, tabbedWindows);
-                adjustSizeOfFormerlyTabbedWindows(childWinIdentity, formerlyTabbedWindows, childWin);
+                const childWindow = await getWorkspaceWindow(ofWin, childWinDetail, tabbedWindows);
+                adjustSizeOfFormerlyTabbedWindows(childWindow, formerlyTabbedWindows);
 
-                return {...childWin, ...windowLayoutData};
+                return childWindow;
             });
             if (wasCreatedFromManifest(appInfo, uuid)) {
-                delete appInfo.manifest;
-                return {mainWindow, childWindows, ...appInfo, uuid, confirmed: false} as WorkspaceApp;
+                return {uuid, mainWindow, childWindows, confirmed: false, manifestUrl: appInfo.manifestUrl};
             } else if (canRestoreProgrammatically(appInfo)) {
-                delete appInfo.manifest;
-                delete appInfo.manifestUrl;
-                return {mainWindow, childWindows, ...appInfo, uuid, confirmed: false} as WorkspaceApp;
+                return {uuid, mainWindow, childWindows, confirmed: false, initialOptions: appInfo.initialOptions, parentUuid: appInfo.parentUuid || undefined};
             } else {
                 console.error('Not saving app, cannot restore:', windowInfo);
                 return null;
@@ -152,16 +147,16 @@ export const getCurrentWorkspace = async(): Promise<Workspace> => {
     console.log('Pre-Layout Save Apps:', apps);
     console.log('Post-Layout Valid Apps:', validApps);
 
-    const layoutObject: Workspace = {type: 'layout', schemaVersion: LAYOUTS_SCHEMA_VERSION, apps: validApps, monitorInfo, tabGroups: filteredTabGroups};
+    const layoutObject: Workspace = {type: 'workspace', schemaVersion: LAYOUTS_SCHEMA_VERSION, apps: validApps, monitorInfo, tabGroups: filteredTabGroups};
 
     const event: WorkspaceGeneratedEvent = {type: 'workspace-generated', workspace: layoutObject};
     apiHandler.sendToAll(EVENT_CHANNEL_TOPIC, event);
 
     return layoutObject;
-};
+}
 
 // No payload. Just returns the current layout with child windows.
-export const generateWorkspace = async(payload: null, identity: Identity): Promise<Workspace> => {
+export async function generateWorkspace(payload: null, identity: Identity): Promise<Workspace> {
     const preLayout = await getCurrentWorkspace();
 
     const apps = await promiseMap(preLayout.apps, async (app: WorkspaceApp) => {
@@ -188,12 +183,12 @@ export const generateWorkspace = async(payload: null, identity: Identity): Promi
 
     const confirmedLayout = {...preLayout, apps};
     return confirmedLayout;
-};
+}
 
 // Grabs all of the necessary layout information for a window. Filters by multiple criteria.
-const getWorkspaceWindowData = async(ofWin: Window, tabbedWindows: WindowObject): Promise<WorkspaceWindowData> => {
-    const {uuid} = ofWin.identity;
-    const identity: WindowIdentity = ofWin.identity as WindowIdentity;
+async function getWorkspaceWindow(ofWin: Window, windowDetail: WindowDetail, tabbedWindows: WindowObject): Promise<WorkspaceWindow> {
+    const {uuid, name} = ofWin.identity;
+    const identity: WindowIdentity = {uuid, name: name || uuid};
     const info = await ofWin.getInfo();
 
     const windowGroup = await getGroup(ofWin.identity);
@@ -217,6 +212,25 @@ const getWorkspaceWindowData = async(ofWin: Window, tabbedWindows: WindowObject)
     const isTabbed = inWindowObject(ofWin.identity, tabbedWindows) ? true : false;
 
     const state = desktopWindow.currentState.state;
+    const partialBounds: Bounds = pick(windowDetail, 'left', 'top', 'width', 'height');
+    const bounds: Required<Bounds> = {...partialBounds, right: partialBounds.left + partialBounds.width, bottom: partialBounds.top + partialBounds.height};
 
-    return {info, uuid, windowGroup: filteredWindowGroup, frame: applicationState.frame, state, isTabbed, isShowing: !applicationState.hidden};
-};
+    return {
+        ...identity,
+        url: info.url,
+        bounds,
+        windowGroup: filteredWindowGroup,
+        frame: applicationState.frame,
+        state,
+        isTabbed,
+        isShowing: !applicationState.hidden
+    };
+}
+
+function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K> {
+    const ret = {} as Pick<T, K>;
+    keys.forEach(key => {
+        ret[key] = obj[key];
+    });
+    return ret;
+}

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -7,21 +7,11 @@ import {WorkspaceApp, WorkspaceWindow} from '../../client/workspaces';
 import {model, tabService} from '../main';
 import {DesktopSnapGroup} from '../model/DesktopSnapGroup';
 import {WindowIdentity} from '../model/DesktopWindow';
-import {isWin10} from '../snapanddock/utils/platform';
 
 export interface SemVer {
     major: number;
     minor: number;
     patch: number;
-}
-
-/**
- * Partial re-declaration of 'ApplicationInfo'.
- *
- * `manifest` lacks type information, so defining the subset of manifest fields that are used by the service here.
- */
-interface AppInfo extends ApplicationInfo {
-    manifest: {startup_app: {uuid: string;};};
 }
 
 // TODO: Create Placeholder and PlaceholderStore classes?
@@ -63,7 +53,7 @@ export const positionWindow = async (win: WorkspaceWindow, replacingPlaceholder:
         const {isShowing, isTabbed} = win;
 
         const ofWin = await fin.Window.wrap(win);
-        await ofWin.setBounds(win.bounds);
+        await ofWin.setBounds(win);
 
         if (isTabbed) {
             if (replacingPlaceholder) {
@@ -166,9 +156,9 @@ export const canRestoreProgrammatically = (app: ApplicationInfo|WorkspaceApp) =>
 
 // Type here should be ApplicationInfo from the js-adapter (needs to be updated)
 export const wasCreatedFromManifest = (app: ApplicationInfo, uuid?: string) => {
-    const {manifest} = app as AppInfo;
+    const {manifest} = {...app, uuid} as AppInfo;
     const appUuid = uuid || undefined;
-    return typeof manifest === 'object' && app.manifestUrl && manifest.startup_app && manifest.startup_app.uuid === appUuid;
+    return typeof manifest === 'object' && manifest.startup_app && manifest.startup_app.uuid === appUuid;
 };
 
 export interface WindowObject {
@@ -255,27 +245,24 @@ export function parseVersionString(versionString: string): SemVer {
     return {major: Number.parseInt(match[1], 10), minor: Number.parseInt(match[2], 10), patch: Number.parseInt(match[3], 10)};
 }
 
-export function adjustSizeOfFormerlyTabbedWindows(layoutWindow: WorkspaceWindow, formerlyTabbedWindows: WindowObject) {
-    if (inWindowObject(layoutWindow, formerlyTabbedWindows)) {
-        const tabWindow = model.getWindow(layoutWindow);
+export function adjustSizeOfFormerlyTabbedWindows(
+    winIdentity: WindowIdentity, formerlyTabbedWindows: WindowObject, layoutWindow: WorkspaceWindow|WindowDetail) {
+    if (inWindowObject(winIdentity, formerlyTabbedWindows)) {
+        const tabWindow = model.getWindow(winIdentity);
         if (tabWindow) {
             const applicationState = tabWindow.applicationState;
             const tabGroup = tabWindow.tabGroup;
             if (tabGroup) {
                 const tabStripHeight = tabGroup.config.height;
-                const bounds = layoutWindow.bounds;
 
-                bounds.top = bounds.top - tabStripHeight;
-                bounds.height = bounds.height + tabStripHeight;
+                layoutWindow.top = layoutWindow.top - tabStripHeight;
+                layoutWindow.height = layoutWindow.height + tabStripHeight;
 
-                if (isWin10() && applicationState.frame === true) {
-                    bounds.left -= 7;
-                    bounds.width += 14;
-                    bounds.height += 7;
+                if (applicationState.frame === true) {
+                    layoutWindow.height = layoutWindow.height + 7;
+                    layoutWindow.left = layoutWindow.left - 7;
+                    layoutWindow.width = layoutWindow.width + 14;
                 }
-
-                bounds.right = bounds.left + bounds.width;
-                bounds.bottom = bounds.top + bounds.height;
             }
         }
     }
@@ -305,7 +292,7 @@ async function delay(milliseconds: number) {
 
 // TODO: Make placeholder windows close-able
 const createPlaceholderWindow = async (win: WorkspaceWindow) => {
-    const {height, width, left, top} = win.bounds;
+    const {height, width, left, top} = win;
 
     const placeholderName = 'Placeholder-' + Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 
@@ -328,3 +315,9 @@ const createPlaceholderWindow = async (win: WorkspaceWindow) => {
 
     return placeholderWindow;
 };
+
+interface AppInfo {
+    manifest: {startup_app: {uuid: string;};};
+    manifestUrl: string;
+    uuid: string;
+}

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -7,11 +7,21 @@ import {WorkspaceApp, WorkspaceWindow} from '../../client/workspaces';
 import {model, tabService} from '../main';
 import {DesktopSnapGroup} from '../model/DesktopSnapGroup';
 import {WindowIdentity} from '../model/DesktopWindow';
+import {isWin10} from '../snapanddock/utils/platform';
 
 export interface SemVer {
     major: number;
     minor: number;
     patch: number;
+}
+
+/**
+ * Partial re-declaration of 'ApplicationInfo'.
+ *
+ * `manifest` lacks type information, so defining the subset of manifest fields that are used by the service here.
+ */
+interface AppInfo extends ApplicationInfo {
+    manifest: {startup_app: {uuid: string;};};
 }
 
 // TODO: Create Placeholder and PlaceholderStore classes?
@@ -53,7 +63,7 @@ export const positionWindow = async (win: WorkspaceWindow, replacingPlaceholder:
         const {isShowing, isTabbed} = win;
 
         const ofWin = await fin.Window.wrap(win);
-        await ofWin.setBounds(win);
+        await ofWin.setBounds(win.bounds);
 
         if (isTabbed) {
             if (replacingPlaceholder) {
@@ -156,9 +166,9 @@ export const canRestoreProgrammatically = (app: ApplicationInfo|WorkspaceApp) =>
 
 // Type here should be ApplicationInfo from the js-adapter (needs to be updated)
 export const wasCreatedFromManifest = (app: ApplicationInfo, uuid?: string) => {
-    const {manifest} = {...app, uuid} as AppInfo;
+    const {manifest} = app as AppInfo;
     const appUuid = uuid || undefined;
-    return typeof manifest === 'object' && manifest.startup_app && manifest.startup_app.uuid === appUuid;
+    return typeof manifest === 'object' && app.manifestUrl && manifest.startup_app && manifest.startup_app.uuid === appUuid;
 };
 
 export interface WindowObject {
@@ -245,24 +255,27 @@ export function parseVersionString(versionString: string): SemVer {
     return {major: Number.parseInt(match[1], 10), minor: Number.parseInt(match[2], 10), patch: Number.parseInt(match[3], 10)};
 }
 
-export function adjustSizeOfFormerlyTabbedWindows(
-    winIdentity: WindowIdentity, formerlyTabbedWindows: WindowObject, layoutWindow: WorkspaceWindow|WindowDetail) {
-    if (inWindowObject(winIdentity, formerlyTabbedWindows)) {
-        const tabWindow = model.getWindow(winIdentity);
+export function adjustSizeOfFormerlyTabbedWindows(layoutWindow: WorkspaceWindow, formerlyTabbedWindows: WindowObject) {
+    if (inWindowObject(layoutWindow, formerlyTabbedWindows)) {
+        const tabWindow = model.getWindow(layoutWindow);
         if (tabWindow) {
             const applicationState = tabWindow.applicationState;
             const tabGroup = tabWindow.tabGroup;
             if (tabGroup) {
                 const tabStripHeight = tabGroup.config.height;
+                const bounds = layoutWindow.bounds;
 
-                layoutWindow.top = layoutWindow.top - tabStripHeight;
-                layoutWindow.height = layoutWindow.height + tabStripHeight;
+                bounds.top = bounds.top - tabStripHeight;
+                bounds.height = bounds.height + tabStripHeight;
 
-                if (applicationState.frame === true) {
-                    layoutWindow.height = layoutWindow.height + 7;
-                    layoutWindow.left = layoutWindow.left - 7;
-                    layoutWindow.width = layoutWindow.width + 14;
+                if (isWin10() && applicationState.frame === true) {
+                    bounds.left -= 7;
+                    bounds.width += 14;
+                    bounds.height += 7;
                 }
+
+                bounds.right = bounds.left + bounds.width;
+                bounds.bottom = bounds.top + bounds.height;
             }
         }
     }
@@ -292,7 +305,7 @@ async function delay(milliseconds: number) {
 
 // TODO: Make placeholder windows close-able
 const createPlaceholderWindow = async (win: WorkspaceWindow) => {
-    const {height, width, left, top} = win;
+    const {height, width, left, top} = win.bounds;
 
     const placeholderName = 'Placeholder-' + Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 
@@ -315,9 +328,3 @@ const createPlaceholderWindow = async (win: WorkspaceWindow) => {
 
     return placeholderWindow;
 };
-
-interface AppInfo {
-    manifest: {startup_app: {uuid: string;};};
-    manifestUrl: string;
-    uuid: string;
-}

--- a/src/provider/workspaces/utils.ts
+++ b/src/provider/workspaces/utils.ts
@@ -255,7 +255,7 @@ export function parseVersionString(versionString: string): SemVer {
     return {major: Number.parseInt(match[1], 10), minor: Number.parseInt(match[2], 10), patch: Number.parseInt(match[3], 10)};
 }
 
-export function adjustSizeOfFormerlyTabbedWindows(layoutWindow: WorkspaceWindow, formerlyTabbedWindows: WindowObject) {
+export function adjustSizeOfFormerlyTabbedWindows(layoutWindow: WorkspaceWindow, formerlyTabbedWindows: WindowObject): void {
     if (inWindowObject(layoutWindow, formerlyTabbedWindows)) {
         const tabWindow = model.getWindow(layoutWindow);
         if (tabWindow) {
@@ -265,8 +265,8 @@ export function adjustSizeOfFormerlyTabbedWindows(layoutWindow: WorkspaceWindow,
                 const tabStripHeight = tabGroup.config.height;
                 const bounds = layoutWindow.bounds;
 
-                bounds.top = bounds.top - tabStripHeight;
-                bounds.height = bounds.height + tabStripHeight;
+                bounds.top -= tabStripHeight;
+                bounds.height += tabStripHeight;
 
                 if (isWin10() && applicationState.frame === true) {
                     bounds.left -= 7;

--- a/test/demo/utils/workspacesUtils.ts
+++ b/test/demo/utils/workspacesUtils.ts
@@ -41,7 +41,7 @@ export async function assertWindowNotRestored(t: TestContext, uuid: string, name
 }
 
 function assertIsLayoutObject(t: TestContext, layout: Workspace) {
-    layout.type === 'workspace' ? t.pass() : t.fail('Layout object has an incorrect type!');
+    layout.type === 'layout' ? t.pass() : t.fail('Layout object has an incorrect type!');
 }
 
 async function assertAllAppsClosed(t: SaveRestoreTestContext) {

--- a/test/demo/utils/workspacesUtils.ts
+++ b/test/demo/utils/workspacesUtils.ts
@@ -41,7 +41,7 @@ export async function assertWindowNotRestored(t: TestContext, uuid: string, name
 }
 
 function assertIsLayoutObject(t: TestContext, layout: Workspace) {
-    layout.type === 'layout' ? t.pass() : t.fail('Layout object has an incorrect type!');
+    layout.type === 'workspace' ? t.pass() : t.fail('Layout object has an incorrect type!');
 }
 
 async function assertAllAppsClosed(t: SaveRestoreTestContext) {

--- a/test/demo/workspaces/schemaVersion.test.ts
+++ b/test/demo/workspaces/schemaVersion.test.ts
@@ -42,5 +42,5 @@ const layoutBase: Workspace = {
     'monitorInfo': {} as MonitorInfo,
     'schemaVersion': '',
     'tabGroups': [],
-    'type': 'layout'
+    'type': 'workspace'
 };

--- a/test/demo/workspaces/schemaVersion.test.ts
+++ b/test/demo/workspaces/schemaVersion.test.ts
@@ -42,5 +42,5 @@ const layoutBase: Workspace = {
     'monitorInfo': {} as MonitorInfo,
     'schemaVersion': '',
     'tabGroups': [],
-    'type': 'workspace'
+    'type': 'layout'
 };


### PR DESCRIPTION
Updated workspaces API docs, and some minor tweaks/clean-up elsewhere.

Some code changes to clean-up `Workspace`/`WorkspaceWindow`, and to get the service to stick to those definitions (removed some unused fields that were being added to these objects during generate calls).