### PR TITLE
[SERVICE-472] Add special validation check for right-click-moves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openfin-layouts",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/provider/model/DesktopTabGroup.ts
+++ b/src/provider/model/DesktopTabGroup.ts
@@ -8,8 +8,8 @@ import {TabGroupDimensions, WindowState} from '../../client/workspaces';
 import {tabService} from '../main';
 import {Signal1} from '../Signal';
 import {Debounced} from '../snapanddock/utils/Debounced';
-import {Point, PointUtils} from '../snapanddock/utils/PointUtils';
-import {Rectangle} from '../snapanddock/utils/RectUtils';
+import {Point} from '../snapanddock/utils/PointUtils';
+import {Rectangle, RectUtils} from '../snapanddock/utils/RectUtils';
 
 import {DesktopEntity} from './DesktopEntity';
 import {DesktopModel} from './DesktopModel';
@@ -803,15 +803,18 @@ export class DesktopTabGroup implements DesktopEntity {
     // Will check that all of the tabs and the tabstrip are still in the correct relative positions, and if not
     // moves them so that they are
     private async validateGroupInternal() {
-        const tabStripOffset: Point<number> = PointUtils.difference(
-            this._window.currentState.center,
-            {x: this.currentState.center.x, y: this.currentState.center.y - this.currentState.halfSize.y + this.config.height / 2}
-        );
+        const expectedTabstripPosition = {
+            center: {
+                x: this.activeTab.currentState.center.x,
+                y: this.activeTab.currentState.center.y - this.activeTab.currentState.halfSize.y - this.config.height / 2
+            },
+            halfSize: {x: this.activeTab.currentState.halfSize.x, y: this._config.height / 2}
+        };
 
-        if (PointUtils.lengthSquared(tabStripOffset) > 0) {
+        if (!RectUtils.isEqual(expectedTabstripPosition, this._window.currentState)) {
             console.log('TabGroup disjointed. Moving tabstrip back to group.', this.id);
             await DesktopWindow.transaction([this._window], async (wins: DesktopWindow[]) => {
-                await wins[0].applyOffset(tabStripOffset);
+                await wins[0].applyProperties(expectedTabstripPosition);
             });
         }
     }

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1145,7 +1145,7 @@ export class DesktopWindow implements DesktopEntity {
         this.updateTransformType(event, this._userInitiatedBoundsChange);
 
         // Temporary extra validation to workaround runtime issues with windows right-click move
-        // TODO: Removed once runtime has better handling of this edge case ([JIRA Ref])
+        // TODO: Removed once runtime has better handling of this edge case (RUN-5074?)
         let disabled = false;
         const disabledListener = () => {
             disabled = true;

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1155,7 +1155,7 @@ export class DesktopWindow implements DesktopEntity {
             if (!disabled && this._snapGroup.length > 1) {
                 if (this._tabGroup) {
                     this._tabGroup.validate();
-                } else if (this._snapGroup.length > 1) {
+                } else {
                     this._snapGroup.validate();
                 }
             }

--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -1143,6 +1143,24 @@ export class DesktopWindow implements DesktopEntity {
         this._userInitiatedBoundsChange = {startBounds, transformType: 0};
 
         this.updateTransformType(event, this._userInitiatedBoundsChange);
+
+        // Temporary extra validation to workaround runtime issues with windows right-click move
+        // TODO: Removed once runtime has better handling of this edge case ([JIRA Ref])
+        let disabled = false;
+        const disabledListener = () => {
+            disabled = true;
+        };
+        this._window.once('disabled-frame-bounds-changing', disabledListener);
+        this._window.once('bounds-changed', () => {
+            if (!disabled && this._snapGroup.length > 1) {
+                if (this._tabGroup) {
+                    this._tabGroup.validate();
+                } else if (this._snapGroup.length > 1) {
+                    this._snapGroup.validate();
+                }
+            }
+            this._window.removeListener('disabled-frame-bounds-changing', disabledListener);
+        });
     }
 
     private handleClosing(): void {


### PR DESCRIPTION
Certain bounds-changed events will now trigger a group validate. This will ensure that if a window is moved by through the context menu move it will get properly ejected from the group.

This is intended as a temporary workaround on the layouts side until a full solution is found from the runtime/core side