### PR TITLE
RUN-5108 RUN-5198 experimental external window support

### DIFF
--- a/res/demo/app.json
+++ b/res/demo/app.json
@@ -13,7 +13,7 @@
     },
     "runtime": {
         "arguments": "--v=1 --enable-crash-reporting --inspect=9222 --enable-aggressive-domstorage-flushing",
-        "version": "9.61.38.41"
+        "version": "11.69.42.17"
     },
     "services": [{
         "name": "layouts",

--- a/res/demo/app.json
+++ b/res/demo/app.json
@@ -22,6 +22,9 @@
             "rules": [{
                 "scope": {"level": "window", "uuid": "Layouts-Manager", "name": "Layouts-Manager"},
                 "config": {"enabled": false}
+            }, {
+                "scope": {"level": "application", "uuid": "layouts-service"},
+                "config": {"features": {"externalWindows": true}}
             }]
         }
     }],

--- a/res/demo/app2.json
+++ b/res/demo/app2.json
@@ -14,7 +14,7 @@
     },
     "runtime": {
         "arguments": "--v=1 --enable-crash-reporting --security-realm=APP_1 --enable-mesh",
-        "version": "9.61.38.41"
+        "version": "11.69.42.17"
     },
     "services": [{"name": "layouts", "manifestUrl": "http://localhost:1337/provider/app.json"}]
 }

--- a/res/demo/app3.json
+++ b/res/demo/app3.json
@@ -14,7 +14,7 @@
     },
     "runtime": {
         "arguments": "--v=1 --enable-crash-reporting --security-realm=APP_1 --enable-mesh",
-        "version": "9.61.38.41"
+        "version": "11.69.42.17"
     },
     "services": [{"name": "layouts", "manifestUrl": "http://localhost:1337/provider/app.json"}]
 }

--- a/res/provider/app.json
+++ b/res/provider/app.json
@@ -16,5 +16,21 @@
     "runtime": {
         "arguments": "--enable-aggressive-domstorage-flushing",
         "version": "9.61.38.41"
-    }
+    },
+    "appAssets": [
+        {
+            "alias": "NativeWindowAgent-x32",
+            "mandatory": false,
+            "src": "https://cdn.openfin.co/release/native-window/NativeWindowAgent-0.0.1-x32.zip",
+            "target": "NativeWindowAgent-x32.exe",
+            "version": "0.0.1"
+        },
+        {
+            "alias": "NativeWindowAgent-x64",
+            "mandatory": false,
+            "src": "https://cdn.openfin.co/release/native-window/NativeWindowAgent-0.0.1-x64.zip",
+            "target": "NativeWindowAgent-x64.exe",
+            "version": "0.0.1"
+        }
+    ]
 }

--- a/res/provider/app.json
+++ b/res/provider/app.json
@@ -21,16 +21,16 @@
         {
             "alias": "NativeWindowAgent-x32",
             "mandatory": false,
-            "src": "https://cdn.openfin.co/release/native-window/NativeWindowAgent-0.0.3-x32.zip",
+            "src": "https://cdn.openfin.co/release/native-window/NativeWindowAgent-0.0.4-x32.zip",
             "target": "NativeWindowAgent-x32.exe",
-            "version": "0.0.3"
+            "version": "0.0.4"
         },
         {
             "alias": "NativeWindowAgent-x64",
             "mandatory": false,
-            "src": "https://cdn.openfin.co/release/native-window/NativeWindowAgent-0.0.3-x64.zip",
+            "src": "https://cdn.openfin.co/release/native-window/NativeWindowAgent-0.0.4-x64.zip",
             "target": "NativeWindowAgent-x64.exe",
-            "version": "0.0.3"
+            "version": "0.0.4"
         }
     ]
 }

