### PR TITLE
[SERVICE-454] Add API for querying docked status

### DIFF
--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -121,7 +121,8 @@ export enum WorkspaceAPI {
 
 export enum SnapAndDockAPI {
     UNDOCK_WINDOW = 'UNDOCK-WINDOW',
-    UNDOCK_GROUP = 'UNDOCK-GROUP'
+    UNDOCK_GROUP = 'UNDOCK-GROUP',
+    GET_DOCKED_WINDOWS = 'GET-DOCKED-WINDOWS'
 }
 
 export enum RegisterAPI {

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -160,11 +160,9 @@ export async function undockGroup(identity: Identity = getId()): Promise<void> {
 export type DockGroup = (Identity | Identity[])[]
 
 /**
- * If the window is not docked returns null.
+ * Returns an array representing the entities docked with the provided window (see {@link DockGroup} for more details).
  *
- * Otherwise returns an array representing the entities docked with the provided window:
- *  - An array entry of type `Identity` represents a single window
- *  - An array entry of type `Identity[]` represents a tab group. The elements of this sub-array are the identities of the tabs that form the tab group.
+ * If the window is not docked returns null.
  *
  * ```ts
  * import {snapAndDock} from 'openfin-layouts';

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -6,7 +6,6 @@ import {Identity} from 'hadouken-js-adapter';
 import {eventEmitter, tryServiceDispatch} from './connection';
 import {getId, parseIdentity, SnapAndDockAPI} from './internal';
 
-
 /**
  * Event fired when one window is docked to another.  See {@link addEventListener}.
  *
@@ -149,4 +148,13 @@ export async function undockWindow(identity: Identity = getId()): Promise<void> 
  */
 export async function undockGroup(identity: Identity = getId()): Promise<void> {
     return tryServiceDispatch<Identity, void>(SnapAndDockAPI.UNDOCK_GROUP, parseIdentity(identity));
+}
+
+type DockGroup = (Identity | Identity[])[]
+
+/**
+ * TODO: Write this doc comment
+ */
+export async function getDockedWindows(identity: Identity = getId()): Promise<DockGroup | null> {
+    return tryServiceDispatch<Identity, DockGroup | null>(SnapAndDockAPI.GET_DOCKED_WINDOWS, parseIdentity(identity));
 }

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -153,7 +153,24 @@ export async function undockGroup(identity: Identity = getId()): Promise<void> {
 type DockGroup = (Identity | Identity[])[]
 
 /**
- * TODO: Write this doc comment
+ * Resolves to an array representing the entities belonging to the dock group of the provided window.
+ *  - An array entry of type `Identity` represents a single window that is docked to the provided window.
+ *  - An array entry of type `Identity[]` represents a tab group that is docked to the provided window. \
+The elements of this sub-array are the identities of the tabs that form the tab group.
+ *
+ * If there is no dock group associated with the window context, will resolve to null.
+ * ```ts
+ * import {snapAndDock} from 'openfin-layouts';
+ *
+ * // Gets all tabs for the current window context.
+ * snapAndDock.getDockedWindows();
+ *
+ * // Get all tabs for another window context.
+ * snapAndDock.getDockedWindows({uuid: "sample-window-uuid", name: "sample-window-name"});
+ * ```
+ *
+ * @param identity The window context, defaults to the current window.
+ * @throws `Error`: If `identity` is not a valid {@link https://developer.openfin.co/docs/javascript/stable/global.html#Identity | Identity}.
  */
 export async function getDockedWindows(identity: Identity = getId()): Promise<DockGroup | null> {
     return tryServiceDispatch<Identity, DockGroup | null>(SnapAndDockAPI.GET_DOCKED_WINDOWS, parseIdentity(identity));

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -5,6 +5,7 @@ import {Identity} from 'hadouken-js-adapter';
 
 import {eventEmitter, tryServiceDispatch} from './connection';
 import {getId, parseIdentity, SnapAndDockAPI} from './internal';
+import {WindowIdentity} from './main';
 
 /**
  * Event fired when one window is docked to another.  See {@link addEventListener}.
@@ -153,11 +154,11 @@ export async function undockGroup(identity: Identity = getId()): Promise<void> {
 /**
  * Represents a group of docked entities (windows and/or tab groups)
  *
- * An array entry of type `Identity` represents a single window
+ * An array entry of type `WindowIdentity` represents a single window
  *
- * An array entry of type `Identity[]` represents a tab group. The elements of this sub-array are the identities of the tabs that form the tab group.
+ * An array entry of type `WindowIdentity[]` represents a tab group. The elements of this sub-array are the identities of the tabs that form the tab group.
  */
-export type DockGroup = (Identity | Identity[])[]
+export type DockGroup = (WindowIdentity | WindowIdentity[])[]
 
 /**
  * Returns an array representing the entities docked with the provided window (see {@link DockGroup} for more details).

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -153,7 +153,7 @@ export async function undockGroup(identity: Identity = getId()): Promise<void> {
 type DockGroup = (Identity | Identity[])[]
 
 /**
- * Resolves to an array representing the entities belonging to the dock group of the provided window.
+ * Returns an array representing the entities belonging to the dock group of the provided window.
  *  - An array entry of type `Identity` represents a single window that is docked to the provided window.
  *  - An array entry of type `Identity[]` represents a tab group that is docked to the provided window.
  *      The elements of this sub-array are the identities of the tabs that form the tab group.

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -155,8 +155,8 @@ type DockGroup = (Identity | Identity[])[]
 /**
  * Resolves to an array representing the entities belonging to the dock group of the provided window.
  *  - An array entry of type `Identity` represents a single window that is docked to the provided window.
- *  - An array entry of type `Identity[]` represents a tab group that is docked to the provided window. \
-The elements of this sub-array are the identities of the tabs that form the tab group.
+ *  - An array entry of type `Identity[]` represents a tab group that is docked to the provided window.
+ *      The elements of this sub-array are the identities of the tabs that form the tab group.
  *
  * If there is no dock group associated with the window context, will resolve to null.
  * ```ts

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -150,7 +150,14 @@ export async function undockGroup(identity: Identity = getId()): Promise<void> {
     return tryServiceDispatch<Identity, void>(SnapAndDockAPI.UNDOCK_GROUP, parseIdentity(identity));
 }
 
-type DockGroup = (Identity | Identity[])[]
+/**
+ * Represents a group of docked entities (windows and/or tab groups)
+ *
+ * An array entry of type `Identity` represents a single window
+ *
+ * An array entry of type `Identity[]` represents a tab group. The elements of this sub-array are the identities of the tabs that form the tab group.
+ */
+export type DockGroup = (Identity | Identity[])[]
 
 /**
  * If the window is not docked returns null.

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -153,12 +153,12 @@ export async function undockGroup(identity: Identity = getId()): Promise<void> {
 type DockGroup = (Identity | Identity[])[]
 
 /**
- * Returns an array representing the entities belonging to the dock group of the provided window.
- *  - An array entry of type `Identity` represents a single window that is docked to the provided window.
- *  - An array entry of type `Identity[]` represents a tab group that is docked to the provided window.
- *      The elements of this sub-array are the identities of the tabs that form the tab group.
+ * If the window is not docked returns null.
  *
- * If there is no dock group associated with the window context, will resolve to null.
+ * Otherwise returns an array representing the entities docked with the provided window:
+ *  - An array entry of type `Identity` represents a single window
+ *  - An array entry of type `Identity[]` represents a tab group. The elements of this sub-array are the identities of the tabs that form the tab group.
+ *
  * ```ts
  * import {snapAndDock} from 'openfin-layouts';
  *
@@ -174,7 +174,17 @@ type DockGroup = (Identity | Identity[])[]
  * @throws `Error`: If `identity` is not a valid {@link https://developer.openfin.co/docs/javascript/stable/global.html#Identity | Identity}.
  * @throws `Error`: If the window specified by `identity` does not exist
  * @throws `Error`: If the window specified by `identity` has been de-registered
+ * @throws `Error`: If the provider is running an incompatible version
+ *
+ * @since 1.0.3
  */
 export async function getDockedWindows(identity: Identity = getId()): Promise<DockGroup | null> {
-    return tryServiceDispatch<Identity, DockGroup | null>(SnapAndDockAPI.GET_DOCKED_WINDOWS, parseIdentity(identity));
+    const response = await tryServiceDispatch<Identity, DockGroup | null>(SnapAndDockAPI.GET_DOCKED_WINDOWS, parseIdentity(identity));
+    // @ts-ignore Compatability check. Provider will return false on unregistered actions.
+    if (response === false) {
+        console.warn('Warning: The currently running layouts service does not support the "getDockedWindows" method.');
+        return null;
+    }
+
+    return response;
 }

--- a/src/client/snapanddock.ts
+++ b/src/client/snapanddock.ts
@@ -163,14 +163,17 @@ type DockGroup = (Identity | Identity[])[]
  * import {snapAndDock} from 'openfin-layouts';
  *
  * // Gets all tabs for the current window context.
- * snapAndDock.getDockedWindows();
+ * const myGroup: DockGroup | null = snapAndDock.getDockedWindows();
  *
  * // Get all tabs for another window context.
- * snapAndDock.getDockedWindows({uuid: "sample-window-uuid", name: "sample-window-name"});
+ * const otherWindow: Identity = {uuid: "sample-window-uuid", name: "sample-window-name"}
+ * const otherWindowGroup: DockGroup | null = snapAndDock.getDockedWindows(otherWindow);
  * ```
  *
  * @param identity The window context, defaults to the current window.
  * @throws `Error`: If `identity` is not a valid {@link https://developer.openfin.co/docs/javascript/stable/global.html#Identity | Identity}.
+ * @throws `Error`: If the window specified by `identity` does not exist
+ * @throws `Error`: If the window specified by `identity` has been de-registered
  */
 export async function getDockedWindows(identity: Identity = getId()): Promise<DockGroup | null> {
     return tryServiceDispatch<Identity, DockGroup | null>(SnapAndDockAPI.GET_DOCKED_WINDOWS, parseIdentity(identity));

--- a/src/demo/testbed/SnapAndDockUI.ts
+++ b/src/demo/testbed/SnapAndDockUI.ts
@@ -23,6 +23,19 @@ export class SnapAndDockUI {
         snapAndDock.addEventListener('window-docked', this.onDockEvent);
         snapAndDock.addEventListener('window-undocked', this.onDockEvent);
 
+        // Query the docked state on load and update the UI accordingly. This covers the case of being reloaded while docked.
+        snapAndDock.getDockedWindows().then(dockGroup => {
+            if (dockGroup !== null) {
+                document.body.classList.toggle('docked', true);
+                document.getElementById('dock-status')!.innerText = Messages.STATUS_DOCKED;
+
+                this._buttons.forEach(button => {
+                    button.classList.toggle('btn-primary', true);
+                    button.classList.toggle('btn-secondary', false);
+                });
+            }
+        });
+
         this._buttons = [elements.undockWindow, elements.undockGroup];
         this._log = log;
     }

--- a/src/demo/testbed/SnapAndDockUI.ts
+++ b/src/demo/testbed/SnapAndDockUI.ts
@@ -26,13 +26,7 @@ export class SnapAndDockUI {
         // Query the docked state on load and update the UI accordingly. This covers the case of being reloaded while docked.
         snapAndDock.getDockedWindows().then(dockGroup => {
             if (dockGroup !== null) {
-                document.body.classList.toggle('docked', true);
-                document.getElementById('dock-status')!.innerText = Messages.STATUS_DOCKED;
-
-                this._buttons.forEach(button => {
-                    button.classList.toggle('btn-primary', true);
-                    button.classList.toggle('btn-secondary', false);
-                });
+                this.toggleDocked(true);
             }
         });
 
@@ -42,6 +36,13 @@ export class SnapAndDockUI {
 
     private onDockEvent(event: WindowDockedEvent|WindowUndockedEvent): void {
         const isDocked = (event.type === 'window-docked');
+
+        this.toggleDocked(isDocked);
+
+        this._log.addEvent(event);
+    }
+
+    private toggleDocked(isDocked: boolean) {
         const message = isDocked ? Messages.STATUS_DOCKED : Messages.STATUS_UNDOCKED;
 
         document.body.classList.toggle('docked', isDocked);
@@ -52,7 +53,5 @@ export class SnapAndDockUI {
             button.classList.toggle('btn-primary', isDocked);
             button.classList.toggle('btn-secondary', !isDocked);
         });
-
-        this._log.addEvent(event);
     }
 }

--- a/src/demo/testbed/TabbingUI.ts
+++ b/src/demo/testbed/TabbingUI.ts
@@ -139,6 +139,19 @@ export class TabbingUI {
         tabbing.addEventListener('tab-removed', this.onTabEvent);
         tabbing.addEventListener('tab-activated', event => this._log.addEvent(event));
         tabbing.addEventListener('tab-properties-updated', event => this._log.addEvent(event));
+
+        tabbing.getTabs().then(tabs => {
+            if (tabs !== null) {
+                document.body.classList.toggle('tabbed', true);
+                document.getElementById('tab-status')!.innerText = Messages.STATUS_TABBED;
+
+                // Show which buttons are useful in this state
+                this._buttons.forEach(button => {
+                    button.classList.toggle('btn-primary', true);
+                    button.classList.toggle('btn-secondary', false);
+                });
+            }
+        });
     }
 
     private async onTabEvent(event: TabAddedEvent|TabRemovedEvent): Promise<void> {

--- a/src/demo/testbed/TabbingUI.ts
+++ b/src/demo/testbed/TabbingUI.ts
@@ -142,20 +142,20 @@ export class TabbingUI {
 
         tabbing.getTabs().then(tabs => {
             if (tabs !== null) {
-                document.body.classList.toggle('tabbed', true);
-                document.getElementById('tab-status')!.innerText = Messages.STATUS_TABBED;
-
-                // Show which buttons are useful in this state
-                this._buttons.forEach(button => {
-                    button.classList.toggle('btn-primary', true);
-                    button.classList.toggle('btn-secondary', false);
-                });
+                this.toggleTabbed(true);
             }
         });
     }
 
     private async onTabEvent(event: TabAddedEvent|TabRemovedEvent): Promise<void> {
         const isTabbed: boolean = (event.type === 'tab-added');
+
+        this.toggleTabbed(isTabbed);
+
+        this._log.addEvent(event);
+    }
+
+    private toggleTabbed(isTabbed: boolean) {
         const message: string = isTabbed ? Messages.STATUS_TABBED : Messages.STATUS_UNTABBED;
 
         document.body.classList.toggle('tabbed', isTabbed);
@@ -166,8 +166,6 @@ export class TabbingUI {
             button.classList.toggle('btn-primary', isTabbed);
             button.classList.toggle('btn-secondary', !isTabbed);
         });
-
-        this._log.addEvent(event);
     }
 
     private async getWindowsMatching(filter: (identity: WindowIdentity) => Promise<boolean>): Promise<WindowIdentity[]> {

--- a/src/provider/APIHandler.ts
+++ b/src/provider/APIHandler.ts
@@ -147,7 +147,7 @@ export class APIHandler {
             throw new Error(getErrorMessage(ErrorType.NO_WINDOW, identity));
         }
 
-        if (targetWindow.snapGroup.length === 1) {
+        if (targetWindow.snapGroup.entities.length === 1) {
             // Window is not docked
             return null;
         }

--- a/test/demo/snapanddock/getDockGroup.inttest.ts
+++ b/test/demo/snapanddock/getDockGroup.inttest.ts
@@ -1,0 +1,78 @@
+import {createWindowTest, CreateWindowData} from '../utils/createWindowTest';
+import {dragSideToSide} from '../../provider/utils/dragWindowTo';
+import {layoutsClientPromise} from '../utils/serviceUtils';
+import {tabWindowsTogether} from '../../provider/utils/tabWindowsTogether';
+
+describe('When calling getDockGroup the correct data is returned', () => {
+    it('Two single undocked windows', async () => createWindowTest(async (context, testOptions: CreateWindowData) => {
+        const {windows} = context;
+        const layouts = await layoutsClientPromise;
+
+        const groups = await Promise.all(windows.map(win => layouts.snapAndDock.getDockedWindows(win.identity)));
+
+        expect(groups).toEqual([null, null]);
+    })({windowCount: 2, frame: true}));
+
+    it('Two docked windows and a single undocked window', async () => createWindowTest(async (context, testOptions: CreateWindowData) => {
+        const {windows} = context;
+        const layouts = await layoutsClientPromise;
+
+        await dragSideToSide(windows[1], 'left', windows[0], 'right');
+
+        const groups = await Promise.all(windows.map(win => layouts.snapAndDock.getDockedWindows(win.identity)));
+
+        const expectedGroup = [
+            windows[0].identity,
+            windows[1].identity
+        ];
+
+        expect(groups).toEqual([expectedGroup, expectedGroup, null]);
+    })({windowCount: 3, frame: true}));
+
+    it('One tabgroup and one window both undocked', async () => createWindowTest(async (context, testOptions: CreateWindowData) => {
+        const {windows} = context;
+        const layouts = await layoutsClientPromise;
+
+        await tabWindowsTogether(windows[0], windows[1]);
+
+        const groups = await Promise.all(windows.map(win => layouts.snapAndDock.getDockedWindows(win.identity)));
+
+        expect(groups).toEqual([null, null, null]);
+    })({windowCount: 3, frame: true}));
+
+    it('One tabgroup docked to a window', async () => createWindowTest(async (context, testOptions: CreateWindowData) => {
+        const {windows} = context;
+        const layouts = await layoutsClientPromise;
+
+        await tabWindowsTogether(windows[0], windows[1]);
+        await dragSideToSide(windows[2], 'left', windows[0], 'right');
+
+        const groups = await Promise.all(windows.map(win => layouts.snapAndDock.getDockedWindows(win.identity)));
+
+        const expectedGroup = [
+            [windows[0].identity, windows[1].identity], // Tab group
+            windows[2].identity
+        ];
+
+        expect(groups).toEqual([expectedGroup, expectedGroup, expectedGroup]);
+    })({windowCount: 3, frame: true}));
+
+    it('Two docked tabgroups', async () => createWindowTest(async (context, testOptions: CreateWindowData) => {
+        const {windows} = context;
+        const layouts = await layoutsClientPromise;
+
+        await tabWindowsTogether(windows[0], windows[1]);
+        await tabWindowsTogether(windows[2], windows[3]);
+
+        await dragSideToSide(windows[2], 'left', windows[0], 'right');
+
+        const groups = await Promise.all(windows.map(win => layouts.snapAndDock.getDockedWindows(win.identity)));
+
+        const expectedGroup = [
+            [windows[0].identity, windows[1].identity],
+            [windows[2].identity, windows[3].identity]
+        ];
+
+        expect(groups).toEqual([expectedGroup, expectedGroup, expectedGroup, expectedGroup]);
+    })({windowCount: 4, frame: true}));
+});

--- a/test/demo/snapanddock/getDockGroup.inttest.ts
+++ b/test/demo/snapanddock/getDockGroup.inttest.ts
@@ -1,10 +1,10 @@
-import {createWindowTest, CreateWindowData} from '../utils/createWindowTest';
+import {createWindowTest} from '../utils/createWindowTest';
 import {dragSideToSide} from '../../provider/utils/dragWindowTo';
 import {layoutsClientPromise} from '../utils/serviceUtils';
 import {tabWindowsTogether} from '../../provider/utils/tabWindowsTogether';
 
-describe('When calling getDockGroup the correct data is returned', () => {
-    it('Two single undocked windows', async () => createWindowTest(async (context, testOptions: CreateWindowData) => {
+describe('When calling getDockGroup, the data returned accurately represents the group state of the target window', () => {
+    it('Two single undocked windows', async () => createWindowTest(async context => {
         const {windows} = context;
         const layouts = await layoutsClientPromise;
 
@@ -13,7 +13,7 @@ describe('When calling getDockGroup the correct data is returned', () => {
         expect(groups).toEqual([null, null]);
     })({windowCount: 2, frame: true}));
 
-    it('Two docked windows and a single undocked window', async () => createWindowTest(async (context, testOptions: CreateWindowData) => {
+    it('Two docked windows and a single undocked window', async () => createWindowTest(async context => {
         const {windows} = context;
         const layouts = await layoutsClientPromise;
 
@@ -29,7 +29,7 @@ describe('When calling getDockGroup the correct data is returned', () => {
         expect(groups).toEqual([expectedGroup, expectedGroup, null]);
     })({windowCount: 3, frame: true}));
 
-    it('One tabgroup and one window both undocked', async () => createWindowTest(async (context, testOptions: CreateWindowData) => {
+    it('One tabgroup and one window both undocked', async () => createWindowTest(async context => {
         const {windows} = context;
         const layouts = await layoutsClientPromise;
 
@@ -40,7 +40,7 @@ describe('When calling getDockGroup the correct data is returned', () => {
         expect(groups).toEqual([null, null, null]);
     })({windowCount: 3, frame: true}));
 
-    it('One tabgroup docked to a window', async () => createWindowTest(async (context, testOptions: CreateWindowData) => {
+    it('One tabgroup docked to a window', async () => createWindowTest(async context => {
         const {windows} = context;
         const layouts = await layoutsClientPromise;
 
@@ -57,7 +57,7 @@ describe('When calling getDockGroup the correct data is returned', () => {
         expect(groups).toEqual([expectedGroup, expectedGroup, expectedGroup]);
     })({windowCount: 3, frame: true}));
 
-    it('Two docked tabgroups', async () => createWindowTest(async (context, testOptions: CreateWindowData) => {
+    it('Two docked tabgroups', async () => createWindowTest(async context => {
         const {windows} = context;
         const layouts = await layoutsClientPromise;
 


### PR DESCRIPTION
Added a new client api method, `getDockedWindows` (name definitely up for discussion), which will return the identities of all entities in the same docked group as the target window. 

This was added to address a use-case where a window uses the docked events to update some ui element, but if refreshed has no easy way to know which state to put itself in.

I have also added some logic to the testbed apps which should make them behave properly if reloaded while docked.