### PR TITLE
[N/A] Warn when tabWindowsTogether does not result in a tabgroup

### DIFF
--- a/test/demo/tabbing/tabGroupResizeConstraints.test.ts
+++ b/test/demo/tabbing/tabGroupResizeConstraints.test.ts
@@ -94,7 +94,7 @@ testParameterized(
 
         await windows[1].resizeBy(-20, -20, 'top-left');
 
-        await tabWindowsTogether(windows[1], windows[0]);
+        await tabWindowsTogether(windows[1], windows[0], options.shouldTab);
         await delay(1000);
 
         if (options.shouldTab) {

--- a/test/demo/tabbing/tabToMaximizedWindow.test.ts
+++ b/test/demo/tabbing/tabToMaximizedWindow.test.ts
@@ -44,7 +44,7 @@ testParameterized(
             }
         } else {
             const restoredBounds: NormalizedBounds = await getBounds(windows[1]);
-            await tabWindowsTogether(windows[1], windows[0]);
+            await tabWindowsTogether(windows[1], windows[0], false);
             // Windows should not have tabbed
             await Promise.all(windows.map(win => assertNotTabbed(win, t)));
         }

--- a/test/demo/tabbing/tabToMaximizedWindow.test.ts
+++ b/test/demo/tabbing/tabToMaximizedWindow.test.ts
@@ -68,7 +68,7 @@ testParameterized(
         await windows[1].setAsForeground();
         await windows[0].setAsForeground();
 
-        await tabWindowsTogether(windows[2], windows[0]);
+        await tabWindowsTogether(windows[2], windows[0], false);
 
         // None of the windows should be tabbed
         await Promise.all(windows.map(win => assertNotTabbed(win, t)));

--- a/test/demo/utils/AppInitializer.ts
+++ b/test/demo/utils/AppInitializer.ts
@@ -115,7 +115,9 @@ export function createAppsArray(numAppsToCreate: number, numberOfChildren: numbe
 
 // A WindowGrouping is an array of array of numbers that corresponds to two windows grouped.
 // e.g. [[0, 1], [2, 3]] would mean that out of an array of 4 windows, win0 and win1 should be grouped, and win2 and win3 should be grouped.
-export type WindowGrouping = number[][];
+export type WindowGrouping = {group: number[], expectSuccess?: boolean}[];
+
+type WindowGroupingInternal = number[][];
 
 // createWindowGroupings takes a number of apps and children, and creates a 1-to-1 mapping of all combinations of apps and child windows.
 // For simplicity, we're supporting up to 4 windows right now, but this is meant to be extended.
@@ -127,11 +129,11 @@ export function createWindowGroupings(numApps: number, children: number): Window
         indexArray.push(index);
     }
 
-    return createWindowPairs(indexArray);
+    return createWindowPairs(indexArray).map(groupingInternal => groupingInternal.map(subGroupingInternal => ({group: subGroupingInternal})));
 }
 
-function createWindowPairs(windows: number[]): WindowGrouping[] {
-    const result: WindowGrouping[] = [];
+function createWindowPairs(windows: number[]): WindowGroupingInternal[] {
+    const result: WindowGroupingInternal[] = [];
     if (windows.length <= 2) {
         return [[windows]];
     } else {
@@ -199,17 +201,17 @@ export class AppInitializer {
 
     public async snapWindows(snapWindowGrouping: WindowGrouping, windows: _Window[]): Promise<void> {
         for (const group of snapWindowGrouping) {
-            const win1 = windows[group[0]];
-            const win2 = windows[group[1]];
+            const win1 = windows[group.group[0]];
+            const win2 = windows[group.group[1]];
             await dragSideToSide(win1, 'left', win2, 'right');
         }
     }
 
     public async tabWindows(tabWindowGrouping: WindowGrouping, windows: _Window[]): Promise<void> {
         for (const group of tabWindowGrouping) {
-            const win1 = windows[group[0]];
-            const win2 = windows[group[1]];
-            await tabWindowsTogether(win1, win2);
+            const win1 = windows[group.group[0]];
+            const win2 = windows[group.group[1]];
+            await tabWindowsTogether(win1, win2, group.expectSuccess !== undefined ? group.expectSuccess : true);
         }
     }
 }

--- a/test/demo/utils/AppInitializer.ts
+++ b/test/demo/utils/AppInitializer.ts
@@ -115,7 +115,10 @@ export function createAppsArray(numAppsToCreate: number, numberOfChildren: numbe
 
 // A WindowGrouping is an array of array of numbers that corresponds to two windows grouped.
 // e.g. [[0, 1], [2, 3]] would mean that out of an array of 4 windows, win0 and win1 should be grouped, and win2 and win3 should be grouped.
-export type WindowGrouping = {group: number[], expectSuccess?: boolean}[];
+export type WindowGrouping = {
+    group: number[],
+    expectSuccess?: boolean
+}[];
 
 type WindowGroupingInternal = number[][];
 

--- a/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
+++ b/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
@@ -18,7 +18,7 @@ const deregisteredManifestParentandChild =
 const combinedManifestApps = registeredManifestApp.concat(deregisteredManifestParentandChild);
 
 // First grouping includes a deregistered window. It exists to move the deregistered window out the way of the registered window underneath.
-const windowGrouping = [[3, 1], [0, 2]];
+const windowGrouping = [{group: [3, 1], expectSuccess: false}, {group: [0, 2], expectSuccess: true}];
 
 test.afterEach.always(async (t) => {
     await closeAllPreviews(t);
@@ -32,8 +32,8 @@ testParameterized<CreateAppData, AppContext>(
     createAppTest(async (t, applicationData: CreateAppData) => {
         if (applicationData.tabWindowGrouping) {
             const group = applicationData.tabWindowGrouping[1];
-            const win1 = t.context.windows[group[0]];
-            const win2 = t.context.windows[group[1]];
+            const win1 = t.context.windows[group.group[0]];
+            const win2 = t.context.windows[group.group[1]];
 
             await assertPairTabbed(win1, win2, t);
             await assertGrouped(t, win1, win2);

--- a/test/demo/workspaces/snapSaveAndRestore.test.ts
+++ b/test/demo/workspaces/snapSaveAndRestore.test.ts
@@ -51,8 +51,8 @@ testParameterized<CreateAppData, AppContext>(
         for (let index = 0; index < applicationData.snapWindowGrouping!.length; index++) {
             const group = applicationData.snapWindowGrouping![index];
 
-            const win1 = t.context.windows[group[0]];
-            const win2 = t.context.windows[group[1]];
+            const win1 = t.context.windows[group.group[0]];
+            const win2 = t.context.windows[group.group[1]];
 
             await dragWindowTo(win1, 500, ((260 * index) + 100));
             await assertAdjacent(t, win1, win2);

--- a/test/demo/workspaces/tabSaveAndRestore.test.ts
+++ b/test/demo/workspaces/tabSaveAndRestore.test.ts
@@ -48,8 +48,8 @@ testParameterized<CreateAppData, AppContext>(
         await createCloseAndRestoreLayout(t);
 
         for (const group of applicationData.tabWindowGrouping!) {
-            const win1 = t.context.windows[group[0]];
-            const win2 = t.context.windows[group[1]];
+            const win1 = t.context.windows[group.group[0]];
+            const win2 = t.context.windows[group.group[1]];
 
             await assertPairTabbed(win1, win2, t);
             await assertGrouped(t, win1, win2);

--- a/test/provider/utils/tabWindowsTogether.ts
+++ b/test/provider/utils/tabWindowsTogether.ts
@@ -5,7 +5,7 @@ import {getTabGroupID, getTabGroupIdentity} from '../../demo/utils/tabServiceUti
 import {delay} from './delay';
 import {dragWindowToOtherWindow} from './dragWindowTo';
 
-export async function tabWindowsTogether(target: _Window, windowToTab: _Window, expectSucceess: boolean = true) {
+export async function tabWindowsTogether(target: _Window, windowToTab: _Window, expectSucceess = true) {
     const isTargetTabbed: boolean = await getTabGroupIdentity(target.identity) !== null;
 
     await dragWindowToOtherWindow(windowToTab, 'top-left', target, 'top-left', {x: 10, y: isTargetTabbed ? -20 : 10});

--- a/test/provider/utils/tabWindowsTogether.ts
+++ b/test/provider/utils/tabWindowsTogether.ts
@@ -1,6 +1,6 @@
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
-import {getTabGroupIdentity} from '../../demo/utils/tabServiceUtils';
+import {getTabGroupID, getTabGroupIdentity} from '../../demo/utils/tabServiceUtils';
 
 import {delay} from './delay';
 import {dragWindowToOtherWindow} from './dragWindowTo';
@@ -10,4 +10,9 @@ export async function tabWindowsTogether(target: _Window, windowToTab: _Window) 
 
     await dragWindowToOtherWindow(windowToTab, 'top-left', target, 'top-left', {x: 10, y: isTargetTabbed ? -20 : 10});
     await delay(500);
+
+    const tabGroupID = await getTabGroupID(windowToTab.identity);
+    if (tabGroupID === null) {
+        console.warn(`Window not tabbed following tabWindowsTogether (${windowToTab.identity.uuid}/${windowToTab.identity.name})`);
+    }
 }

--- a/test/provider/utils/tabWindowsTogether.ts
+++ b/test/provider/utils/tabWindowsTogether.ts
@@ -11,8 +11,12 @@ export async function tabWindowsTogether(target: _Window, windowToTab: _Window) 
     await dragWindowToOtherWindow(windowToTab, 'top-left', target, 'top-left', {x: 10, y: isTargetTabbed ? -20 : 10});
     await delay(500);
 
-    const tabGroupID = await getTabGroupID(windowToTab.identity);
-    if (tabGroupID === null) {
-        console.warn(`Window not tabbed following tabWindowsTogether (${windowToTab.identity.uuid}/${windowToTab.identity.name})`);
+    const targetTabGroupID = await getTabGroupID(target.identity);
+    if (targetTabGroupID === null) {
+        console.warn(`Target window not tabbed following tabWindowsTogether (${target.identity.uuid}/${target.identity.name})`);
+    }
+    const windowToTabTabGroupID = await getTabGroupID(windowToTab.identity);
+    if (windowToTabTabGroupID === null) {
+        console.warn(`Window to tab not tabbed following tabWindowsTogether (${windowToTab.identity.uuid}/${windowToTab.identity.name})`);
     }
 }

--- a/test/provider/utils/tabWindowsTogether.ts
+++ b/test/provider/utils/tabWindowsTogether.ts
@@ -5,18 +5,20 @@ import {getTabGroupID, getTabGroupIdentity} from '../../demo/utils/tabServiceUti
 import {delay} from './delay';
 import {dragWindowToOtherWindow} from './dragWindowTo';
 
-export async function tabWindowsTogether(target: _Window, windowToTab: _Window) {
+export async function tabWindowsTogether(target: _Window, windowToTab: _Window, expectSucceess: boolean = true) {
     const isTargetTabbed: boolean = await getTabGroupIdentity(target.identity) !== null;
 
     await dragWindowToOtherWindow(windowToTab, 'top-left', target, 'top-left', {x: 10, y: isTargetTabbed ? -20 : 10});
     await delay(500);
 
-    const targetTabGroupID = await getTabGroupID(target.identity);
-    if (targetTabGroupID === null) {
-        console.warn(`Target window not tabbed following tabWindowsTogether (${target.identity.uuid}/${target.identity.name})`);
-    }
-    const windowToTabTabGroupID = await getTabGroupID(windowToTab.identity);
-    if (windowToTabTabGroupID === null) {
-        console.warn(`Window to tab not tabbed following tabWindowsTogether (${windowToTab.identity.uuid}/${windowToTab.identity.name})`);
+    if (expectSucceess) {
+        const targetTabGroupID = await getTabGroupID(target.identity);
+        if (targetTabGroupID === null) {
+            console.warn(`Target window not tabbed following tabWindowsTogether (${target.identity.uuid}/${target.identity.name})`);
+        }
+        const windowToTabTabGroupID = await getTabGroupID(windowToTab.identity);
+        if (windowToTabTabGroupID === null) {
+            console.warn(`Window to tab not tabbed following tabWindowsformerTogether (${windowToTab.identity.uuid}/${windowToTab.identity.name})`);
+        }
     }
 }


### PR DESCRIPTION
This seems to be the cause of a lot of our random test failures. Logging to better diagnose.

This *may* give some false positives where we don't expect the call to result in a tabgroup being created

Reviewers intentionally left blank for now