### PR TITLE
[NA] Prevent window flicker on service startup

### DIFF
--- a/src/provider/model/DesktopTabstripFactory.ts
+++ b/src/provider/model/DesktopTabstripFactory.ts
@@ -19,8 +19,6 @@ const DEFAULT_UI_URL = (() => {
     return providerLocation.replace('provider.html', 'tabbing/tabstrip/tabstrip.html');
 })();
 
-let VIRTUAL_SCREEN: DipRect;
-
 /**
  * Handles creation and pooling of Tab Group Windows
  */
@@ -129,12 +127,9 @@ export class DesktopTabstripFactory {
      * @param window The window to hide.
      */
     private async hideOffScreen(window: _Window){
-        if (!VIRTUAL_SCREEN){
-            const {virtualScreen} = await fin.System.getMonitorInfo();
-            VIRTUAL_SCREEN = virtualScreen;
-        }
+        const {virtualScreen} = await fin.System.getMonitorInfo();
         const {width, height} = await window.getBounds();
-        await window.showAt(VIRTUAL_SCREEN.left - width, VIRTUAL_SCREEN.top - height);
+        await window.showAt(virtualScreen.left - width, virtualScreen.top - height);
         await window.hide();
     }
 

--- a/src/provider/model/DesktopTabstripFactory.ts
+++ b/src/provider/model/DesktopTabstripFactory.ts
@@ -44,10 +44,10 @@ export class DesktopTabstripFactory {
         this._watch = new MaskWatch(config, {tabstrip: true});
         this._watch.onAdd.add(this.onTabstripConfigAdded, this);
 
-        // Creates 3 default windows in the pool.
-        this.createAndPool(DesktopTabstripFactory.DEFAULT_CONFIG);
-        this.createAndPool(DesktopTabstripFactory.DEFAULT_CONFIG);
-        this.createAndPool(DesktopTabstripFactory.DEFAULT_CONFIG);
+        // Fills the pool with the default tabstrip windows.
+        for (let i = 0; i < DesktopTabstripFactory.POOL_MAX_SIZE; i++){
+            this.createAndPool(DesktopTabstripFactory.DEFAULT_CONFIG);
+        }
     }
 
     /**

--- a/src/provider/tabbing/DragWindowManager.ts
+++ b/src/provider/tabbing/DragWindowManager.ts
@@ -99,12 +99,14 @@ export class DragWindowManager {
     private async createDragWindow(): Promise<void> {
         const {virtualScreen} = await fin.System.getMonitorInfo();
         await new Promise(resolve => {
+            // default size can't be smaller than 60.
+            const size = 100;
             this._window = new fin.desktop.Window(
                 {
                     name: 'TabbingDragWindow',
                     url: 'about:blank',
-                    defaultHeight: 1,
-                    defaultWidth: 1,
+                    defaultHeight: size,
+                    defaultWidth: size,
                     defaultLeft: 0,
                     defaultTop: 0,
                     saveWindowState: false,
@@ -117,7 +119,8 @@ export class DragWindowManager {
                     smallWindow: true
                 },
                 () => {
-                    this._window.showAt(virtualScreen.left - 100, virtualScreen.top - 100);
+                    // Show window offscreen so it can render without a flicker
+                    this._window.showAt(virtualScreen.left - size, virtualScreen.top - size);
                     resolve();
                 }
             );

--- a/src/provider/tabbing/DragWindowManager.ts
+++ b/src/provider/tabbing/DragWindowManager.ts
@@ -97,6 +97,7 @@ export class DragWindowManager {
      * Creates the drag overlay window.
      */
     private async createDragWindow(): Promise<void> {
+        const {virtualScreen} = await fin.System.getMonitorInfo();
         await new Promise(resolve => {
             this._window = new fin.desktop.Window(
                 {
@@ -107,7 +108,7 @@ export class DragWindowManager {
                     defaultLeft: 0,
                     defaultTop: 0,
                     saveWindowState: false,
-                    autoShow: true,
+                    autoShow: false,
                     opacity: 0.01,
                     frame: false,
                     waitForPageLoad: false,
@@ -116,6 +117,7 @@ export class DragWindowManager {
                     smallWindow: true
                 },
                 () => {
+                    this._window.showAt(virtualScreen.left - 100, virtualScreen.top - 100);
                     resolve();
                 }
             );


### PR DESCRIPTION
Stops `DragWindowManager` & `DesktopTabstripFactory` windows flickering on service startup.
Also fixes tabstrip pooling. Before tabstrips pooling was async and overwriting the pool array, leaving windows that were not being managed.

#414 Removes the flicker from preview windows.