--- a/res/provider/app.json
+++ b/res/provider/app.json
@@ -21,16 +21,16 @@
         {
             "alias": "NativeWindowAgent-x32",
             "mandatory": false,
-            "src": "https://cdn.openfin.co/release/native-window/NativeWindowAgent-0.0.1-x32.zip",
+            "src": "https://cdn.openfin.co/release/native-window/NativeWindowAgent-0.0.3-x32.zip",
             "target": "NativeWindowAgent-x32.exe",
-            "version": "0.0.1"
+            "version": "0.0.3"
         },
         {
             "alias": "NativeWindowAgent-x64",
             "mandatory": false,
-            "src": "https://cdn.openfin.co/release/native-window/NativeWindowAgent-0.0.1-x64.zip",
+            "src": "https://cdn.openfin.co/release/native-window/NativeWindowAgent-0.0.3-x64.zip",
             "target": "NativeWindowAgent-x64.exe",
-            "version": "0.0.1"
+            "version": "0.0.3"
         }
     ]
 }

--- a/res/provider/app.json
+++ b/res/provider/app.json
@@ -15,7 +15,7 @@
     },
     "runtime": {
         "arguments": "--enable-aggressive-domstorage-flushing",
-        "version": "9.61.38.41"
+        "version": "11.69.42.17"
     },
     "appAssets": [
         {

--- a/res/provider/config/layouts-config.schema.json
+++ b/res/provider/config/layouts-config.schema.json
@@ -170,12 +170,17 @@
                         "tab": {
                             "type": "boolean",
                             "description": "Toggles the ability to tab windows by drag-and-drop. Windows can still be tabbed programmatically using the layouts client api."
+                        },
+                        "externalWindows": {
+                            "type": "boolean",
+                            "description": "Toggles the support for external windows."
                         }
                     },
                     "default": {
                         "snap": true,
                         "dock": true,
-                        "tab": true
+                        "tab": true,
+                        "externalWindows": true
                     },
                     "additionalProperties": false
                 },
