### PR TITLE
[N/A] Track changes when using ActionOrigin.SERVICE_TEMPORARY

### DIFF
--- a/src/provider/utils/iteration.ts
+++ b/src/provider/utils/iteration.ts
@@ -1,0 +1,3 @@
+export function forEachProperty<T>(object: T, f: (property: keyof T) => (void)): void {
+    (Object.keys(object) as (keyof T)[]).forEach((property) => f(property));
+}


### PR DESCRIPTION
Previously, when we used `applyOverride()` and `resetOverride()` on `DesktopWindow`, the store value to reset to would get lost if there was a call to `refresh()` between the apply and reset steps. I ran into this problem in the display scaling feature branch, as we call can `refresh()` around the same time we make a window translucent for snapping.

This was because when calling `updateState()` with `ActionOrigin.SERVICE_TEMPORARY`, we were not properly updating `this._modifiedState` as we were for `ActionOrigin.SERVICE`. This fix changes it so that we properly update `this._modifiedState` for both `ActionOrigin.SERVICE` and `ActionOrigin.SERVICE_TEMPORARY`.