### PR TITLE
[N/A] Fix tab maximization in 10.66.39.43

### DIFF
--- a/src/provider/snapanddock/utils/async.ts
+++ b/src/provider/snapanddock/utils/async.ts
@@ -1,12 +1,12 @@
-export async function promiseMap<T, U>(arr: T[], asyncF: (x: T, i: number, r: T[]) => Promise<U>): Promise<U[]>;
-export async function promiseMap<T, U>(arr: T[], asyncF: (x: T, i: number) => Promise<U>): Promise<U[]>;
-export async function promiseMap<T, U>(arr: T[], asyncF: (x: T) => Promise<U>): Promise<U[]>;
-export async function promiseMap<T, U>(arr: T[], asyncF: () => Promise<U>): Promise<U[]>;
-export async function promiseMap<T, U>(arr: T[], asyncF: (...args: any[]) => any): Promise<U[]> {
+export async function promiseMap<T, U>(arr: ReadonlyArray<T>, asyncF: (x: T, i: number, r: ReadonlyArray<T>) => Promise<U>): Promise<U[]>;
+export async function promiseMap<T, U>(arr: ReadonlyArray<T>, asyncF: (x: T, i: number) => Promise<U>): Promise<U[]>;
+export async function promiseMap<T, U>(arr: ReadonlyArray<T>, asyncF: (x: T) => Promise<U>): Promise<U[]>;
+export async function promiseMap<T, U>(arr: ReadonlyArray<T>, asyncF: () => Promise<U>): Promise<U[]>;
+export async function promiseMap<T, U>(arr: ReadonlyArray<T>, asyncF: (...args: any[]) => any): Promise<U[]> {
     return Promise.all<U>(arr.map(asyncF));
 }
 
-export async function promiseFilter<T>(arr: T[], asyncF: (x: T) => Promise<boolean>): Promise<T[]> {
+export async function promiseFilter<T>(arr: ReadonlyArray<T>, asyncF: (x: T) => Promise<boolean>): Promise<T[]> {
     const result: T[] = [];
 
     for (let i = 0; i < arr.length; i++) {
@@ -18,7 +18,7 @@ export async function promiseFilter<T>(arr: T[], asyncF: (x: T) => Promise<boole
     return result;
 }
 
-export async function promiseForEach<T>(arr: T[], asyncF: (x: T) => Promise<void>): Promise<void> {
+export async function promiseForEach<T>(arr: ReadonlyArray<T>, asyncF: (x: T) => Promise<void>): Promise<void> {
     for (let i = 0; i < arr.length; i++) {
         await asyncF(arr[i]);
     }


### PR DESCRIPTION
When maximizing or restoring a tabgroup, we assume everything will work nicely even though we are changing the bounds of grouped windows. This assumption holds for the 9.61.38.41 runtime, but not 10.66.39.43, so we should resize the tabgroup within a transaction