### PR TITLE
[RUN-5434]/[RUN-5435] Change restore to use startManyManifests

### DIFF
--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -67,7 +67,7 @@ export const restoreWorkspace = async(payload: Workspace): Promise<Workspace> =>
 
     const apps: WorkspaceApp[] = await promiseMap(workspace.apps, app => restoreApp(app, startupApps, manifestApps));
 
-    //@ts-ignore
+    // @ts-ignore
     fin.Application.startManyManifests(manifestApps);
 
     // Wait for all apps to start-up

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -420,18 +420,6 @@ const instructClientAppToRestoreItself = async(workspaceApp: WorkspaceApp): Prom
     }
 };
 
-const attemptToRunCreatedApp = async (ofAppNotRunning: Application) => {
-    let timeout;
-    const timeoutPromise = new Promise<void>((resolve, reject) => timeout = window.setTimeout(() => {
-        reject(new Error(`Run was called on Application ${ofAppNotRunning.identity.uuid}, but it seems to be hanging. Continuing restoration.`));
-    }, CLIENT_APP_RUN_TIMEOUT));
-    const runCall = ofAppNotRunning.run();
-
-    await Promise.race([timeoutPromise, runCall]);
-
-    clearTimeout(timeout);
-};
-
 // If an app creation fails during the beginning of the restore process, add it to appsToDeleteFromWorkspace so it can get cleaned up in the processAppResponse
 // function. Then, resolve its pending setClientAppToRestoreWhenReady promise and remove it from appsToRestoreWhenReady.
 const deleteAppFromRestoreWhenReadyMap = (app: WorkspaceApp) => {


### PR DESCRIPTION
This PR uses `startManyManifests` to start a batch of applications, instead of running them individually. This avoids the issue reported earlier of applications failing to come up during a large restore.

This PR is linked to the following PRs:
https://github.com/HadoukenIO/core/pull/907
https://github.com/HadoukenIO/js-adapter/pull/325
https://github.com/openfin/openfinrvm/pull/307
