### PR TITLE
[SERVICE-423] Renamed global variable created by non-module client

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ The client library is also available as a resource which can be included via `<s
 ```
    <script src="https://cdn.openfin/services/openfin/layouts/<VERSION>/openfin-layouts.js"></script>
 ```
-This will expose the global variable `OpenFinLayouts` with the API methods documented in the link below.  Example:
+This will expose the global variable `layouts` with the API methods documented in the link below.  Example:
 ```
-   OpenFinLayouts.snapAndDock.undockWindow();
+   layouts.snapAndDock.undockWindow();
 ```
 
 The client module exports a set of functions - [API docs available here](https://cdn.openfin.co/docs/services/layouts/stable/api/).

--- a/res/demo/libScriptIncluded.html
+++ b/res/demo/libScriptIncluded.html
@@ -15,6 +15,6 @@
         });
     </script>
     
-    <p>Openfin Layouts Library is included via script tag in this window.  Accessible with global var OpenfinLayouts</p>
+    <p>Openfin Layouts Library is included via script tag in this window.  Accessible with global var 'layouts'</p>
 </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,8 +39,8 @@ const schemaTypesPlugin = new SchemaToTypeScriptPlugin({
 });
 
 module.exports = [
-    webpackTools.createConfig(`${outputDir}/client`, './src/client/main.ts', {minify: false, isLibrary: true, libraryName: 'OpenFinLayouts'}, webpackTools.versionPlugin),
-    webpackTools.createConfig(`${outputDir}/client`, './src/client/main.ts', {minify: true, isLibrary: true, libraryName: 'OpenFinLayouts', outputFilename: "openfin-layouts"}, webpackTools.versionPlugin),
+    webpackTools.createConfig(`${outputDir}/client`, './src/client/main.ts', {minify: false, isLibrary: true, libraryName: 'layouts'}, webpackTools.versionPlugin),
+    webpackTools.createConfig(`${outputDir}/client`, './src/client/main.ts', {minify: true, isLibrary: true, libraryName: 'layouts', outputFilename: "openfin-layouts"}, webpackTools.versionPlugin),
     webpackTools.createConfig(`${outputDir}/provider`, {
         main: './src/provider/main.ts',
         tabStrip: './src/provider/tabbing/tabstrip/main.ts',


### PR DESCRIPTION
Renamed from `OpenFinLayouts` global variable to `layouts`.

This is to align with the same change made in FDC3, and to make this version of the client less clunky to use.

See https://github.com/HadoukenIO/fdc3-service/pull/30.