### PR TITLE
[SERVICE-365] Allow tabstrip maximise/restore by double-clicking an empty portion of the tabstrip window

### DIFF
--- a/res/demo/tabstrips/custom1.css
+++ b/res/demo/tabstrips/custom1.css
@@ -55,7 +55,6 @@ body {
 	justify-content: space-between;
 	margin-left: -15px;
 	min-width: 72px;
-	-webkit-app-region: no-drag;
 }
 
 
@@ -173,7 +172,6 @@ body {
 	display: flex;
 	align-items: center;
 	z-index: 15;
-	-webkit-app-region: no-drag;
 }
 
 #window-button-wrap div {
@@ -220,10 +218,6 @@ body {
 	background-color: rgba(0, 0, 0, 0.3);
 }
 
-.drag {
-	-webkit-app-region: drag;
-}
-
 #drag-region {
 	position: absolute;
 	top:2px;
@@ -231,6 +225,7 @@ body {
 	height:calc(100% - 8px);
 	width:calc(100% - 8px);
 	z-index: 1;
+	-webkit-user-select: none;
 }
 
 #drag-shield {
@@ -241,7 +236,6 @@ body {
 	width:calc(100% - 8px);
 	display: none;
 	z-index:5;
-	-webkit-app-region: no-drag;
 }
 
 .preview {

--- a/res/demo/tabstrips/custom1.css
+++ b/res/demo/tabstrips/custom1.css
@@ -27,6 +27,7 @@ body {
 	width: 100%;
 	height: 28px;
 	display: flex;
+	pointer-events: none;
 }
 
 #tabs .tab:first-child {
@@ -45,6 +46,7 @@ body {
 	margin-right: 15px;
 	overflow: scroll;
 	z-index: 15;
+	pointer-events: none;
 }
 
 .tab {
@@ -55,6 +57,7 @@ body {
 	justify-content: space-between;
 	margin-left: -15px;
 	min-width: 72px;
+	pointer-events: auto;
 }
 
 

--- a/res/demo/tabstrips/custom1.html
+++ b/res/demo/tabstrips/custom1.html
@@ -5,7 +5,7 @@
 </head>
 
 <body>
-    <div id="drag-region" class="drag"></div>
+    <div id="drag-region"></div>
     <div id="tabs-container">
         <div id="tabs">
         </div>

--- a/res/demo/tabstrips/custom2.css
+++ b/res/demo/tabstrips/custom2.css
@@ -26,6 +26,7 @@ body {
 	width: 100%;
 	height: 28px;
 	display: flex;
+	pointer-events: none;
 }
 
 #tabs .tab:first-child {
@@ -44,6 +45,7 @@ body {
 	margin-right: 15px;
 	overflow: scroll;
 	z-index: 15;
+	pointer-events: none;
 }
 
 .tab {
@@ -54,6 +56,7 @@ body {
 	justify-content: space-between;
 	margin-left: -15px;
 	min-width: 72px;
+	pointer-events: auto;
 }
 
 

--- a/res/demo/tabstrips/custom2.css
+++ b/res/demo/tabstrips/custom2.css
@@ -54,7 +54,6 @@ body {
 	justify-content: space-between;
 	margin-left: -15px;
 	min-width: 72px;
-	-webkit-app-region: no-drag;
 }
 
 
@@ -171,7 +170,6 @@ body {
 	display: flex;
 	align-items: center;
 	z-index: 15;
-	-webkit-app-region: no-drag;
 }
 
 #window-button-wrap div {
@@ -218,10 +216,6 @@ body {
 	background-color: rgba(0, 0, 0, 0.3);
 }
 
-.drag {
-	-webkit-app-region: drag;
-}
-
 #drag-region {
 	position: absolute;
 	top:2px;
@@ -229,6 +223,7 @@ body {
 	height:calc(100% - 8px);
 	width:calc(100% - 8px);
 	z-index: 1;
+	-webkit-user-select: none;
 }
 
 #drag-shield {
@@ -239,7 +234,6 @@ body {
 	width:calc(100% - 8px);
 	display: none;
 	z-index:5;
-	-webkit-app-region: no-drag;
 }
 
 .preview {

--- a/res/demo/tabstrips/custom2.html
+++ b/res/demo/tabstrips/custom2.html
@@ -5,7 +5,7 @@
 </head>
 
 <body>
-    <div id="drag-region" class="drag"></div>
+    <div id="drag-region"></div>
     <div id="tabs-container">
         <div id="tabs">
         </div>

--- a/res/provider/tabbing/tabstrip/css/tabs.css
+++ b/res/provider/tabbing/tabstrip/css/tabs.css
@@ -28,6 +28,7 @@ body {
 	height: 28px;
 	display: flex;
 	margin: 0 20;
+	pointer-events: none;
 }
 
 #tabs-container {
@@ -38,6 +39,7 @@ body {
 	margin-right: 15px;
 	overflow: scroll;
 	z-index: 15;
+	pointer-events: none;
 }
 
 .tab {
@@ -48,6 +50,7 @@ body {
 	justify-content: space-between;
 	margin: 0 -7px;
 	min-width: 72px;
+	pointer-events: auto;
 }
 
 

--- a/res/provider/tabbing/tabstrip/css/tabs.css
+++ b/res/provider/tabbing/tabstrip/css/tabs.css
@@ -48,7 +48,6 @@ body {
 	justify-content: space-between;
 	margin: 0 -7px;
 	min-width: 72px;
-	-webkit-app-region: no-drag;
 }
 
 
@@ -174,7 +173,6 @@ body {
 	display: flex;
 	align-items: center;
 	z-index: 15;
-	-webkit-app-region: no-drag;
 }
 
 #window-button-wrap div {
@@ -218,7 +216,6 @@ body {
 	background-color: rgba(0, 0, 0, 0.3);
 }
 
-
 #drag-region {
 	position: absolute;
 	top:2px;
@@ -226,5 +223,5 @@ body {
 	height:calc(100% - 8px);
 	width:calc(100% - 8px);
 	z-index: 1;
-	-webkit-app-region: drag;
+	-webkit-user-select: none;
 }

--- a/src/provider/tabbing/tabstrip/main.ts
+++ b/src/provider/tabbing/tabstrip/main.ts
@@ -113,7 +113,7 @@ const createWindowUIListeners = () => {
         }
     };
 
-    dragElem.onmouseup = () => {
+    window.onmouseup = () => {
         if (dragAnimationFrameRequestID) {
             cancelAnimationFrame(dragAnimationFrameRequestID);
             dragAnimationFrameRequestID = undefined;

--- a/src/provider/tabbing/tabstrip/main.ts
+++ b/src/provider/tabbing/tabstrip/main.ts
@@ -139,6 +139,5 @@ const updateBoundsFromDragging = async (startMousePosition: PointTopLeft, startB
     });
 };
 
-
 createLayoutsEventListeners();
 createWindowUIListeners();

--- a/src/provider/tabbing/tabstrip/main.ts
+++ b/src/provider/tabbing/tabstrip/main.ts
@@ -133,10 +133,12 @@ const updateBoundsFromDragging = async (startMousePosition: PointTopLeft, startB
 
     const bounds = {left, top, width, height};
 
-    ofWindow.setBounds(bounds);
-    dragAnimationFrameRequestID = requestAnimationFrame(async () => {
-        await updateBoundsFromDragging(startMousePosition, startBounds, ofWindow);
-    });
+    await ofWindow.setBounds(bounds);
+    if (dragAnimationFrameRequestID !== undefined) {
+        dragAnimationFrameRequestID = requestAnimationFrame(async () => {
+            await updateBoundsFromDragging(startMousePosition, startBounds, ofWindow);
+        });
+    }
 };
 
 createLayoutsEventListeners();


### PR DESCRIPTION
**Edit: Not ready for review. Discovered issue where this approach breaks snapping for tabgroups**

Previously we used the `webkit-app-region: drag` CSS attribute to allow users to drag the tabstrip window. However, this swallowed all other DOM mouse events¹, preventing us from listening for the double click event.

To solve this, this PR removes the use of `webkit-app-region: drag`, and instead listens for mouse up and down events, and moves the window around using the OpenFin API. This also allows us to easily prevent dragging while the tabstrip is maximized, as a stopgap solution until we can address SERVICE-369.

One downside of this approach is that we lose the context menu with move, maximize, minimize, etc. options that came for free with `webkit-app-region: drag`. We also lose "shake window to clear desktop" on this window, and any other OS-level feature than came or will come for free with `webkit-app-region: drag`.

¹ https://github.com/electron/electron/issues/1354 (I've tried the solution suggested in the last comment, but it did not appear to work)