### PR TITLE
[SERVICE-449][Continued] Windows in snap group with resize constraints grow rapidly when dragged

### DIFF
--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1107,7 +1107,7 @@ export class DesktopWindow implements DesktopEntity {
 
                     const expectedEdgeChanged = sizeChangeSign * centerChangeSign;
 
-                    expectedCenter = startBounds.center[axis] + expectedEdgeChanged * (startBounds.halfSize[axis] - halfSize[axis]);
+                    expectedCenter = startBounds.center[axis] + expectedEdgeChanged * (halfSize[axis] - startBounds.halfSize[axis]);
                 }
 
                 const move = Math.abs(expectedCenter - center[axis]) > MINIMUM_MOVE_CHANGE;


### PR DESCRIPTION
Fix maths being back-to-front, causing us to detect resizes as moves