### PR TITLE
[SERVICE-471] Fixed flicker issue with fully-transparent previews

### DIFF
--- a/src/provider/model/DesktopWindow.ts
+++ b/src/provider/model/DesktopWindow.ts
@@ -485,7 +485,7 @@ export class DesktopWindow implements DesktopEntity {
 
     public get isActive(): boolean {
         const state: EntityState = this._currentState;
-        return !state.hidden && state.opacity > 0 && state.state !== 'minimized';
+        return !state.hidden && (state.opacity > 0 || this.applicationState.opacity > 0) && state.state !== 'minimized';
     }
 
     /**

--- a/src/provider/snapanddock/Resolver.ts
+++ b/src/provider/snapanddock/Resolver.ts
@@ -1,7 +1,7 @@
 import {ConfigStore} from '../main';
 import {DesktopEntity} from '../model/DesktopEntity';
 import {DesktopSnapGroup} from '../model/DesktopSnapGroup';
-import {EntityState} from '../model/DesktopWindow';
+import {EntityState, DesktopWindow} from '../model/DesktopWindow';
 import {eTargetType, TargetBase} from '../WindowHandler';
 
 import {SNAP_DISTANCE} from './Constants';
@@ -169,7 +169,17 @@ export class Resolver {
      * @param identity Handle to the window we are considering for snapping
      * @param state State of the window object we are considering for snapping
      */
-    private isSnappable(window: DesktopEntity, state: EntityState): boolean {
-        return !state.hidden && state.opacity > 0 && state.state === 'normal' && this._config.query(window.scope).features.snap;
+    private isSnappable(entity: DesktopEntity, state: EntityState): boolean {
+        if (!state.hidden && state.state === 'normal' && this._config.query(entity.scope).features.snap) {
+            if (state.opacity > 0) {
+                return true;
+            } else {
+                // Handle edge case where window is fully transparent, but only as a temporary snap preview.
+                const window: DesktopWindow = (entity.tabGroup && entity.tabGroup.activeTab) || entity as DesktopWindow;
+                return window && window.applicationState.opacity > 0;
+            }
+        } else {
+            return false;
+        }
     }
 }

--- a/test/demo/utils/createWindowsWithConfig.ts
+++ b/test/demo/utils/createWindowsWithConfig.ts
@@ -27,7 +27,7 @@ export async function createWindowsWithConfig(type: 'snap'|'tab', ...configs: (P
         const app = await createApp({
             type: 'manifest',
             // All app uuid's must be unique, due to apparent manifest caching behaviour
-            id: `window-${index}:${counter++}`,
+            id: `window-${type}-${index}:${counter++}`,
             position: {x: 200 + (index * 350), y: 150},
             config
         });


### PR DESCRIPTION
Fixed flicker issue with fully-transparent previews, fixed uuid issue when running both snap and tab preview tests in the same run.