@@ -257,6 +262,9 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "isExternalWindow": {
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -28,6 +28,11 @@ export interface WindowIdentity {
      * Window identifier
      */
     name: string;
+
+    /**
+     * External Window identifier
+     */
+    isExternalWindow?: boolean;
 }
 
 /**

--- a/src/finV2.d.ts
+++ b/src/finV2.d.ts
@@ -21,5 +21,6 @@ declare global {
         const ExternalApplication: ExternalApplication;
         const Frame: _FrameModule;
         const GlobalHotkey: GlobalHotkey;
+        const ExternalWindow: any; // TODO: waiting for js-adapter changes
     }
 }

--- a/src/provider/main.ts
+++ b/src/provider/main.ts
@@ -13,6 +13,7 @@ import {SnapService} from './snapanddock/SnapService';
 import {win10Check} from './snapanddock/utils/platform';
 import {TabService} from './tabbing/TabService';
 import {WindowHandler} from './WindowHandler';
+import {NativeWindowService} from './nativeWindows/NativeWindowService';
 
 export type ConfigStore = Store<ConfigurationObject>;
 
@@ -23,6 +24,7 @@ export let snapService: SnapService;
 export let tabService: TabService;
 export let apiHandler: APIHandler;
 export let windowHandler: WindowHandler;
+export let nativeWindowService: NativeWindowService;
 
 declare const window: Window&{
     config: ConfigStore;
@@ -31,6 +33,7 @@ declare const window: Window&{
     snapService: SnapService;
     tabService: TabService;
     apiHandler: APIHandler;
+    nativeWindowService: NativeWindowService;
 };
 
 fin.desktop.main(main);
@@ -68,6 +71,7 @@ Please contact support@openfin.co with any further questions.`;
     snapService = window.snapService = new SnapService(model, config);
     tabService = window.tabService = new TabService(model, config);
     apiHandler = window.apiHandler = new APIHandler(model, config, snapService, tabService);
+    nativeWindowService = window.nativeWindowService = new NativeWindowService(config, model, snapService);
 
     // Need to ensure that `DesktopTabstripFactory` is created synchronously at service startup.
     // This ensures that it's watch listeners are active at the point where any application-specific tabstrips are configured.

--- a/src/provider/model/DesktopModel.ts
+++ b/src/provider/model/DesktopModel.ts
@@ -13,6 +13,7 @@ import {DesktopSnapGroup} from '../model/DesktopSnapGroup';
 import {SignalSlot} from '../Signal';
 import {Point} from '../snapanddock/utils/PointUtils';
 import {Rectangle, RectUtils} from '../snapanddock/utils/RectUtils';
+import {wrapWindow} from '../utils/main';
 
 import {DesktopTabGroup} from './DesktopTabGroup';
 import {DesktopWindow, EntityState, WindowIdentity} from './DesktopWindow';
@@ -34,10 +35,10 @@ export class DesktopModel {
     private _tabGroups: DesktopTabGroup[];
     private _snapGroups: DesktopSnapGroup[];
     private _windowLookup: {[key: string]: DesktopWindow};
-    private _zIndexer: ZIndexer;
     private _mouseTracker: MouseTracker;
     private _monitors: Rectangle[];
     private _displayScaling: boolean;
+    public _zIndexer: ZIndexer;
 
     constructor(config: ConfigStore) {
         this._windows = [];
@@ -284,7 +285,7 @@ export class DesktopModel {
         return promiseWithTimeout.then(removeSlot, removeSlot);
     }
 
-    private async addIfEnabled(identity: WindowIdentity): Promise<void> {
+    public async addIfEnabled(identity: WindowIdentity): Promise<void> {
         const result: Masked<ConfigurationObject, EnabledMask> =
             this._config.queryPartial({level: 'window', uuid: identity.uuid, name: identity.name}, enabledMask);
 
@@ -304,7 +305,7 @@ export class DesktopModel {
             existingWindow.teardown();
         }
 
-        const window: Window = fin.Window.wrapSync(identity);
+        const window: Window = wrapWindow(identity);
         return DesktopWindow.getWindowState(window).then<DesktopWindow|null>((state: EntityState): DesktopWindow|null => {
             if (!this._config.queryPartial({level: 'window', ...identity}, enabledMask).enabled) {
                 // An 'enabled: false' rule was added to the store whilst we were in the process of setting-up the

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -663,7 +663,10 @@ export class DesktopTabGroup implements DesktopEntity {
             const {center, halfSize} = existingTabState;
 
             // Align tab with existing tab
-            await tab.applyProperties({center, halfSize, frame: false});
+            // Note: An external window can't remove its frame, so setting
+            // frame property to true.
+            const frame = tab.identity.isExternalWindow ? true : false;
+            await tab.applyProperties({center, halfSize, frame});
         }
 
         await tab.setTabGroup(this);

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -52,6 +52,7 @@ export interface ResizeConstraint {
 export interface WindowIdentity extends Identity {
     uuid: string;
     name: string;
+    isExternalWindow?: boolean;
 }
 
 /**

--- a/src/provider/model/ZIndexer.ts
+++ b/src/provider/model/ZIndexer.ts
@@ -7,6 +7,7 @@ import Bounds from 'hadouken-js-adapter/out/types/src/api/window/bounds';
 import {_Window} from 'hadouken-js-adapter/out/types/src/api/window/window';
 
 import {SERVICE_IDENTITY} from '../../client/internal';
+import {wrapWindow} from '../utils/main';
 
 import {DesktopModel} from './DesktopModel';
 import {DesktopSnapGroup} from './DesktopSnapGroup';
@@ -147,7 +148,7 @@ export class ZIndexer {
             }
         } else if (!bounds) {
             // Must request bounds before being able to add
-            fin.Window.wrapSync(identity).getBounds().then(bounds => {
+            wrapWindow(identity).getBounds().then((bounds: Bounds) => {
                 // Since this required an async operation, entry may now exist within stack, so recursively call update
                 this.update(identity, eventNum, active, this.sanitizeBounds(bounds));
             });
@@ -183,7 +184,7 @@ export class ZIndexer {
      * Creates window event listeners on a specified window.
      * @param win Window to add the event listeners to.
      */
-    private async _addEventListeners(win: _Window) {
+    public async _addEventListeners(win: _Window) {
         const identity = win.identity as WindowIdentity;  // A window identity will always have a name, so it is safe to cast
 
         const bringToFront = () => {

--- a/src/provider/nativeWindows/NativeWindowService.ts
+++ b/src/provider/nativeWindows/NativeWindowService.ts
@@ -1,0 +1,130 @@
+import {WindowEvent} from 'hadouken-js-adapter/out/types/src/api/events/base';
+
+import {ConfigStore} from '../main';
+import {DesktopModel} from '../model/DesktopModel';
+import {SnapService} from '../snapanddock/SnapService';
+
+export class NativeWindowService {
+    private _config: ConfigStore;
+    private _model: DesktopModel;
+    private _snapService: SnapService;
+
+    constructor(config: ConfigStore, model: DesktopModel, snapService: SnapService) {
+        this._config = config;
+        this._model = model;
+        this._snapService = snapService;
+        this._init().catch(console.error);
+    }
+
+    /**
+     * Initial logic that launches native window agent if configuation
+     * allows it.
+     */
+    private async _init() {
+        const layoutsServiceConfig = this._config.query({level: 'application', uuid: 'layouts-service'});
+        const {features: {externalWindows: externalWindowsAllowed}} = layoutsServiceConfig;
+        // TODO: waiting for the definition of Desktop Owner Settings configuration
+        const {nativeDesktopOwnerSettingsAllowed} = await (<any>fin.System).getServiceConfiguration({name: 'layouts'});
+
+        if (!externalWindowsAllowed || !nativeDesktopOwnerSettingsAllowed) {
+            // Native windows support is not allowed via a configuration
+            return;
+        }
+
+        const supportedArchs = ['x32', 'x64'];
+        let {architecture} = await fin.System.getRuntimeInfo();
+        if (architecture === 'ia32') {
+            architecture = 'x32';
+        }
+
+        // Check if current architecture is supported for the native window agent.
+        if (!supportedArchs.includes(architecture)) {
+            console.warn('Current architecture is not supported for native window integration.');
+            return;
+        }
+
+        await this._launchNativeWindowAgent(architecture);
+        await this._registerFutureExternalWindows();
+        await this._registerCurrentExternalWindows();
+        await this._registerGlobalHotkeys();
+    }
+
+    /**
+     * Launches native window agent using via OpenFin API.
+     */
+    private async _launchNativeWindowAgent(architecture: string) {
+        await (<any>fin.System).launchExternalProcess({
+            alias: `NativeWindowAgent-${architecture}`,
+            lifetime: 'application',
+            listener: (args: any) => {
+                console.log(`Native window agent ${args.topic} (${args.exitCode})`);
+            }
+        });
+    }
+
+    /**
+     * Listen for external windows shown event and register only new ones.
+     * Using "...-shown" event here instead of "...-created" because most external
+     * windows are hidden at first when created, shown afterwards.
+     */
+    private async _registerFutureExternalWindows() {
+        const listener = async (evt: WindowEvent<'system', 'external-window-shown'>) => {
+            const {uuid} = evt;
+            const identity = {uuid, name: uuid, isExternalWindow: true};
+            const foundWindow = this._model.getWindow(identity);
+
+            if (!foundWindow) {
+                const wrappedExternalWindow = fin.ExternalWindow.wrapSync(identity);
+                await this._model.addIfEnabled(identity);
+                await this._model._zIndexer._addEventListeners(wrappedExternalWindow);
+            }
+        };
+
+        await fin.System.addListener('external-window-shown', listener);
+    }
+
+    /**
+     * Register any external windows created before the service started
+     */
+    private async _registerCurrentExternalWindows() {
+        const externalWindows = await (<any>fin.System).getAllExternalWindows();
+
+        externalWindows.forEach(async (e: any) => {
+            const {uuid, visible} = e;
+
+            if (visible) {
+                const identity = {uuid, name: uuid, isExternalWindow: true};
+                const wrappedExternalWindow = fin.ExternalWindow.wrapSync(identity);
+                await this._model.addIfEnabled(identity);
+                await this._model._zIndexer._addEventListeners(wrappedExternalWindow);
+            }
+        });
+    }
+
+    /**
+     * Register global hotkey listener for external windows
+     */
+    private async _registerGlobalHotkeys() {
+        const listener = async () => {
+            const focusedExternalWindow = await (<any>fin.System).getFocusedExternalWindow();
+
+            if (!focusedExternalWindow) {
+                return;
+            }
+
+            focusedExternalWindow.name = focusedExternalWindow.uuid;
+            focusedExternalWindow.isExternalWindow = true;
+
+            const isRegistered = !!this._model.getWindow(focusedExternalWindow);
+
+            if (!isRegistered) {
+                return;
+            }
+
+            console.log('Global hotkey invoked on external window', focusedExternalWindow);
+            this._snapService.undock(focusedExternalWindow);
+        };
+
+        await fin.GlobalHotkey.register('CommandOrControl+Shift+U', listener);
+    }
+}

--- a/src/provider/nativeWindows/NativeWindowService.ts
+++ b/src/provider/nativeWindows/NativeWindowService.ts
@@ -51,13 +51,19 @@ export class NativeWindowService {
         }
 
         await this._launchNativeWindowAgent(architecture);
+
+        // 64-bit Windows requires both 64 and 32 bit native window agent
+        if (architecture === 'x64') {
+            await this._launchNativeWindowAgent('x32');
+        }
+
         await this._registerFutureExternalWindows();
         await this._registerCurrentExternalWindows();
         await this._registerGlobalHotkeys();
     }
 
     /**
-     * Launches native window agent using via OpenFin API.
+     * Launches native window agent via OpenFin API.
      */
     private async _launchNativeWindowAgent(architecture: string) {
         await (<any>fin.System).launchExternalProcess({

--- a/src/provider/nativeWindows/NativeWindowService.ts
+++ b/src/provider/nativeWindows/NativeWindowService.ts
@@ -23,10 +23,17 @@ export class NativeWindowService {
     private async _init() {
         const layoutsServiceConfig = this._config.query({level: 'application', uuid: 'layouts-service'});
         const {features: {externalWindows: externalWindowsAllowed}} = layoutsServiceConfig;
-        // TODO: waiting for the definition of Desktop Owner Settings configuration
-        const {nativeDesktopOwnerSettingsAllowed} = await (<any>fin.System).getServiceConfiguration({name: 'layouts'});
+        let externalWindowsAllowedDOS;
 
-        if (!externalWindowsAllowed || !nativeDesktopOwnerSettingsAllowed) {
+        try {
+            // TODO: waiting for the definition of Desktop Owner Settings configuration
+            ({externalWindows: externalWindowsAllowedDOS} = await (<any>fin.System).getServiceConfiguration({name: 'layouts'}));
+        } catch (error) {
+            console.error('External windows are disabled: Desktop Owner Settings are not configured.');
+            return;
+        }
+
+        if (!externalWindowsAllowed || !externalWindowsAllowedDOS) {
             // Native windows support is not allowed via a configuration
             return;
         }

--- a/src/provider/utils/main.ts
+++ b/src/provider/utils/main.ts
@@ -1,0 +1,9 @@
+import {WindowIdentity} from '../model/DesktopWindow';
+
+export function wrapWindow(identity: WindowIdentity) {
+    if (identity.isExternalWindow) {
+        return fin.ExternalWindow.wrapSync(identity);
+    } else {
+        return fin.Window.wrapSync(identity);
+    }
+}


### PR DESCRIPTION
#### Description
This adds experimental support for external windows (native window integration).
Still waiting for some missing functionality to be available, so this PR is a draft for now.

#### Waiting for missing things / ToDos:
1. ✅ Need at least the 1st version of native window agent to be deployed, e.g. `https://cdn.openfin.co/release/native-window/NativeWindowAgent-0.0.1-x32.zip` (waiting for injection stability issues to be fixed)
2. ✅ Layouts needs to be updated to runtime version where support for native window module was added (min build number not know yet, approximately ~~`11.69.42.8+`~~ `11.69.42.17`)
3. ✅ Core and js-adapter needs to support retrieving Desktop Owner Settings configuration. [Core PR](https://github.com/HadoukenIO/core/pull/773)
4. ⏳ Desktop Owner Settings configuration for layouts needs to be defined, and this PR needs to be further updated to parse it properly.