### PR TITLE
[SERVICE-447]/[SERVICE-449] Unable to tab windows/Windows in snap group with resize constraints grow rapidly when dragged

### DIFF
--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -37,6 +37,7 @@ export class DesktopModel {
     private _zIndexer: ZIndexer;
     private _mouseTracker: MouseTracker;
     private _monitors: Rectangle[];
+    private _displayScaling: boolean;
 
     constructor(config: ConfigStore) {
         this._windows = [];
@@ -46,6 +47,7 @@ export class DesktopModel {
         this._zIndexer = new ZIndexer(this);
         this._mouseTracker = new MouseTracker();
         this._monitors = [];
+        this._displayScaling = false;
 
         DesktopWindow.onCreated.add(this.onWindowCreated, this);
         DesktopWindow.onDestroyed.add(this.onWindowDestroyed, this);
@@ -93,6 +95,7 @@ export class DesktopModel {
         // Validate everything on monitor change, as groups may become disjointed
         fin.System.addListener('monitor-info-changed', async (evt: MonitorEvent<'system', 'monitor-info-changed'>) => {
             this._monitors = [evt.primaryMonitor, ...evt.nonPrimaryMonitors].map(mon => RectUtils.convertToCenterHalfSize(mon.monitorRect));
+            this._displayScaling = evt.deviceScaleFactor !== 1;
 
             // Validate all tabgroups
             this.tabGroups.map(g => g.validate());
@@ -104,6 +107,7 @@ export class DesktopModel {
         // Get and store the current monitors
         fin.System.getMonitorInfo().then((monitorInfo: MonitorInfo) => {
             this._monitors = [monitorInfo.primaryMonitor, ...monitorInfo.nonPrimaryMonitors].map(mon => RectUtils.convertToCenterHalfSize(mon.availableRect));
+            this._displayScaling = monitorInfo.deviceScaleFactor !== 1;
         });
     }
 
@@ -129,6 +133,10 @@ export class DesktopModel {
 
     public get monitors(): ReadonlyArray<Rectangle> {
         return this._monitors;
+    }
+
+    public get displayScaling(): boolean {
+        return this._displayScaling;
     }
 
     /**

--- a/src/provider/model/DesktopSnapGroup.ts
+++ b/src/provider/model/DesktopSnapGroup.ts
@@ -78,14 +78,14 @@ export class DesktopSnapGroup {
 
     private _validateGroup: Debounced<() => void, DesktopSnapGroup, []>;
 
-    private _resizeConstraintsOverridden: boolean;
+    private _resizeConstraintsSuspended: boolean;
 
     constructor() {
         this._id = DesktopSnapGroup._nextId++;
         this._entities = [];
         this._windows = [];
         this.rootWindow = null;
-        this._resizeConstraintsOverridden = false;
+        this._resizeConstraintsSuspended = false;
 
         const refreshFunc = this.calculateProperties.bind(this);
         this._localBounds = new CalculatedProperty<Rectangle>(refreshFunc);
@@ -189,17 +189,17 @@ export class DesktopSnapGroup {
      * scaling is enabled
      */
     public suspendResizeConstraints(): void {
-        if (this._windows.length > 1 && !this._resizeConstraintsOverridden) {
+        if (this._windows.length > 1 && !this._resizeConstraintsSuspended) {
             const nullConstraint: ResizeConstraint = {resizableMin: true, resizableMax: true, minSize: 0, maxSize: Number.MAX_SAFE_INTEGER};
             const nullConstraints: Point<ResizeConstraint> = {x: nullConstraint, y: nullConstraint};
 
-            this._resizeConstraintsOverridden = true;
+            this._resizeConstraintsSuspended = true;
 
             for (const window of this._windows) {
                 // We refresh here, otherwise we may not know about constraint changes made by the app via the runtime API, which
                 // would prevent applyOverride properly unsetting them
                 window.refresh().then(() => {
-                    if (this._resizeConstraintsOverridden) {
+                    if (this._resizeConstraintsSuspended) {
                         window.applyOverride('resizeConstraints', nullConstraints);
                     }
                 });
@@ -208,12 +208,12 @@ export class DesktopSnapGroup {
     }
 
     public restoreResizeConstraints(): void {
-        if (this._resizeConstraintsOverridden) {
+        if (this._resizeConstraintsSuspended) {
             for (const window of this._windows) {
                 window.resetOverride('resizeConstraints');
             }
 
-            this._resizeConstraintsOverridden = false;
+            this._resizeConstraintsSuspended = false;
         }
     }
 

--- a/src/provider/model/DesktopSnapGroup.ts
+++ b/src/provider/model/DesktopSnapGroup.ts
@@ -189,7 +189,7 @@ export class DesktopSnapGroup {
      * scaling is enabled
      */
     public suspendResizeConstraints(): void {
-        if (this._windows.length > 2) {
+        if (this._windows.length > 2 && !this._storedResizeConstraints) {
             const nullConstraint: ResizeConstraint = {resizableMin: true, resizableMax: true, minSize: 0, maxSize: Number.MAX_SAFE_INTEGER};
             const nullConstraints: Point<ResizeConstraint> = {x: nullConstraint, y: nullConstraint};
 
@@ -208,6 +208,7 @@ export class DesktopSnapGroup {
             for (const window of this._windows) {
                 if (this._storedResizeConstraints.has(window.id)) {
                     const constraints = this._storedResizeConstraints.get(window.id)!;
+
                     window.applyProperties({resizeConstraints: constraints});
                 }
             }

--- a/src/provider/model/DesktopSnapGroup.ts
+++ b/src/provider/model/DesktopSnapGroup.ts
@@ -277,7 +277,7 @@ export class DesktopSnapGroup {
                 // If a window is not visible it cannot be adjacent to anything. This also allows us
                 // to avoid the questionable position tracking for hidden windows.
                 return false;
-            } else if (distance.border(2) && Math.abs(distance.maxAbs) > MIN_OVERLAP) {
+            } else if (distance.border(0) && Math.abs(distance.maxAbs) > MIN_OVERLAP) {
                 // The overlap check ensures that only valid snap configurations are counted
                 return true;
             }

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -204,9 +204,12 @@ export class DesktopTabGroup implements DesktopEntity {
              * rather than taking the earlier approach of just moving the active tab and relying on grouping and resize constraints to make
              * everything work as expected. We particularly run into this race condition when snapping a tabgroup to another window
              */
-            return DesktopWindow.transaction([this.activeTab, this._window], async (windows) => {
-                await windows[0].applyOffset(offset, activeTabHalfSize);
-                await windows[1].applyOffset(offset, tabstripHalfSize);
+            return DesktopWindow.transaction([this._window, ...this.tabs], async (windows) => {
+                await this._window.applyOffset(offset, tabstripHalfSize);
+
+                for (const tab of this.tabs) {
+                    await tab.applyOffset(offset, activeTabHalfSize);
+                }
             });
         } else {
             return this.activeTab.applyOffset(offset, activeTabHalfSize);

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -192,8 +192,20 @@ export class DesktopTabGroup implements DesktopEntity {
 
     public async applyOffset(offset: Point, halfSize?: Point): Promise<void> {
         const tabstripHalfHeight: number = this._config.height / 2;
-        const adjustedHalfSize: Point|undefined = halfSize && {x: halfSize.x, y: halfSize.y - tabstripHalfHeight};
-        return this.activeTab.applyOffset(offset, adjustedHalfSize);
+
+        const activeTabHalfSize: Point|undefined = halfSize && {x: halfSize.x, y: halfSize.y - tabstripHalfHeight};
+        const tabstripHalfSize: Point|undefined = halfSize && {x: halfSize.x, y: tabstripHalfHeight};
+
+        /**
+         * We can't depend on the tabstrip having the appropriate resize constraints at this point, due to a race condition with our
+         * mitigations for display scaling issues in DesktopSnapGroup, so we manually move both the active tab, and the tabstrip itself,
+         * rather than taking the earlier approach of just moving the active tab and relying on grouping and resize constraints to make
+         * everything work as expected. We particularly run into this race condition when snapping a tabgroup to another window
+         */
+        await DesktopWindow.transaction([this.activeTab, this._window], async (windows) => {
+            await windows[0].applyOffset(offset, activeTabHalfSize);
+            await windows[1].applyOffset(offset, tabstripHalfSize);
+        });
     }
 
     /**

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1129,7 +1129,7 @@ export class DesktopWindow implements DesktopEntity {
             evaluateAxis('x');
             evaluateAxis('y');
 
-            const newTransformType = boundsChange.confirmedTransformType | eTransformType.MOVE;
+            const newTransformType = boundsChange.confirmedTransformType;
 
             if (newTransformType === eTransformType.MOVE && prevTransformType !== eTransformType.MOVE) {
                 this._snapGroup.restoreResizeConstraints();

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1080,14 +1080,21 @@ export class DesktopWindow implements DesktopEntity {
 
             const startBounds = boundsChange.startBounds;
 
-            if (Math.abs(startBounds.halfSize.x - halfSize.x) > MINIMUM_RESIZE_CHANGE ||
-                Math.abs(startBounds.halfSize.y - halfSize.y) > MINIMUM_RESIZE_CHANGE) {
-                boundsChange.confirmedTransformType |= eTransformType.RESIZE;
-            }
+            const leftEdgeChanged = Math.abs((center.x - halfSize.x) - (startBounds.center.x - startBounds.halfSize.x)) > MINIMUM_RESIZE_CHANGE;
+            const rightEdgeChanged = Math.abs((center.x + halfSize.x) - (startBounds.center.x + startBounds.halfSize.x)) > MINIMUM_RESIZE_CHANGE;
+            const topEdgeChanged = Math.abs((center.y - halfSize.y) - (startBounds.center.y - startBounds.halfSize.y)) > MINIMUM_RESIZE_CHANGE;
+            const bottomEdgeChanged = Math.abs((center.y + halfSize.y) - (startBounds.center.y + startBounds.halfSize.y)) > MINIMUM_RESIZE_CHANGE;
 
-            if (Math.abs(startBounds.center.x - center.x) > MINIMUM_MOVE_CHANGE ||
-                Math.abs(startBounds.center.y - center.y) > MINIMUM_MOVE_CHANGE) {
-                boundsChange.confirmedTransformType |= eTransformType.MOVE;
+            const allEdgesChanged = leftEdgeChanged && rightEdgeChanged && topEdgeChanged && bottomEdgeChanged;
+            const anyEdgesChanged = leftEdgeChanged || rightEdgeChanged || topEdgeChanged || bottomEdgeChanged;
+
+            if (anyEdgesChanged) {
+                if ((Math.abs(center.x - startBounds.center.x) > MINIMUM_MOVE_CHANGE ||
+                     Math.abs(center.y - startBounds.center.y) > MINIMUM_MOVE_CHANGE) && allEdgesChanged) {
+                    boundsChange.confirmedTransformType |= eTransformType.MOVE;
+                } else {
+                    boundsChange.confirmedTransformType |= eTransformType.RESIZE;
+                }
             }
 
             if (boundsChange.confirmedTransformType !== 0) {

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1119,6 +1119,7 @@ export class DesktopWindow implements DesktopEntity {
             boundsChange.transformType |= evaluateAxis('x');
             boundsChange.transformType |= evaluateAxis('y');
 
+            // Err on the side of regarding transforms as purely moves
             if ((boundsChange.transformType & eTransformType.MOVE)) {
                 boundsChange.transformType = eTransformType.MOVE;
             }

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -69,7 +69,7 @@ export enum eTransformType {
 }
 
 interface BoundsChange {
-    confirmedTransformType: Mask<eTransformType>;
+    transformType: Mask<eTransformType>;
     startBounds: Rectangle;
 }
 
@@ -1086,7 +1086,7 @@ export class DesktopWindow implements DesktopEntity {
     private updateTransformType(event: fin.WindowBoundsEvent, boundsChange: BoundsChange): Mask<eTransformType> {
         // If display scaling is enabled, distrust the changeType given by the runtime
         if (this._model.displayScaling) {
-            const prevTransformType = boundsChange.confirmedTransformType || eTransformType.MOVE;
+            const prevTransformType = boundsChange.transformType || eTransformType.MOVE;
 
             const startBounds = boundsChange.startBounds;
 
@@ -1115,18 +1115,18 @@ export class DesktopWindow implements DesktopEntity {
                 }
 
                 if (move) {
-                    boundsChange.confirmedTransformType |= eTransformType.MOVE;
+                    boundsChange.transformType |= eTransformType.MOVE;
                 }
 
                 if (resize) {
-                    boundsChange.confirmedTransformType |= eTransformType.RESIZE;
+                    boundsChange.transformType |= eTransformType.RESIZE;
                 }
             };
 
             evaluateAxis('x');
             evaluateAxis('y');
 
-            const newTransformType = boundsChange.confirmedTransformType;
+            const newTransformType = boundsChange.transformType;
 
             if (newTransformType === eTransformType.MOVE && prevTransformType !== eTransformType.MOVE) {
                 this._snapGroup.restoreResizeConstraints();
@@ -1144,7 +1144,7 @@ export class DesktopWindow implements DesktopEntity {
     private handleBeginUserBoundsChanging(event: fin.WindowBoundsEvent) {
         const startBounds = {center: {...this.currentState.center}, halfSize: {...this.currentState.halfSize}};
 
-        this._userInitiatedBoundsChange = {startBounds, confirmedTransformType: 0};
+        this._userInitiatedBoundsChange = {startBounds, transformType: 0};
 
         const transformType = this.updateTransformType(event, this._userInitiatedBoundsChange);
 

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1085,7 +1085,8 @@ export class DesktopWindow implements DesktopEntity {
                 boundsChange.confirmedTransformType |= eTransformType.RESIZE;
             }
 
-            if (Math.abs(startBounds.center.x - center.x) > MINIMUM_MOVE_CHANGE || Math.abs(startBounds.center.y - center.y) > MINIMUM_MOVE_CHANGE) {
+            if (Math.abs(startBounds.center.x - center.x) > MINIMUM_MOVE_CHANGE ||
+                Math.abs(startBounds.center.y - center.y) > MINIMUM_MOVE_CHANGE) {
                 boundsChange.confirmedTransformType |= eTransformType.MOVE;
             }
 

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1080,21 +1080,14 @@ export class DesktopWindow implements DesktopEntity {
 
             const startBounds = boundsChange.startBounds;
 
-            const leftEdgeChanged = Math.abs((center.x - halfSize.x) - (startBounds.center.x - startBounds.halfSize.x)) > MINIMUM_RESIZE_CHANGE;
-            const rightEdgeChanged = Math.abs((center.x + halfSize.x) - (startBounds.center.x + startBounds.halfSize.x)) > MINIMUM_RESIZE_CHANGE;
-            const topEdgeChanged = Math.abs((center.y - halfSize.y) - (startBounds.center.y - startBounds.halfSize.y)) > MINIMUM_RESIZE_CHANGE;
-            const bottomEdgeChanged = Math.abs((center.y + halfSize.y) - (startBounds.center.y + startBounds.halfSize.y)) > MINIMUM_RESIZE_CHANGE;
+            if (Math.abs(startBounds.halfSize.x - halfSize.x) > MINIMUM_RESIZE_CHANGE ||
+                Math.abs(startBounds.halfSize.y - halfSize.y) > MINIMUM_RESIZE_CHANGE) {
+                boundsChange.confirmedTransformType |= eTransformType.RESIZE;
+            }
 
-            const allEdgesChanged = leftEdgeChanged && rightEdgeChanged && topEdgeChanged && bottomEdgeChanged;
-            const anyEdgesChanged = leftEdgeChanged || rightEdgeChanged || topEdgeChanged || bottomEdgeChanged;
-
-            if (anyEdgesChanged) {
-                if ((Math.abs(center.x - startBounds.center.x) > MINIMUM_MOVE_CHANGE ||
-                     Math.abs(center.y - startBounds.center.y) > MINIMUM_MOVE_CHANGE) && allEdgesChanged) {
-                    boundsChange.confirmedTransformType |= eTransformType.MOVE;
-                } else {
-                    boundsChange.confirmedTransformType |= eTransformType.RESIZE;
-                }
+            if (Math.abs(startBounds.center.x - center.x) > MINIMUM_MOVE_CHANGE ||
+                Math.abs(startBounds.center.y - center.y) > MINIMUM_MOVE_CHANGE) {
+                boundsChange.confirmedTransformType |= eTransformType.MOVE;
             }
 
             if (boundsChange.confirmedTransformType !== 0) {

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -675,9 +675,6 @@ export class DesktopWindow implements DesktopEntity {
 
     public async applyOverride<K extends keyof EntityState>(property: K, value: EntityState[K]): Promise<void> {
         if (value !== this._currentState[property]) {
-            this._temporaryState[property] = this._temporaryState[property] || this._currentState[property];
-            this._currentState[property] = value;
-
             return this.updateState({[property]: value}, ActionOrigin.SERVICE_TEMPORARY);
         }
     }

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1102,7 +1102,7 @@ export class DesktopWindow implements DesktopEntity {
                 } else {
                     const sizeChangeSign = Math.sign(halfSize[axis] - startBounds.halfSize[axis]);
                     // If start and new centers are equal, arbitrarily pick a sign, so as to not
-                    // accidentally support 'symmetrical' resize
+                    // accidentally support 'symmetrical' resize from both edges
                     const centerChangeSign = Math.sign(center[axis] - startBounds.center[axis]) || 1;
 
                     const expectedEdgeChanged = sizeChangeSign * centerChangeSign;

--- a/src/provider/snapanddock/Constants.ts
+++ b/src/provider/snapanddock/Constants.ts
@@ -20,7 +20,7 @@ export const MIN_OVERLAP = 50;
 /**
  * To calculate window adjacency, we use a tiny fuzz distance to deal with sub-pixel window drift
  */
-export const ADJACENCY_FUZZ_DISTANCE = 1;
+export const ADJACENCY_FUZZ_DISTANCE = 2;
 
 /**
  * Defines the distance windows will be moved when undocked.


### PR DESCRIPTION
- Expose 'displayScaling' boolean from DesktopModel, so we can use DS mitigations selectively
- Manually compute the transform type when display scaling is active
- Disable resize constraints when a window is being dragged, so prevent window-growth bug
