### PR TITLE
[SERVICE-384] Prevent reattachment of a DesktopWindow that no longer exists

### DIFF
--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -442,8 +442,10 @@ export class DesktopTabGroup implements DesktopEntity {
                 // the other snapped windows.
                 // TODO (SERVICE-311): Investigate how to properly harden against these issues
                 await new Promise(res => setTimeout(res, 10));
-                console.log('Re-attaching remaining tab: ' + remainingTab.id + ' => ' + joinedSnappable.id);
-                await remainingTab.setSnapGroup(joinedSnappable.snapGroup);
+                if (remainingTab.isReady) {
+                    console.log('Re-attaching remaining tab: ' + remainingTab.id + ' => ' + joinedSnappable.id);
+                    await remainingTab.setSnapGroup(joinedSnappable.snapGroup);
+                }
             }
         }
     }

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -764,10 +764,10 @@ export class DesktopWindow implements DesktopEntity {
                         // Bring other windows in group to front
                         await windows.map(groupWindow => {
                             // Checks to make sure the window actually exists before bringing it to front. Fix for SERVICE-384
-                            if (groupWindow._window && groupWindow._window.bringToFront) {
+                            if (groupWindow.isReady) {
                                 groupWindow._window.bringToFront();
                             } else {
-                                console.warn("groupWindow._window.bringToFront called with a nonexistent window: ", groupWindow);
+                                console.warn("groupWindow is not ready. You may have a nonexistent window in your snapGroup: ", groupWindow);
                             }
                         });
                     }

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -762,7 +762,14 @@ export class DesktopWindow implements DesktopEntity {
                         const windows: DesktopWindow[] = this._snapGroup.windows as DesktopWindow[];
 
                         // Bring other windows in group to front
-                        await windows.map(groupWindow => groupWindow._window.bringToFront());
+                        await windows.map(groupWindow => {
+                            // Checks to make sure the window actually exists before bringing it to front. Fix for SERVICE-384
+                            if (groupWindow._window && groupWindow._window.bringToFront) {
+                                groupWindow._window.bringToFront();
+                            } else {
+                                console.warn("groupWindow._window.bringToFront called with a nonexistent window: ", groupWindow);
+                            }
+                        });
                     }
                 })();
 


### PR DESCRIPTION
Original bug was calling `bringToFront` on windows that do not exist, which threw the error `bringToFront is not a function`. The bug was caused by reattachment of a DesktopWindow that doesn't exist (when closing out a TabSet that is snapped to other windows).

I added a check to the reattachment code to only attach the DesktopWindow if it is `ready`. Is that the most dependable call to know if a window exists? Would we be better served adding the `ready` check in `setSnapGroup` instead?

Same goes for the `bringToFront` check. Should we use the `ready` check there instead?