### PR TITLE
[SERVICE-435] Display scaling support for 150% and 200%

### DIFF
--- a/src/provider/main.ts
+++ b/src/provider/main.ts
@@ -35,16 +35,20 @@ declare const window: Window&{
 
 fin.desktop.main(main);
 
+const supportedScaleFactors = [1, 1.5, 2];
+
 export async function main() {
     const monitorInfo = await fin.System.getMonitorInfo();
 
-    // Disable the service if display scaling is not 100%
-    if (monitorInfo.deviceScaleFactor !== 1) {
+    // Disable the service if display scaling is not a supported scale factor
+    if (!supportedScaleFactors.some(scaleFactor => scaleFactor === monitorInfo.deviceScaleFactor)) {
         console.error('Desktop has non-standard display scaling. Notifying user and disabling all layouts functionality.');
 
-        const errorMessage =
-            `OpenFin Layouts will only work with monitors that are set to a scaling ratio of 100%. This can be changed in monitor or display settings.
-            \n\nPlease contact support@openfin.co with any further questions.`;
+        const errorMessage = `\
+OpenFin Layouts will only work with monitors that are set to a scaling ratio of 100%, 150% or 200%. \
+This can be changed in monitor or display settings.
+\n\n\
+Please contact support@openfin.co with any further questions.`;
 
         const providerChannel: ChannelProvider = await fin.InterApplicationBus.Channel.create(SERVICE_CHANNEL);
         providerChannel.onConnection((app: Identity) => {

--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -37,6 +37,7 @@ export class DesktopModel {
     private _zIndexer: ZIndexer;
     private _mouseTracker: MouseTracker;
     private _monitors: Rectangle[];
+    private _displayScaling: boolean;
 
     constructor(config: ConfigStore) {
         this._windows = [];
@@ -46,6 +47,7 @@ export class DesktopModel {
         this._zIndexer = new ZIndexer(this);
         this._mouseTracker = new MouseTracker();
         this._monitors = [];
+        this._displayScaling = false;
 
         DesktopWindow.onCreated.add(this.onWindowCreated, this);
         DesktopWindow.onDestroyed.add(this.onWindowDestroyed, this);
@@ -93,6 +95,7 @@ export class DesktopModel {
         // Validate everything on monitor change, as groups may become disjointed
         fin.System.addListener('monitor-info-changed', async (evt: MonitorEvent<'system', 'monitor-info-changed'>) => {
             this._monitors = [evt.primaryMonitor, ...evt.nonPrimaryMonitors].map(mon => RectUtils.convertToCenterHalfSize(mon.monitorRect));
+            this._displayScaling = evt.deviceScaleFactor !== 1;
 
             // Validate all tabgroups
             this.tabGroups.map(g => g.validate());
@@ -104,6 +107,7 @@ export class DesktopModel {
         // Get and store the current monitors
         fin.System.getMonitorInfo().then((monitorInfo: MonitorInfo) => {
             this._monitors = [monitorInfo.primaryMonitor, ...monitorInfo.nonPrimaryMonitors].map(mon => RectUtils.convertToCenterHalfSize(mon.availableRect));
+            this._displayScaling = monitorInfo.deviceScaleFactor !== 1;
         });
     }
 
@@ -129,6 +133,10 @@ export class DesktopModel {
 
     public get monitors(): ReadonlyArray<Rectangle> {
         return this._monitors;
+    }
+
+    public get displayScaling(): boolean {
+        return this._displayScaling;
     }
 
     /**

--- a/src/provider/model/DesktopSnapGroup.ts
+++ b/src/provider/model/DesktopSnapGroup.ts
@@ -1,6 +1,6 @@
 import {WindowDockedEvent, WindowUndockedEvent} from '../../client/snapanddock';
 import {Signal1, Signal2} from '../Signal';
-import {MIN_OVERLAP} from '../snapanddock/Constants';
+import {MIN_OVERLAP, ADJACENCY_FUZZ_DISTANCE} from '../snapanddock/Constants';
 import {CalculatedProperty} from '../snapanddock/utils/CalculatedProperty';
 import {Debounced} from '../snapanddock/utils/Debounced';
 import {Point, PointUtils} from '../snapanddock/utils/PointUtils';
@@ -231,6 +231,13 @@ export class DesktopSnapGroup {
             }
         }
 
+        /**
+         * Are the two DesktopEntitys adjacent? True if they are windows in the same tab group, false
+         * if they are not both visible, true if they are both visible and within the fuzz distance.
+         * @param win1 one DesktopEntity
+         * @param win2 the other DesktopEntity
+         * @returns true if they are adjacent
+         */
         function isAdjacent(win1: DesktopEntity, win2: DesktopEntity) {
             const distance = RectUtils.distance(win1.currentState, win2.currentState);
             if (win1.tabGroup && win1.tabGroup === win2.tabGroup) {
@@ -241,8 +248,9 @@ export class DesktopSnapGroup {
                 // If a window is not visible it cannot be adjacent to anything. This also allows us
                 // to avoid the questionable position tracking for hidden windows.
                 return false;
-            } else if (distance.border(0) && Math.abs(distance.maxAbs) > MIN_OVERLAP) {
-                // The overlap check ensures that only valid snap configurations are counted
+            } else if (distance.border(ADJACENCY_FUZZ_DISTANCE) && Math.abs(distance.maxAbs) > MIN_OVERLAP) {
+                // The overlap check ensures that only valid snap configurations are counted.
+                // We make it a small number to account for sub-pixel distances on > 100% scale monitors
                 return true;
             }
             return false;

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -192,8 +192,28 @@ export class DesktopTabGroup implements DesktopEntity {
 
     public async applyOffset(offset: Point, halfSize?: Point): Promise<void> {
         const tabstripHalfHeight: number = this._config.height / 2;
-        const adjustedHalfSize: Point|undefined = halfSize && {x: halfSize.x, y: halfSize.y - tabstripHalfHeight};
-        return this.activeTab.applyOffset(offset, adjustedHalfSize);
+
+        const activeTabHalfSize: Point|undefined = halfSize && {x: halfSize.x, y: halfSize.y - tabstripHalfHeight};
+
+        if (this._model.displayScaling) {
+            const tabstripHalfSize: Point|undefined = halfSize && {x: halfSize.x, y: tabstripHalfHeight};
+
+            /**
+             * We can't depend on the tabstrip having the appropriate resize constraints at this point, due to a race condition with our
+             * mitigations for display scaling issues in DesktopSnapGroup, so we manually move both the active tab, and the tabstrip itself,
+             * rather than taking the earlier approach of just moving the active tab and relying on grouping and resize constraints to make
+             * everything work as expected. We particularly run into this race condition when snapping a tabgroup to another window
+             */
+            return DesktopWindow.transaction([this._window, ...this.tabs], async (windows) => {
+                await this._window.applyOffset(offset, tabstripHalfSize);
+
+                for (const tab of this.tabs) {
+                    await tab.applyOffset(offset, activeTabHalfSize);
+                }
+            });
+        } else {
+            return this.activeTab.applyOffset(offset, activeTabHalfSize);
+        }
     }
 
     /**

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1107,7 +1107,7 @@ export class DesktopWindow implements DesktopEntity {
 
                     const expectedEdgeChanged = sizeChangeSign * centerChangeSign;
 
-                    expectedCenter = startBounds.center[axis] + expectedEdgeChanged * (startBounds.halfSize[axis] - halfSize[axis]);
+                    expectedCenter = startBounds.center[axis] + expectedEdgeChanged * (halfSize[axis] - startBounds.halfSize[axis]);
                 }
 
                 const move = Math.abs(expectedCenter - center[axis]) > MINIMUM_MOVE_CHANGE;

--- a/src/provider/snapanddock/Constants.ts
+++ b/src/provider/snapanddock/Constants.ts
@@ -18,6 +18,11 @@ export const ANCHOR_DISTANCE = 100;
 export const MIN_OVERLAP = 50;
 
 /**
+ * To calculate window adjacency, we use a tiny fuzz distance to deal with sub-pixel window drift
+ */
+export const ADJACENCY_FUZZ_DISTANCE = 1;
+
+/**
  * Defines the distance windows will be moved when undocked.
  */
 export const UNDOCK_MOVE_DISTANCE = 30;

--- a/src/provider/snapanddock/Constants.ts
+++ b/src/provider/snapanddock/Constants.ts
@@ -20,7 +20,7 @@ export const MIN_OVERLAP = 50;
 /**
  * To calculate window adjacency, we use a tiny fuzz distance to deal with sub-pixel window drift
  */
-export const ADJACENCY_FUZZ_DISTANCE = 1;
+export const ADJACENCY_FUZZ_DISTANCE = 2;
 
 /**
  * Defines the distance windows will be moved when undocked.


### PR DESCRIPTION
This enables support for display scaling at 150% and 200%, and includes mitigations for issues that occur at this scales
- Misreporting of moves vs. resizes, so we compute this ourselves
- Grouped windows resizing when being moved when some of the group includes resize constraints, so we temporarily resize constraints during moves
- Fuzziness when checking group validity, since windows drift slightly when being moved, and don't always go quite where we want them to when they are first snapped 