### PR TITLE
[SERVICE-451] Fix tab group splicing when maximized

### DIFF
--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1081,6 +1081,10 @@ export class DesktopWindow implements DesktopEntity {
             this._snapGroup.windows
                 .filter(snapGroupWindow => snapGroupWindow !== this && !snapGroupWindow.isMaximizedOrInMaximizedTab() && !snapGroupWindow.currentState.hidden)
                 .forEach(snapGroupWindow => snapGroupWindow.bringToFront());
+        } else if (this._tabGroup && this._tabGroup.state === 'maximized') {
+            this._snapGroup.windows
+                .filter(snapGroupWindow => snapGroupWindow !== this && snapGroupWindow._tabGroup === this._tabGroup)
+                .forEach(snapGroupWindow => snapGroupWindow.bringToFront());
         }
     }
 


### PR DESCRIPTION
Added some additional logic to handle focused to stop the "keep tab group at same z-index" stuff being blocked when the group is maximized.