### PR TITLE
[N/A] Modify ZIndexer to reduce test failure rate

### DIFF
--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -213,9 +213,13 @@ export class ZIndexer {
         // Remove listeners when the window is destroyed
         win.addListener('closed', onClose);
 
-        // Add the window to the stack immediately, as there are rare cases where neither 'shown' nor 'focused' will be called
-        // following the 'window-created' event. See SERVICE-380
-        this.update(identity);
+        // If the window is showing, add the window to the stack immediately, as there are rare cases where neither
+        // 'shown' nor 'focused' will be called following the 'window-created' event. See SERVICE-380
+        win.isShowing().then(showing => {
+            if (showing) {
+                this.update(identity); 
+            }
+        });
     }
 
     private addToStack(entry: ZIndex): void {

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -125,7 +125,9 @@ export class ZIndexer {
 
         if (entry) {
             // Update existing entry
-            entry.timestamp = timestamp;
+            if (timestamp > entry.timestamp) {
+                entry.timestamp = timestamp;
+            }
 
             if (active !== undefined) {
                 entry.active = active;
@@ -215,8 +217,9 @@ export class ZIndexer {
 
         // If the window is showing, add the window to the stack ASAP, as there are rare cases where neither
         // 'shown' nor 'focused' will be called following the 'window-created' event. See SERVICE-380
+        const timestamp = Date.now();
         if (await win.isShowing()) {
-            this.update(identity);
+            this.update(identity, undefined, undefined, timestamp);
         }
     }
 

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -171,7 +171,7 @@ export class ZIndexer {
      * Creates window event listeners on a specified window.
      * @param win Window to add the event listeners to.
      */
-    private _addEventListeners(win: _Window) {
+    private async _addEventListeners(win: _Window) {
         const identity = win.identity as WindowIdentity;  // A window identity will always have a name, so it is safe to cast
 
         const bringToFront = () => {
@@ -213,13 +213,11 @@ export class ZIndexer {
         // Remove listeners when the window is destroyed
         win.addListener('closed', onClose);
 
-        // If the window is showing, add the window to the stack immediately, as there are rare cases where neither
+        // If the window is showing, add the window to the stack ASAP, as there are rare cases where neither
         // 'shown' nor 'focused' will be called following the 'window-created' event. See SERVICE-380
-        win.isShowing().then(showing => {
-            if (showing) {
-                this.update(identity); 
-            }
-        });
+        if  (await win.isShowing()) {
+            this.update(identity); 
+        }
     }
 
     private addToStack(entry: ZIndex): void {

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -215,8 +215,8 @@ export class ZIndexer {
 
         // If the window is showing, add the window to the stack ASAP, as there are rare cases where neither
         // 'shown' nor 'focused' will be called following the 'window-created' event. See SERVICE-380
-        if  (await win.isShowing()) {
-            this.update(identity); 
+        if (await win.isShowing()) {
+            this.update(identity);
         }
     }
 

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -79,7 +79,11 @@ export class ZIndexer {
             if (item.active) {
                 const index: number = ids.indexOf(item.id);
                 if (index >= 0) {
-                    return items[index];
+                    if (item.identity.uuid === SERVICE_IDENTITY.uuid) {
+                        console.log(`Ignoring service window in ZIndexer which would otherwise be on top`);
+                    } else {
+                        return items[index];
+                    }
                 }
             }
         }
@@ -88,6 +92,9 @@ export class ZIndexer {
     }
 
     public getWindowAt(x: number, y: number, exclusions: WindowIdentity[]): WindowIdentity|null {
+        console.log(`*** getWindowAt `, this._stack);
+
+        
         const entry: ZIndex|undefined = this._stack.find((item: ZIndex) => {
             const identity = item.identity;
 

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -82,7 +82,7 @@ export class ZIndexer {
                     if (!this.isServiceWindow(item)) {
                         return items[index];
                     } else {
-                        console.warn('Top-most window is a preview window, ignoring');
+                        console.warn('Top-most window is a service window, ignoring');
                     }
                 }
             }

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -212,6 +212,8 @@ export class ZIndexer {
 
         // Remove listeners when the window is destroyed
         win.addListener('closed', onClose);
+
+        this.update(identity);
     }
 
     private addToStack(entry: ZIndex): void {

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -127,7 +127,7 @@ export class ZIndexer {
             // Update existing entry
             if (timestamp >= entry.timestamp) {
                 entry.timestamp = timestamp;
-            
+
                 if (active !== undefined) {
                     entry.active = active;
                 }

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -79,10 +79,10 @@ export class ZIndexer {
             if (item.active) {
                 const index: number = ids.indexOf(item.id);
                 if (index >= 0) {
-                    if (item.identity.uuid === SERVICE_IDENTITY.uuid) {
-                        console.log(`Ignoring service window in ZIndexer which would otherwise be on top`);
-                    } else {
+                    if (item.identity.uuid !== SERVICE_IDENTITY.uuid) {
                         return items[index];
+                    } else {
+                        console.warn('Top-most window is a service window, ignoring');
                     }
                 }
             }
@@ -94,7 +94,7 @@ export class ZIndexer {
     public getWindowAt(x: number, y: number, exclusions: WindowIdentity[]): WindowIdentity|null {
         console.log(`*** getWindowAt `, this._stack);
 
-        
+
         const entry: ZIndex|undefined = this._stack.find((item: ZIndex) => {
             const identity = item.identity;
 
@@ -142,7 +142,7 @@ export class ZIndexer {
                     Object.assign(entry.bounds, bounds);
                 }
             } else {
-                console.warn('Rejecting update due to earlier timestamp');
+                console.warn('Out of order update attempted in ZIndexer, rejecting');
             }
         } else if (!bounds) {
             // Must request bounds before being able to add

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -213,6 +213,8 @@ export class ZIndexer {
         // Remove listeners when the window is destroyed
         win.addListener('closed', onClose);
 
+        // Add the window to the stack immediately, as there are rare cases where neither 'shown' nor 'focused' will be called
+        // following the 'window-created' event. See SERVICE-380
         this.update(identity);
     }
 

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -134,6 +134,8 @@ export class ZIndexer {
                 if (bounds) {
                     Object.assign(entry.bounds, bounds);
                 }
+            } else {
+                console.warn("Rejecting update due to earlier timestamp");
             }
         } else if (!bounds) {
             // Must request bounds before being able to add

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -125,15 +125,15 @@ export class ZIndexer {
 
         if (entry) {
             // Update existing entry
-            if (timestamp > entry.timestamp) {
+            if (timestamp >= entry.timestamp) {
                 entry.timestamp = timestamp;
-            }
-
-            if (active !== undefined) {
-                entry.active = active;
-            }
-            if (bounds) {
-                Object.assign(entry.bounds, bounds);
+            
+                if (active !== undefined) {
+                    entry.active = active;
+                }
+                if (bounds) {
+                    Object.assign(entry.bounds, bounds);
+                }
             }
         } else if (!bounds) {
             // Must request bounds before being able to add

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -142,7 +142,7 @@ export class ZIndexer {
                     Object.assign(entry.bounds, bounds);
                 }
             } else {
-                console.warn("Rejecting update due to earlier timestamp");
+                console.warn('Rejecting update due to earlier timestamp');
             }
         } else if (!bounds) {
             // Must request bounds before being able to add

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -128,6 +128,10 @@ export class ZIndexer {
         const entry: ZIndex|undefined = this._stack.find(i => i.id === id);
 
         if (entry) {
+            if (timestamp < entry.timestamp) {
+                console.warn('Out of order update in ZIndexer');
+            }
+
             // Update existing entry
             entry.timestamp = timestamp;
 

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -263,7 +263,7 @@ export class ZIndexer {
         return (item as ObjectWithIdentity).identity !== undefined;
     }
 
-    private isPreviewWindow(item : ZIndex) {
+    private isPreviewWindow(item: ZIndex) {
         if (item.identity.uuid === SERVICE_IDENTITY.uuid) {
             const name = item.identity.name;
 

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -79,10 +79,10 @@ export class ZIndexer {
             if (item.active) {
                 const index: number = ids.indexOf(item.id);
                 if (index >= 0) {
-                    if (item.identity.uuid !== SERVICE_IDENTITY.uuid) {
+                    if (!this.isPreviewWindow(item)) {
                         return items[index];
                     } else {
-                        console.warn('Top-most window is a service window, ignoring');
+                        console.warn('Top-most window is a preview window, ignoring');
                     }
                 }
             }
@@ -264,5 +264,15 @@ export class ZIndexer {
 
     private hasIdentity(item: Identifiable): item is ObjectWithIdentity {
         return (item as ObjectWithIdentity).identity !== undefined;
+    }
+
+    private isPreviewWindow(item : ZIndex) {
+        if (item.identity.uuid === SERVICE_IDENTITY.uuid) {
+            const name = item.identity.name;
+
+            return name === 'successPreview' || name === 'failurePreview';
+        } else {
+            return false;
+        }
     }
 }

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -92,9 +92,6 @@ export class ZIndexer {
     }
 
     public getWindowAt(x: number, y: number, exclusions: WindowIdentity[]): WindowIdentity|null {
-        console.log(`*** getWindowAt `, this._stack);
-
-
         const entry: ZIndex|undefined = this._stack.find((item: ZIndex) => {
             const identity = item.identity;
 

--- a/test/demo/tabbing/tabGroupResizeConstraints.test.ts
+++ b/test/demo/tabbing/tabGroupResizeConstraints.test.ts
@@ -94,7 +94,7 @@ testParameterized(
 
         await windows[1].resizeBy(-20, -20, 'top-left');
 
-        await tabWindowsTogether(windows[1], windows[0]);
+        await tabWindowsTogether(windows[1], windows[0], options.shouldTab);
         await delay(1000);
 
         if (options.shouldTab) {

--- a/test/demo/tabbing/tabToMaximizedWindow.test.ts
+++ b/test/demo/tabbing/tabToMaximizedWindow.test.ts
@@ -44,7 +44,7 @@ testParameterized(
             }
         } else {
             const restoredBounds: NormalizedBounds = await getBounds(windows[1]);
-            await tabWindowsTogether(windows[1], windows[0]);
+            await tabWindowsTogether(windows[1], windows[0], false);
             // Windows should not have tabbed
             await Promise.all(windows.map(win => assertNotTabbed(win, t)));
         }
@@ -68,7 +68,7 @@ testParameterized(
         await windows[1].setAsForeground();
         await windows[0].setAsForeground();
 
-        await tabWindowsTogether(windows[2], windows[0]);
+        await tabWindowsTogether(windows[2], windows[0], false);
 
         // None of the windows should be tabbed
         await Promise.all(windows.map(win => assertNotTabbed(win, t)));

--- a/test/demo/utils/AppInitializer.ts
+++ b/test/demo/utils/AppInitializer.ts
@@ -115,7 +115,12 @@ export function createAppsArray(numAppsToCreate: number, numberOfChildren: numbe
 
 // A WindowGrouping is an array of array of numbers that corresponds to two windows grouped.
 // e.g. [[0, 1], [2, 3]] would mean that out of an array of 4 windows, win0 and win1 should be grouped, and win2 and win3 should be grouped.
-export type WindowGrouping = number[][];
+export type WindowGrouping = {
+    group: number[],
+    expectSuccess?: boolean
+}[];
+
+type WindowGroupingInternal = number[][];
 
 // createWindowGroupings takes a number of apps and children, and creates a 1-to-1 mapping of all combinations of apps and child windows.
 // For simplicity, we're supporting up to 4 windows right now, but this is meant to be extended.
@@ -127,11 +132,11 @@ export function createWindowGroupings(numApps: number, children: number): Window
         indexArray.push(index);
     }
 
-    return createWindowPairs(indexArray);
+    return createWindowPairs(indexArray).map(groupingInternal => groupingInternal.map(subGroupingInternal => ({group: subGroupingInternal})));
 }
 
-function createWindowPairs(windows: number[]): WindowGrouping[] {
-    const result: WindowGrouping[] = [];
+function createWindowPairs(windows: number[]): WindowGroupingInternal[] {
+    const result: WindowGroupingInternal[] = [];
     if (windows.length <= 2) {
         return [[windows]];
     } else {
@@ -199,17 +204,17 @@ export class AppInitializer {
 
     public async snapWindows(snapWindowGrouping: WindowGrouping, windows: _Window[]): Promise<void> {
         for (const group of snapWindowGrouping) {
-            const win1 = windows[group[0]];
-            const win2 = windows[group[1]];
+            const win1 = windows[group.group[0]];
+            const win2 = windows[group.group[1]];
             await dragSideToSide(win1, 'left', win2, 'right');
         }
     }
 
     public async tabWindows(tabWindowGrouping: WindowGrouping, windows: _Window[]): Promise<void> {
         for (const group of tabWindowGrouping) {
-            const win1 = windows[group[0]];
-            const win2 = windows[group[1]];
-            await tabWindowsTogether(win1, win2);
+            const win1 = windows[group.group[0]];
+            const win2 = windows[group.group[1]];
+            await tabWindowsTogether(win1, win2, group.expectSuccess !== undefined ? group.expectSuccess : true);
         }
     }
 }

--- a/test/demo/utils/AppInitializer.ts
+++ b/test/demo/utils/AppInitializer.ts
@@ -120,8 +120,6 @@ export type WindowGrouping = {
     expectSuccess?: boolean
 }[];
 
-type WindowGroupingInternal = number[][];
-
 // createWindowGroupings takes a number of apps and children, and creates a 1-to-1 mapping of all combinations of apps and child windows.
 // For simplicity, we're supporting up to 4 windows right now, but this is meant to be extended.
 export function createWindowGroupings(numApps: number, children: number): WindowGrouping[] {
@@ -132,13 +130,13 @@ export function createWindowGroupings(numApps: number, children: number): Window
         indexArray.push(index);
     }
 
-    return createWindowPairs(indexArray).map(groupingInternal => groupingInternal.map(subGroupingInternal => ({group: subGroupingInternal})));
+    return createWindowPairs(indexArray);
 }
 
-function createWindowPairs(windows: number[]): WindowGroupingInternal[] {
-    const result: WindowGroupingInternal[] = [];
+function createWindowPairs(windows: number[]): WindowGrouping[] {
+    const result: WindowGrouping[] = [];
     if (windows.length <= 2) {
-        return [[windows]];
+        return [[{group: windows}]];
     } else {
         const a = windows[0];
         for (let index = 1; index < windows.length; index++) {
@@ -148,7 +146,7 @@ function createWindowPairs(windows: number[]): WindowGroupingInternal[] {
 
             const subCombinations = createWindowPairs(newArray);
             subCombinations.forEach(subCombo => {
-                result.push([pair].concat(subCombo));
+                result.push([{group: pair}].concat(subCombo));
             });
         }
     }
@@ -203,18 +201,18 @@ export class AppInitializer {
     }
 
     public async snapWindows(snapWindowGrouping: WindowGrouping, windows: _Window[]): Promise<void> {
-        for (const group of snapWindowGrouping) {
-            const win1 = windows[group.group[0]];
-            const win2 = windows[group.group[1]];
+        for (const grouping of snapWindowGrouping) {
+            const win1 = windows[grouping.group[0]];
+            const win2 = windows[grouping.group[1]];
             await dragSideToSide(win1, 'left', win2, 'right');
         }
     }
 
     public async tabWindows(tabWindowGrouping: WindowGrouping, windows: _Window[]): Promise<void> {
-        for (const group of tabWindowGrouping) {
-            const win1 = windows[group.group[0]];
-            const win2 = windows[group.group[1]];
-            await tabWindowsTogether(win1, win2, group.expectSuccess !== undefined ? group.expectSuccess : true);
+        for (const grouping of tabWindowGrouping) {
+            const win1 = windows[grouping.group[0]];
+            const win2 = windows[grouping.group[1]];
+            await tabWindowsTogether(win1, win2, grouping.expectSuccess !== undefined ? grouping.expectSuccess : true);
         }
     }
 }

--- a/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
+++ b/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
@@ -31,9 +31,9 @@ testParameterized<CreateAppData, AppContext>(
     [{apps: combinedProgrammaticApps, tabWindowGrouping: windowGrouping}, {apps: combinedManifestApps, tabWindowGrouping: windowGrouping}],
     createAppTest(async (t, applicationData: CreateAppData) => {
         if (applicationData.tabWindowGrouping) {
-            const group = applicationData.tabWindowGrouping[1];
-            const win1 = t.context.windows[group.group[0]];
-            const win2 = t.context.windows[group.group[1]];
+            const grouping = applicationData.tabWindowGrouping[1];
+            const win1 = t.context.windows[grouping.group[0]];
+            const win2 = t.context.windows[grouping.group[1]];
 
             await assertPairTabbed(win1, win2, t);
             await assertGrouped(t, win1, win2);

--- a/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
+++ b/test/demo/workspaces/formerTabGroupRestoreResize.test.ts
@@ -18,7 +18,7 @@ const deregisteredManifestParentandChild =
 const combinedManifestApps = registeredManifestApp.concat(deregisteredManifestParentandChild);
 
 // First grouping includes a deregistered window. It exists to move the deregistered window out the way of the registered window underneath.
-const windowGrouping = [[3, 1], [0, 2]];
+const windowGrouping = [{group: [3, 1], expectSuccess: false}, {group: [0, 2], expectSuccess: true}];
 
 test.afterEach.always(async (t) => {
     await closeAllPreviews(t);
@@ -32,8 +32,8 @@ testParameterized<CreateAppData, AppContext>(
     createAppTest(async (t, applicationData: CreateAppData) => {
         if (applicationData.tabWindowGrouping) {
             const group = applicationData.tabWindowGrouping[1];
-            const win1 = t.context.windows[group[0]];
-            const win2 = t.context.windows[group[1]];
+            const win1 = t.context.windows[group.group[0]];
+            const win2 = t.context.windows[group.group[1]];
 
             await assertPairTabbed(win1, win2, t);
             await assertGrouped(t, win1, win2);

--- a/test/demo/workspaces/snapSaveAndRestore.test.ts
+++ b/test/demo/workspaces/snapSaveAndRestore.test.ts
@@ -49,10 +49,10 @@ testParameterized<CreateAppData, AppContext>(
         await createCloseAndRestoreLayout(t);
 
         for (let index = 0; index < applicationData.snapWindowGrouping!.length; index++) {
-            const group = applicationData.snapWindowGrouping![index];
+            const grouping = applicationData.snapWindowGrouping![index];
 
-            const win1 = t.context.windows[group.group[0]];
-            const win2 = t.context.windows[group.group[1]];
+            const win1 = t.context.windows[grouping.group[0]];
+            const win2 = t.context.windows[grouping.group[1]];
 
             await dragWindowTo(win1, 500, ((260 * index) + 100));
             await assertAdjacent(t, win1, win2);

--- a/test/demo/workspaces/snapSaveAndRestore.test.ts
+++ b/test/demo/workspaces/snapSaveAndRestore.test.ts
@@ -51,8 +51,8 @@ testParameterized<CreateAppData, AppContext>(
         for (let index = 0; index < applicationData.snapWindowGrouping!.length; index++) {
             const group = applicationData.snapWindowGrouping![index];
 
-            const win1 = t.context.windows[group[0]];
-            const win2 = t.context.windows[group[1]];
+            const win1 = t.context.windows[group.group[0]];
+            const win2 = t.context.windows[group.group[1]];
 
             await dragWindowTo(win1, 500, ((260 * index) + 100));
             await assertAdjacent(t, win1, win2);

--- a/test/demo/workspaces/tabSaveAndRestore.test.ts
+++ b/test/demo/workspaces/tabSaveAndRestore.test.ts
@@ -47,9 +47,9 @@ testParameterized<CreateAppData, AppContext>(
     createAppTest(async (t, applicationData: CreateAppData) => {
         await createCloseAndRestoreLayout(t);
 
-        for (const group of applicationData.tabWindowGrouping!) {
-            const win1 = t.context.windows[group.group[0]];
-            const win2 = t.context.windows[group.group[1]];
+        for (const grouping of applicationData.tabWindowGrouping!) {
+            const win1 = t.context.windows[grouping.group[0]];
+            const win2 = t.context.windows[grouping.group[1]];
 
             await assertPairTabbed(win1, win2, t);
             await assertGrouped(t, win1, win2);

--- a/test/demo/workspaces/tabSaveAndRestore.test.ts
+++ b/test/demo/workspaces/tabSaveAndRestore.test.ts
@@ -48,8 +48,8 @@ testParameterized<CreateAppData, AppContext>(
         await createCloseAndRestoreLayout(t);
 
         for (const group of applicationData.tabWindowGrouping!) {
-            const win1 = t.context.windows[group[0]];
-            const win2 = t.context.windows[group[1]];
+            const win1 = t.context.windows[group.group[0]];
+            const win2 = t.context.windows[group.group[1]];
 
             await assertPairTabbed(win1, win2, t);
             await assertGrouped(t, win1, win2);

--- a/test/provider/utils/tabWindowsTogether.ts
+++ b/test/provider/utils/tabWindowsTogether.ts
@@ -13,12 +13,11 @@ export async function tabWindowsTogether(target: _Window, windowToTab: _Window, 
 
     if (expectSucceess) {
         const targetTabGroupID = await getTabGroupID(target.identity);
-        if (targetTabGroupID === null) {
-            console.warn(`Target window not tabbed following tabWindowsTogether (${target.identity.uuid}/${target.identity.name})`);
-        }
         const windowToTabTabGroupID = await getTabGroupID(windowToTab.identity);
-        if (windowToTabTabGroupID === null) {
-            console.warn(`Window to tab not tabbed following tabWindowsformerTogether (${windowToTab.identity.uuid}/${windowToTab.identity.name})`);
+
+        if (targetTabGroupID === null || windowToTabTabGroupID == null || (targetTabGroupID !== windowToTabTabGroupID)) {
+            console.warn(`Windows not tabbed following tabWindowsTogether. Target window: ${target.identity.uuid}/${target.identity.name}, ${
+                targetTabGroupID}. Window to tab: ${windowToTab.identity.uuid}/${windowToTab.identity.name}, ${windowToTabTabGroupID}`);
         }
     }
 }

--- a/test/provider/utils/tabWindowsTogether.ts
+++ b/test/provider/utils/tabWindowsTogether.ts
@@ -1,13 +1,24 @@
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
-import {getTabGroupIdentity} from '../../demo/utils/tabServiceUtils';
+import {getTabGroupID, getTabGroupIdentity} from '../../demo/utils/tabServiceUtils';
 
 import {delay} from './delay';
 import {dragWindowToOtherWindow} from './dragWindowTo';
 
-export async function tabWindowsTogether(target: _Window, windowToTab: _Window) {
+export async function tabWindowsTogether(target: _Window, windowToTab: _Window, expectSucceess = true) {
     const isTargetTabbed: boolean = await getTabGroupIdentity(target.identity) !== null;
 
     await dragWindowToOtherWindow(windowToTab, 'top-left', target, 'top-left', {x: 10, y: isTargetTabbed ? -20 : 10});
     await delay(500);
+
+    if (expectSucceess) {
+        const targetTabGroupID = await getTabGroupID(target.identity);
+        if (targetTabGroupID === null) {
+            console.warn(`Target window not tabbed following tabWindowsTogether (${target.identity.uuid}/${target.identity.name})`);
+        }
+        const windowToTabTabGroupID = await getTabGroupID(windowToTab.identity);
+        if (windowToTabTabGroupID === null) {
+            console.warn(`Window to tab not tabbed following tabWindowsformerTogether (${windowToTab.identity.uuid}/${windowToTab.identity.name})`);
+        }
+    }
 }


### PR DESCRIPTION
This partially addresses SERVICE-380, but does leave some so-far unexplained random test failures remaining.

Many of the random test failures were caused by `tabWindowsTogether` not resulting in windows being tabbed together, which was ultimately caused by `ZIndexer` occasionally not properly tracking an OF window.

I also saw some cases locally where the topmost window in the stack would be the preview window, which seemed to be another cause of test failures, but I've been unable to confirm this occured on Jenkins.

This PR
- Adds logging to `tabWindowsTogether` so we can track when it does not work as expected. That is complicated by the fact that occasionally we do not expect `tabWindowsTogether` to actually tab windows together
- Changes `ZIndexer` to add windows to the stack ASAP upon creation, rather than waiting for that window's first `shown` or `focused` event.
- Changes to `ZIndexer` to filter service windows from both `getTopMost` and `getWindowAt`

