### PR TITLE
[N/A] Fixing runtime channel manifests upload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,9 +108,9 @@ def buildProject() {
 }
 
 def addReleaseChannels() {
-    if (env.BRANCH_NAME == 'master') {
+    //if (env.BRANCH_NAME == 'master') {
         sh "npm run channels"
-    }
+    //}
 }
 
 def deployToS3() {
@@ -122,7 +122,7 @@ def deployToS3() {
     sh "aws s3 cp ./dist/docs ${DIR_DOCS_VERSION} --recursive"
 
     sh "aws s3 cp ./dist/provider/app.json ${DIR_BUILD_ROOT}${MANIFEST_NAME}"
-    sh "aws s3 cp ./dist/provider/ ${DIR_BUILD_ROOT} --exclude \"*\" --include \"app.runtime-*.json\""
+    sh "aws s3 cp ./dist/provider/ ${DIR_BUILD_ROOT} --recursive --exclude \"*\" --include \"app.runtime-*.json\" --dryrun"
 }
 
 def deployToNPM() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,9 +108,9 @@ def buildProject() {
 }
 
 def addReleaseChannels() {
-    //if (env.BRANCH_NAME == 'master') {
+    if (env.BRANCH_NAME == 'master') {
         sh "npm run channels"
-    //}
+    }
 }
 
 def deployToS3() {
@@ -122,7 +122,7 @@ def deployToS3() {
     sh "aws s3 cp ./dist/docs ${DIR_DOCS_VERSION} --recursive"
 
     sh "aws s3 cp ./dist/provider/app.json ${DIR_BUILD_ROOT}${MANIFEST_NAME}"
-    sh "aws s3 cp ./dist/provider/ ${DIR_BUILD_ROOT} --recursive --exclude \"*\" --include \"app.runtime-*.json\" --dryrun"
+    sh "aws s3 cp ./dist/provider/ ${DIR_BUILD_ROOT} --recursive --exclude \"*\" --include \"app.runtime-*.json\""
 }
 
 def deployToNPM() {


### PR DESCRIPTION
Upload of `app.runtime-*.json` manifests wasn't working due to missing `aws` argument.