### PR TITLE
[N/A] Demonstrate behaviour when resizing window on drag

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:dev": "svc-tools build -- --mode development",
     "generate": "node scripts/generateCode.js",
     "zip": "svc-tools zip",
-    "start": "svc-tools start"
+    "start": "svc-tools start -- -r 9.61.38.41"
   },
   "keywords": [],
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR demonstrates what currently happens when we try to resize a window while it is being dragged by the user. Different approaches can be tried by commenting out various changes in this PR. Having this behave well is a prerequisite for SERVICE-369 - https://appoji.jira.com/browse/SERVICE-369

To try this PR, start the demo app, open any window (say, click 'Deafult Tab UI') and then drag the window. What we should see is the window being resized to 550x550, anchored on the top left, as it is being dragged. What we see in practice, regardless of approach, is 'fighting' over the size of the window as it is being dragged. 