### PR TITLE
[SERVICE-401] Fix "unhandled promise rejection" errors when including client from non-OpenFin contexts

### DIFF
--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -41,24 +41,33 @@ export const eventEmitter = new EventEmitter();
 /**
  * Promise to the channel object that allows us to connect to the client
  */
-export const channelPromise: Promise<ChannelClient> = typeof fin === 'undefined' ?
-    Promise.reject('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.') :
-    fin.InterApplicationBus.Channel.connect(SERVICE_CHANNEL, {payload: {version: PACKAGE_VERSION}}).then((channel: ChannelClient) => {
-        // Register service listeners
-        channel.register('WARN', (payload: any) => console.warn(payload));  // tslint:disable-line:no-any
-        channel.register('event', (event: LayoutsEvent) => {
-            eventEmitter.emit(event.type, event);
-        });
-        // Any unregistered action will simply return false
-        channel.setDefaultAction(() => false);
 
-        return channel;
-    });
+let channelPromise: Promise<ChannelClient>|null = (typeof fin !== 'undefined') ? getServicePromise() : null;
+
+export function getServicePromise(): Promise<ChannelClient> {
+    if (!channelPromise) {
+        channelPromise = typeof fin === 'undefined' ?
+            Promise.reject('fin is not defined. The openfin-layouts module is only intended for use in an OpenFin application.') :
+            fin.InterApplicationBus.Channel.connect(SERVICE_CHANNEL, {payload: {version: PACKAGE_VERSION}}).then((channel: ChannelClient) => {
+                // Register service listeners
+                channel.register('WARN', (payload: any) => console.warn(payload));  // tslint:disable-line:no-any
+                channel.register('event', (event: LayoutsEvent) => {
+                    eventEmitter.emit(event.type, event);
+                });
+                // Any unregistered action will simply return false
+                channel.setDefaultAction(() => false);
+
+                return channel;
+            });
+    }
+
+    return channelPromise;
+}
 
 /**
  * Wrapper around service.dispatch to help with type checking
  */
 export async function tryServiceDispatch<T, R>(action: APITopic, payload?: T): Promise<R> {
-    const channel: ChannelClient = await channelPromise;
+    const channel: ChannelClient = await getServicePromise();
     return channel.dispatch(action, payload) as Promise<R>;
 }

--- a/src/client/workspaces.ts
+++ b/src/client/workspaces.ts
@@ -6,7 +6,7 @@ import {ChannelClient} from 'hadouken-js-adapter/out/types/src/api/interappbus/c
 import {MonitorInfo} from 'hadouken-js-adapter/out/types/src/api/system/monitor';
 import Bounds from 'hadouken-js-adapter/out/types/src/api/window/bounds';
 
-import {channelPromise, eventEmitter, tryServiceDispatch} from './connection';
+import {eventEmitter, getServicePromise, tryServiceDispatch} from './connection';
 import {WorkspaceAPI} from './internal';
 import {WindowIdentity} from './main';
 import {ApplicationUIConfig} from './tabbing';
@@ -336,7 +336,7 @@ export function removeEventListener<K extends WorkspacesEvent>(eventType: K['typ
  * will be saved as the workspace's `customData` property for this app within the generated {@link Workspace}.
  */
 export async function setGenerateHandler(customDataDecorator: () => CustomData): Promise<boolean> {
-    const channel: ChannelClient = await channelPromise;
+    const channel: ChannelClient = await getServicePromise();
     return channel.register(WorkspaceAPI.GENERATE_HANDLER, customDataDecorator);
 }
 
@@ -359,7 +359,7 @@ export async function setGenerateHandler(customDataDecorator: () => CustomData):
  *
  */
 export async function setRestoreHandler(listener: (workspaceApp: WorkspaceApp) => WorkspaceApp | false | Promise<WorkspaceApp|false>): Promise<boolean> {
-    const channel: ChannelClient = await channelPromise;
+    const channel: ChannelClient = await getServicePromise();
     return channel.register(WorkspaceAPI.RESTORE_HANDLER, listener);
 }
 


### PR DESCRIPTION
Phil's implementation. After a lot of messing around, couldn't figure out a way to optimize it further. 

Essentially fetches the channel client from a function instead of an awaited promise.