### PR TITLE
[SERVICE-383] Tabbing to a window with a declared state of 'maximized' in its app.json will end up maximizing the TabSet

### DIFF
--- a/res/demo/testbed/index.html
+++ b/res/demo/testbed/index.html
@@ -156,6 +156,15 @@
                                 </select>
                             </div>
                         </div>
+                        <div class="row"><label for="inputState" class="col-sm-3 col-form-label">State</label>
+                            <div class="col-sm-9">
+                                <select id="inputState" class="form-control-sm">
+                                    <option value="normal" selected>Normal</option>
+                                    <option value="minimized">Minimized</option>
+                                    <option value="maximized">Maximized</option>
+                                </select>
+                            </div>
+                        </div>
                         <div class="row">
                             <label for="inputSize" class="col-sm-3 col-form-label">Window Size</label>
                             <div class="col-sm-6 col-lg-7 pr-sm-1">

--- a/scripts/server/spawn.js
+++ b/scripts/server/spawn.js
@@ -12,7 +12,7 @@ const {PORT, CDN_LOCATION} = require('./config');
 function createCustomManifestMiddleware() {
     return async (req, res, next) => {
         const defaultConfig = await readJsonFile(path.resolve('res/demo/app.json')).catch(next);
-        const {uuid, url, frame, defaultCentered, defaultLeft, defaultTop, defaultWidth, defaultHeight, realmName, enableMesh, runtime, useService, provider, config} = {
+        const {uuid, url, frame, defaultCentered, defaultLeft, defaultTop, defaultWidth, defaultHeight, realmName, enableMesh, runtime, useService, provider, state, config} = {
             // Set default values
             uuid: `demo-app-${Math.random().toString(36).substr(2, 4)}`,
             url: `http://localhost:${PORT}/demo/testbed/index.html`,
@@ -40,6 +40,7 @@ function createCustomManifestMiddleware() {
                 name: uuid,
                 url,
                 frame,
+                state,
                 autoShow: true,
                 saveWindowState: false,
                 defaultCentered,

--- a/src/demo/spawn.ts
+++ b/src/demo/spawn.ts
@@ -69,6 +69,11 @@ export interface WindowData {
      * If not specified, the calling window will create the app/window directly.
      */
     parent?: Identity;
+
+    /**
+     * State of the window. Defaults to normal.
+     */
+    state?: 'normal'|'minimized'|'maximized';
 }
 
 /**
@@ -160,12 +165,13 @@ async function createApplication(options: Omit<AppData, 'parent'>): Promise<Appl
     const url = getUrl(options);
     const position = getWindowPosition(options);
     const size = getWindowSize(options);
+    const state = options.state || 'normal';
 
     if (options.type === 'programmatic') {
         const data: fin.ApplicationOptions = {
             uuid,
             name: uuid,
-            mainWindowOptions: {...position, url, frame: options.frame, autoShow: true, saveWindowState: false, defaultWidth: size.x, defaultHeight: size.y}
+            mainWindowOptions: {...position, url, frame: options.frame, state, autoShow: true, saveWindowState: false, defaultWidth: size.x, defaultHeight: size.y, }
         };
         return await startApp(fin.Application.create(data));
     } else {
@@ -173,6 +179,7 @@ async function createApplication(options: Omit<AppData, 'parent'>): Promise<Appl
             ...position as Required<typeof position>,
             uuid,
             url,
+            state,
             defaultWidth: size.x,
             defaultHeight: size.y,
             frame: options.frame || false,

--- a/src/demo/spawn.ts
+++ b/src/demo/spawn.ts
@@ -171,7 +171,16 @@ async function createApplication(options: Omit<AppData, 'parent'>): Promise<Appl
         const data: fin.ApplicationOptions = {
             uuid,
             name: uuid,
-            mainWindowOptions: {...position, url, frame: options.frame, state, autoShow: true, saveWindowState: false, defaultWidth: size.x, defaultHeight: size.y, }
+            mainWindowOptions: {
+                ...position,
+                url,
+                frame: options.frame,
+                state,
+                autoShow: true,
+                saveWindowState: false,
+                defaultWidth: size.x,
+                defaultHeight: size.y,
+            }
         };
         return await startApp(fin.Application.create(data));
     } else {

--- a/src/demo/testbed/View.ts
+++ b/src/demo/testbed/View.ts
@@ -40,6 +40,7 @@ export interface Elements {
     inputURL: HTMLInputElement;
     inputSection: HTMLSelectElement;
     inputFrame: HTMLSelectElement;
+    inputState: HTMLSelectElement;
     inputSize: HTMLSelectElement;
     inputSizeRandomize: HTMLSelectElement;
     inputUseService: HTMLSelectElement;
@@ -116,6 +117,7 @@ export class View {
             inputURL: document.getElementById('inputURL') as HTMLInputElement,
             inputSection: document.getElementById('inputSection') as HTMLSelectElement,
             inputFrame: document.getElementById('inputFrame') as HTMLSelectElement,
+            inputState: document.getElementById('inputState') as HTMLSelectElement,
             inputSize: document.getElementById('inputSize') as HTMLSelectElement,
             inputSizeRandomize: document.getElementById('inputSizeRandomize') as HTMLSelectElement,
             inputUseService: document.getElementById('inputUseService') as HTMLSelectElement,

--- a/src/demo/testbed/WindowsUI.ts
+++ b/src/demo/testbed/WindowsUI.ts
@@ -80,6 +80,7 @@ export class WindowsUI {
             url: elements.inputURL,
             queryArgs: elements.inputSection,
             frame: elements.inputFrame,
+            state: elements.inputState,
             size: elements.inputSize,
             sizeOffset: elements.inputSizeRandomize,
             useService: elements.inputUseService,
@@ -93,6 +94,7 @@ export class WindowsUI {
             url: elements.inputURL,
             queryArgs: elements.inputSection,
             frame: elements.inputFrame,
+            state: elements.inputState,
             size: elements.inputSize,
             sizeOffset: elements.inputSizeRandomize,
             parent: elements.inputParent

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -116,12 +116,13 @@ export class DesktopWindow implements DesktopEntity {
     public static activeTransactions: Transaction[] = [];
 
     public static async getWindowState(window: Window): Promise<EntityState> {
-        return Promise.all([window.getOptions(), window.getInfo(), window.isShowing(), window.getBounds()])
-            .then((results: [fin.WindowOptions, WindowInfo, boolean, fin.WindowBounds]): EntityState => {
+        return Promise.all([window.getOptions(), window.getState(), window.getInfo(), window.isShowing(), window.getBounds()])
+            .then((results: [fin.WindowOptions, string, WindowInfo, boolean, fin.WindowBounds]): EntityState => {
                 const options: fin.WindowOptions = results[0];
-                const info: WindowInfo = results[1];
-                const isShowing: boolean = results[2];
-                const bounds: fin.WindowBounds = results[3];
+                const state: WindowState = results[1] as WindowState;
+                const info: WindowInfo = results[2];
+                const isShowing: boolean = results[3];
+                const bounds: fin.WindowBounds = results[4];
                 const halfSize: Point = {x: bounds.width / 2, y: bounds.height / 2};
                 const center: Point = {x: bounds.left + halfSize.x, y: bounds.top + halfSize.y};
 
@@ -183,7 +184,7 @@ export class DesktopWindow implements DesktopEntity {
                     resizeConstraints,
                     frame: options.frame!,
                     hidden: !isShowing,
-                    state: options.state!,
+                    state,
                     icon: options.icon || `https://www.google.com/s2/favicons?domain=${options.url}`,
                     title: windowTitle,
                     showTaskbarIcon: options.showTaskbarIcon!,


### PR DESCRIPTION
The PR incorporates @MichaelMCoates's changes to make it easier to bring up a maximized app.

The bug is fixed by having DesktopWindow.getWindowState() call window.getState(), rather than relying on window.getOptions().state, which seems to give stale data