### PR TITLE
[N/A] Fix for error when running unit tests on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
                 stage('Unit Tests') {
                     agent { label 'linux-slave' }
                     steps {
-                        sh "npm i"
+                        sh "npm i --ignore-scripts"
                         sh "npm run test:unit -- --color=false --reporters=default --reporters=jest-junit"
                         sh "npm run check"
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
                     agent { label 'linux-slave' }
                     steps {
                         sh "npm i --ignore-scripts"
+                        sh "npm run generate"
                         sh "npm run test:unit -- --color=false --reporters=default --reporters=jest-junit"
                         sh "npm run check"
                     }


### PR DESCRIPTION
Skips robotjs install, since the VM this runs on isn't setup with the robotjs dependencies.